### PR TITLE
Harden adoption-ready OSS launch surfaces

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @KryptosAI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,5 +33,8 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Validate checked-in artifacts
+        run: npm run validate:artifacts
+
       - name: README smoke test
         run: npm run smoke

--- a/.github/workflows/real-server-matrix.yml
+++ b/.github/workflows/real-server-matrix.yml
@@ -1,0 +1,36 @@
+name: real-server-matrix
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 8 * * *"
+
+jobs:
+  matrix:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install
+        run: npm install
+
+      - name: Run real-server matrix
+        id: matrix
+        run: npm run integration:real
+
+      - name: Upload matrix artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: real-server-matrix-artifacts
+          path: |
+            examples/artifacts/*.json
+            examples/artifacts/*-report.md
+          retention-days: 14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,30 @@ The format is intentionally simple while the project is pre-1.0:
 
 ## Unreleased
 
+### Changed
+
+- reserved for follow-up work after `v0.1.0`
+
+## v0.1.0 - 2026-03-19
+
 ### Added
 
 - initial CLI with `run`, `diff`, and `report`
 - stable `1.0.0` artifact schema with top-level `gate`
+- published JSON Schema files for run and diff artifacts
 - local-process adapter built on the official MCP TypeScript SDK
 - fixture server, sample artifacts, and Markdown reporting
-- real-server smoke coverage and integration script
+- real-server smoke coverage and a nightly/manual matrix workflow
+- checked-in real-server artifacts for filesystem, everything, and ref-tools servers
+- CODEOWNERS, release metadata, and contributor-facing examples
+
+### Changed
+
+- README repositioned as a landing page and adoption asset
+- release process expanded to support tagged GitHub releases before npm publishing
 
 ### Docs
 
-- README positioning as a developer confidence harness
-- contributor, security, code-of-conduct, roadmap, and release docs
+- architecture and performance notes
+- known-issues documentation for ecosystem setup caveats
+- release notes template aligned to GitHub release categories

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # MCP Observatory
 
+[![CI](https://github.com/KryptosAI/mcp-observatory/actions/workflows/ci.yml/badge.svg)](https://github.com/KryptosAI/mcp-observatory/actions/workflows/ci.yml)
+[![Real Server Matrix](https://github.com/KryptosAI/mcp-observatory/actions/workflows/real-server-matrix.yml/badge.svg)](https://github.com/KryptosAI/mcp-observatory/actions/workflows/real-server-matrix.yml)
+[![Latest Release](https://img.shields.io/github/v/release/KryptosAI/mcp-observatory?display_name=tag)](https://github.com/KryptosAI/mcp-observatory/releases)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
+[![Node >= 22](https://img.shields.io/badge/node-%3E%3D22-339933)](./package.json)
+
 MCP Observatory is a developer confidence harness for MCP authors and integrators.
 
 It detects, stores, compares, and explains interoperability drift over time so you can answer the question most conformance tooling does not try to answer:
@@ -34,6 +40,37 @@ MCP Observatory is not trying to replace conformance or redefine the protocol. I
 
 It is not a generic dashboard, not a trust platform, and not a spec fork.
 
+## Where It Fits
+
+| Surface | Primary question answered | Output style | Positioning |
+| --- | --- | --- | --- |
+| Official conformance | "Does this implementation satisfy the protocol contract right now?" | pass/fail conformance evidence | compliance baseline |
+| MCP Observatory | "What changed over time, what regressed, and what recovered?" | versioned run artifacts, diffs, Markdown reports | developer confidence harness |
+| Ad hoc local testing | "Did my one manual run look okay?" | transient console output | useful but not durable |
+
+## Visual Proof
+
+The fastest way to understand the product is to look at the artifact surface directly:
+
+```text
+MCP Observatory Diff
+Base: run_20260318T120000000Z_a1b2c3d4
+Head: run_20260318T130000000Z_e5f6g7h8
+Gate: fail
+Counts: regressions=2, recoveries=1, unchanged=1, added=0, removed=0
+Regressions:
+- tools: pass -> fail (Advertised capability failed during tools/list: server error)
+- semantics: pass -> fail (At least one advertised capability did not respond successfully.)
+Recoveries:
+- prompts: unsupported -> pass (Advertised capability responded with the minimal expected shape (1 item).)
+```
+
+See the full checked-in reports:
+
+- [Sample fixture report](./examples/results/sample-report.md)
+- [Everything server report](./examples/artifacts/everything-server-report.md)
+- [Filesystem server report](./examples/artifacts/filesystem-server-report.md)
+
 ## What You Get
 
 - `run`: execute checks against a target config and persist a versioned run artifact
@@ -53,36 +90,21 @@ npm run cli -- diff --base tests/fixtures/sample-run-a.json --head tests/fixture
 
 This is the shortest path to seeing the product work end-to-end with no external MCP dependency.
 
-## Sample Output
-
-```text
-MCP Observatory Diff
-Base: run_20260318T120000000Z_a1b2c3d4
-Head: run_20260318T130000000Z_e5f6g7h8
-Gate: fail
-Counts: regressions=2, recoveries=1, unchanged=1, added=0, removed=0
-Regressions:
-- tools: pass -> fail (Advertised capability failed during tools/list: server error)
-- semantics: pass -> fail (At least one advertised capability did not respond successfully.)
-Recoveries:
-- prompts: unsupported -> pass (Advertised capability responded with the minimal expected shape (1 item).)
-```
-
 The flagship artifact is the Markdown report:
 
 ```bash
 npm run cli -- report --run tests/fixtures/sample-run-b.json --format markdown --output examples/results/sample-report.md
 ```
 
-See [examples/results/sample-report.md](./examples/results/sample-report.md) for a checked-in example.
-
 ## Real Server Coverage
 
-The repo now includes a small real-world smoke matrix across distinct MCP implementations:
+The repo includes a small real-world smoke matrix across distinct MCP implementations:
 
-- [examples/targets/filesystem-server.json](./examples/targets/filesystem-server.json): official filesystem server, tool-heavy local-process target
-- [examples/targets/everything-server.json](./examples/targets/everything-server.json): official everything server, resources-heavy and prompts-capable target
-- [examples/targets/ref-tools-server.json](./examples/targets/ref-tools-server.json): third-party ref tools server, prompts-capable target from a different implementation
+| Target | Server | Shape | Tools | Prompts | Resources | Notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| [filesystem-server.json](./examples/targets/filesystem-server.json) | `@modelcontextprotocol/server-filesystem` | tool-heavy | pass | unsupported | unsupported | good basic stdio smoke |
+| [everything-server.json](./examples/targets/everything-server.json) | `@modelcontextprotocol/server-everything` | resources-heavy | pass | pass | pass | best capability diversity today |
+| [ref-tools-server.json](./examples/targets/ref-tools-server.json) | `ref-tools-mcp` | prompts-heavy | pass | pass | unsupported | third-party implementation signal |
 
 Manual recipe:
 
@@ -98,7 +120,31 @@ Repeatable script:
 npm run integration:real
 ```
 
-That script regenerates checked-in example artifacts and Markdown reports under [examples/artifacts](./examples/artifacts).
+The real-server matrix also runs in GitHub Actions as a separate nightly and manually-triggered workflow so ecosystem drift is visible without slowing normal PR CI.
+
+## Artifact Contract
+
+Every artifact is versioned and machine-friendly:
+
+- `artifactType`: `run` or `diff`
+- `schemaVersion`: currently `1.0.0`
+- `gate`: `pass` or `fail`
+
+Schema compatibility rules:
+
+- additive changes stay within `1.x`
+- any breaking artifact change requires a major schema bump
+
+Published schemas:
+
+- [schemas/run-artifact.schema.json](./schemas/run-artifact.schema.json)
+- [schemas/diff-artifact.schema.json](./schemas/diff-artifact.schema.json)
+
+Validate checked-in artifacts locally:
+
+```bash
+npm run validate:artifacts
+```
 
 ## Semantics v1
 
@@ -128,39 +174,21 @@ Targets are JSON files with this shape:
 }
 ```
 
-## Artifact Contract
-
-Every artifact is versioned and machine-friendly:
-
-- `artifactType`: `run` or `diff`
-- `schemaVersion`: currently `1.0.0`
-- `gate`: `pass` or `fail`
-
-Schema compatibility rules:
-
-- additive changes stay within `1.x`
-- any breaking artifact change requires a major schema bump
-
 ## Architecture
 
-- `src/runner`: session orchestration and result normalization
-- `src/adapters`: target-specific connection logic, starting with local process/stdio
-- `src/checks`: isolated capability checks with minimal-shape evidence
-- `src/diff`: run-to-run status comparison with regression/recovery classification
-- `src/reporters`: terminal, JSON, and Markdown renderers
-- `src/storage`: filesystem artifact persistence
+See [docs/architecture.md](./docs/architecture.md) for the short system map and [docs/performance.md](./docs/performance.md) for illustrative timing notes from checked-in artifacts.
 
-## Roadmap / Good First Issues
+## How To Pick An Issue
 
-The public work queue lives in GitHub Issues, but the current contribution themes are:
+If you want the highest-leverage starting points, begin here:
 
-- expand real-server coverage across more MCP implementations
-- improve artifact readability and evidence density
-- document unsupported vs failed semantics more clearly
-- add artifact validation and integration examples
-- improve release posture before npm publishing
+- [#1 Add a second resources-heavy real-server smoke target](https://github.com/KryptosAI/mcp-observatory/issues/1)
+- [#3 Improve artifact output readability in the Markdown report](https://github.com/KryptosAI/mcp-observatory/issues/3)
+- [#5 Document unsupported vs failed semantics clearly](https://github.com/KryptosAI/mcp-observatory/issues/5)
+- [#7 Add JSON Schema validation for run artifacts](https://github.com/KryptosAI/mcp-observatory/issues/7)
+- [#10 Add example integrations folder for CI and PR comment usage](https://github.com/KryptosAI/mcp-observatory/issues/10)
 
-See [ROADMAP.md](./ROADMAP.md), [CONTRIBUTING.md](./CONTRIBUTING.md), and the repo’s `good first issue` label for the easiest starting points.
+The public work queue lives in GitHub Issues, and the `good first issue` label is curated intentionally.
 
 ## Contributing
 
@@ -180,7 +208,8 @@ The repo is ready for tagged GitHub releases before npm publishing.
 
 - changelog: [CHANGELOG.md](./CHANGELOG.md)
 - release process: [RELEASE.md](./RELEASE.md)
-- helper script: `node scripts/release.mjs`
+- release notes template: [docs/release-notes-template.md](./docs/release-notes-template.md)
+- helper script: `npm run release:prep`
 - npm publishing decision tracking: keep scoped for now, revisit later
 
 ## Known Issues

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,9 +12,9 @@ The repo is GitHub-release-ready before it is npm-publish-ready.
 ## Release Checklist
 
 1. update [CHANGELOG.md](./CHANGELOG.md)
-2. run `node scripts/release.mjs`
-3. confirm `npm run integration:real` still works locally
-4. create a git tag
+2. run `npm run release:prep`
+3. create a PR and merge through the protected path
+4. create the release tag on `main`
 5. publish GitHub release notes using the template categories in `.github/release.yml`
 6. decide whether the release is GitHub-only or npm-worthy
 
@@ -25,3 +25,24 @@ For now:
 - keep the package scoped as `@kryptosai/mcp-observatory`
 - do not optimize for npm distribution yet
 - revisit unscoped publishing only if adoption warrants it
+
+## Changelog vs Release Notes
+
+- `CHANGELOG.md` is the durable project history
+- GitHub release notes are the launch-facing summary for one tagged release
+
+Use the changelog for:
+
+- all user-visible changes worth preserving
+- schema or workflow changes that affect adopters
+- docs or contributor-surface changes that alter project usability
+
+Use release notes for:
+
+- the best story of the release
+- highlighted improvements grouped by the categories in `.github/release.yml`
+- links to the most important docs, artifacts, and next-step issues
+
+## Release Notes Template
+
+See [docs/release-notes-template.md](./docs/release-notes-template.md).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,32 @@
+# Architecture
+
+MCP Observatory is intentionally small. The core data flow is:
+
+1. **Target config**
+   A JSON description of how to start a target via the local-process adapter.
+2. **Adapter**
+   The adapter starts an MCP server over stdio and establishes a client session.
+3. **Checks**
+   The runner executes `tools`, `prompts`, `resources`, and `semantics`.
+4. **Run artifact**
+   Results are normalized into a stable, versioned JSON artifact with a top-level `gate`.
+5. **Diff**
+   Two run artifacts can be compared to classify regressions and recoveries.
+6. **Report**
+   Run or diff artifacts render as terminal output, JSON, or Markdown.
+
+## Design Intent
+
+- keep the adapter boundary obvious so more target types can be added later
+- keep checks isolated and typed
+- treat artifacts as product surfaces, not incidental output
+- keep the Markdown report strong enough to stand on its own in issues, PRs, and CI
+
+## Stability Surfaces
+
+These are the most important surfaces to preserve carefully:
+
+- artifact schema
+- diff semantics
+- `unsupported` vs `failed` interpretation
+- Markdown report structure and usefulness

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,22 @@
+# Performance Notes
+
+These are illustrative timings from checked-in real-server artifacts, not a formal benchmark suite.
+
+They exist to make runtime expectations legible for contributors and adopters.
+
+## Example Check Timings
+
+| Target | Tools | Prompts | Resources | Semantics |
+| --- | ---: | ---: | ---: | ---: |
+| filesystem-server | 8.13 ms | unsupported | unsupported | 0.00 ms |
+| everything-server | 11.04 ms | 1.19 ms | 1.81 ms | 0.01 ms |
+| ref-tools-server | 1.26 ms | 0.25 ms | unsupported | 0.00 ms |
+
+## How To Interpret This
+
+- these numbers mostly reflect capability request/response time after process startup
+- process startup cost still matters in real-world usage
+- different servers advertise very different capability shapes, so timings are not directly comparable across all targets
+- the current goal is confidence and evidence, not micro-optimized throughput
+
+If benchmarking becomes important later, it should be added as a separate, explicit effort rather than mixed into normal validation output.

--- a/docs/release-notes-template.md
+++ b/docs/release-notes-template.md
@@ -1,0 +1,32 @@
+# Release Notes Template
+
+Use this structure when publishing a tagged GitHub release:
+
+## Highlights
+
+- the one-sentence release story
+- the biggest user-visible win
+
+## CLI and Core
+
+- command or runtime changes
+- adapter/check/diff improvements
+
+## Reporting and Docs
+
+- Markdown report improvements
+- README or contributor-surface upgrades
+
+## Examples and Contributor Experience
+
+- new real-server examples
+- new docs, issue surfacing, or onboarding improvements
+
+## Release and Packaging
+
+- versioning or release-process changes
+- npm posture updates, if any
+
+## Next Recommended Issues
+
+- link to 2-4 issues that are good follow-ups after the release lands

--- a/examples/artifacts/everything-server-report.md
+++ b/examples/artifacts/everything-server-report.md
@@ -1,6 +1,6 @@
 # MCP Observatory Run Report
 
-Generated at 2026-03-19T01:06:08.368Z
+Generated at 2026-03-19T03:08:06.622Z
 
 ## Target and Environment Metadata
 
@@ -25,9 +25,9 @@ _Use the `diff` command against another run artifact to classify regressions and
 
 | Check | Status | Duration (ms) | Message |
 | --- | --- | --- | --- |
-| tools | pass | 11.04 | Advertised capability responded with the minimal expected shape (13 items). |
+| tools | pass | 10.96 | Advertised capability responded with the minimal expected shape (13 items). |
 | prompts | pass | 1.19 | Advertised capability responded with the minimal expected shape (4 items). |
-| resources | pass | 1.81 | Advertised capability responded with the minimal expected shape (9 items). |
+| resources | pass | 1.14 | Advertised capability responded with the minimal expected shape (9 items). |
 | semantics | pass | 0.01 | Advertised capabilities responded and returned the minimal expected shape. |
 
 ## Evidence Snippets
@@ -97,5 +97,5 @@ npm run cli -- report --run <path-to-run-artifact.json> --format markdown
 
 - Artifact type: `run`
 - Schema version: `1.0.0`
-- Run ID: `run_2026-03-19T010608367Z_bccf39df`
+- Run ID: `run_2026-03-19T030806621Z_8c2ccb42`
 - Gate: `pass`

--- a/examples/artifacts/everything-server.json
+++ b/examples/artifacts/everything-server.json
@@ -2,8 +2,8 @@
   "artifactType": "run",
   "schemaVersion": "1.0.0",
   "gate": "pass",
-  "runId": "run_2026-03-19T010608367Z_bccf39df",
-  "createdAt": "2026-03-19T01:06:08.368Z",
+  "runId": "run_2026-03-19T030806621Z_8c2ccb42",
+  "createdAt": "2026-03-19T03:08:06.622Z",
   "toolVersion": "0.1.0",
   "target": {
     "targetId": "everything-server",
@@ -40,7 +40,7 @@
       "id": "tools",
       "capability": "tools",
       "status": "pass",
-      "durationMs": 11.036374999999907,
+      "durationMs": 10.961958999999979,
       "message": "Advertised capability responded with the minimal expected shape (13 items).",
       "evidence": [
         {
@@ -74,7 +74,7 @@
       "id": "prompts",
       "capability": "prompts",
       "status": "pass",
-      "durationMs": 1.1857499999998709,
+      "durationMs": 1.1916670000000522,
       "message": "Advertised capability responded with the minimal expected shape (4 items).",
       "evidence": [
         {
@@ -99,7 +99,7 @@
       "id": "resources",
       "capability": "resources",
       "status": "pass",
-      "durationMs": 1.8087080000000242,
+      "durationMs": 1.1422079999999823,
       "message": "Advertised capability responded with the minimal expected shape (9 items).",
       "evidence": [
         {
@@ -129,7 +129,7 @@
       "id": "semantics",
       "capability": "semantics",
       "status": "pass",
-      "durationMs": 0.008915999999999258,
+      "durationMs": 0.00825000000008913,
       "message": "Advertised capabilities responded and returned the minimal expected shape.",
       "evidence": [
         {

--- a/examples/artifacts/filesystem-server-report.md
+++ b/examples/artifacts/filesystem-server-report.md
@@ -1,6 +1,6 @@
 # MCP Observatory Run Report
 
-Generated at 2026-03-19T01:06:09.952Z
+Generated at 2026-03-19T03:08:08.111Z
 
 ## Target and Environment Metadata
 
@@ -25,7 +25,7 @@ _Use the `diff` command against another run artifact to classify regressions and
 
 | Check | Status | Duration (ms) | Message |
 | --- | --- | --- | --- |
-| tools | pass | 8.13 | Advertised capability responded with the minimal expected shape (14 items). |
+| tools | pass | 8.91 | Advertised capability responded with the minimal expected shape (14 items). |
 | prompts | unsupported | 0.00 | Prompts are not advertised by the target. |
 | resources | unsupported | 0.00 | Resources are not advertised by the target. |
 | semantics | pass | 0.00 | Advertised capabilities responded and returned the minimal expected shape. |
@@ -97,5 +97,5 @@ npm run cli -- report --run <path-to-run-artifact.json> --format markdown
 
 - Artifact type: `run`
 - Schema version: `1.0.0`
-- Run ID: `run_2026-03-19T010609952Z_6b138360`
+- Run ID: `run_2026-03-19T030808111Z_d9ae6a33`
 - Gate: `pass`

--- a/examples/artifacts/filesystem-server.json
+++ b/examples/artifacts/filesystem-server.json
@@ -2,8 +2,8 @@
   "artifactType": "run",
   "schemaVersion": "1.0.0",
   "gate": "pass",
-  "runId": "run_2026-03-19T010609952Z_6b138360",
-  "createdAt": "2026-03-19T01:06:09.952Z",
+  "runId": "run_2026-03-19T030808111Z_d9ae6a33",
+  "createdAt": "2026-03-19T03:08:08.111Z",
   "toolVersion": "0.1.0",
   "target": {
     "targetId": "filesystem-server",
@@ -41,7 +41,7 @@
       "id": "tools",
       "capability": "tools",
       "status": "pass",
-      "durationMs": 8.13274999999976,
+      "durationMs": 8.91412500000024,
       "message": "Advertised capability responded with the minimal expected shape (14 items).",
       "evidence": [
         {
@@ -79,7 +79,7 @@
       "id": "prompts",
       "capability": "prompts",
       "status": "unsupported",
-      "durationMs": 0.002292000000124972,
+      "durationMs": 0.002375000000029104,
       "message": "Prompts are not advertised by the target.",
       "evidence": [
         {
@@ -95,7 +95,7 @@
       "id": "resources",
       "capability": "resources",
       "status": "unsupported",
-      "durationMs": 0.0008339999999407155,
+      "durationMs": 0.0008749999997235136,
       "message": "Resources are not advertised by the target.",
       "evidence": [
         {
@@ -111,7 +111,7 @@
       "id": "semantics",
       "capability": "semantics",
       "status": "pass",
-      "durationMs": 0.0013750000002801244,
+      "durationMs": 0.0014999999998508429,
       "message": "Advertised capabilities responded and returned the minimal expected shape.",
       "evidence": [
         {

--- a/examples/artifacts/ref-tools-server-report.md
+++ b/examples/artifacts/ref-tools-server-report.md
@@ -1,6 +1,6 @@
 # MCP Observatory Run Report
 
-Generated at 2026-03-19T01:06:10.677Z
+Generated at 2026-03-19T03:08:08.845Z
 
 ## Target and Environment Metadata
 
@@ -25,8 +25,8 @@ _Use the `diff` command against another run artifact to classify regressions and
 
 | Check | Status | Duration (ms) | Message |
 | --- | --- | --- | --- |
-| tools | pass | 1.26 | Advertised capability responded with the minimal expected shape (2 items). |
-| prompts | pass | 0.25 | Advertised capability responded with the minimal expected shape (2 items). |
+| tools | pass | 1.25 | Advertised capability responded with the minimal expected shape (2 items). |
+| prompts | pass | 0.23 | Advertised capability responded with the minimal expected shape (2 items). |
 | resources | unsupported | 0.00 | Resources are not advertised by the target. |
 | semantics | pass | 0.00 | Advertised capabilities responded and returned the minimal expected shape. |
 
@@ -97,5 +97,5 @@ npm run cli -- report --run <path-to-run-artifact.json> --format markdown
 
 - Artifact type: `run`
 - Schema version: `1.0.0`
-- Run ID: `run_2026-03-19T010610677Z_88cc16e4`
+- Run ID: `run_2026-03-19T030808845Z_07a3a2bc`
 - Gate: `pass`

--- a/examples/artifacts/ref-tools-server.json
+++ b/examples/artifacts/ref-tools-server.json
@@ -2,8 +2,8 @@
   "artifactType": "run",
   "schemaVersion": "1.0.0",
   "gate": "pass",
-  "runId": "run_2026-03-19T010610677Z_88cc16e4",
-  "createdAt": "2026-03-19T01:06:10.677Z",
+  "runId": "run_2026-03-19T030808845Z_07a3a2bc",
+  "createdAt": "2026-03-19T03:08:08.845Z",
   "toolVersion": "0.1.0",
   "target": {
     "targetId": "ref-tools-server",
@@ -40,7 +40,7 @@
       "id": "tools",
       "capability": "tools",
       "status": "pass",
-      "durationMs": 1.2629170000000158,
+      "durationMs": 1.2520830000003116,
       "message": "Advertised capability responded with the minimal expected shape (2 items).",
       "evidence": [
         {
@@ -63,7 +63,7 @@
       "id": "prompts",
       "capability": "prompts",
       "status": "pass",
-      "durationMs": 0.25087500000017826,
+      "durationMs": 0.23129100000005565,
       "message": "Advertised capability responded with the minimal expected shape (2 items).",
       "evidence": [
         {
@@ -86,7 +86,7 @@
       "id": "resources",
       "capability": "resources",
       "status": "unsupported",
-      "durationMs": 0.0019999999999527063,
+      "durationMs": 0.0018329999998059066,
       "message": "Resources are not advertised by the target.",
       "evidence": [
         {
@@ -102,7 +102,7 @@
       "id": "semantics",
       "capability": "semantics",
       "status": "pass",
-      "durationMs": 0.0016660000001138542,
+      "durationMs": 0.0018340000001444423,
       "message": "Advertised capabilities responded and returned the minimal expected shape.",
       "evidence": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@types/node": "24.10.1",
         "@typescript-eslint/eslint-plugin": "8.46.3",
         "@typescript-eslint/parser": "8.46.3",
+        "ajv": "8.17.1",
         "eslint": "9.39.1",
         "globals": "16.5.0",
         "tsx": "4.20.6",
@@ -1631,9 +1632,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",

--- a/package.json
+++ b/package.json
@@ -25,19 +25,24 @@
   "files": [
     "dist",
     "README.md",
+    "CHANGELOG.md",
+    "RELEASE.md",
     "LICENSE",
     "CONTRIBUTING.md",
     "ROADMAP.md",
     "SECURITY.md",
-    "CODE_OF_CONDUCT.md"
+    "CODE_OF_CONDUCT.md",
+    "schemas"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "cli": "tsx src/cli.ts",
     "integration:real": "tsx scripts/run-real-server-matrix.ts",
     "lint": "eslint .",
+    "release:prep": "node scripts/release.mjs",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "test": "vitest run",
+    "validate:artifacts": "tsx scripts/validate-artifacts.ts",
     "smoke": "npm run cli -- run --target tests/fixtures/sample-target-config.json && npm run cli -- diff --base tests/fixtures/sample-run-a.json --head tests/fixtures/sample-run-b.json"
   },
   "keywords": [
@@ -53,6 +58,7 @@
     "commander": "14.0.2"
   },
   "devDependencies": {
+    "ajv": "8.17.1",
     "@eslint/js": "9.39.1",
     "@types/node": "24.10.1",
     "@typescript-eslint/eslint-plugin": "8.46.3",

--- a/schemas/diff-artifact.schema.json
+++ b/schemas/diff-artifact.schema.json
@@ -1,0 +1,132 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/KryptosAI/mcp-observatory/schemas/diff-artifact.schema.json",
+  "title": "MCP Observatory Diff Artifact",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifactType",
+    "schemaVersion",
+    "gate",
+    "baseRunId",
+    "headRunId",
+    "createdAt",
+    "summary",
+    "regressions",
+    "recoveries",
+    "unchanged",
+    "added",
+    "removed"
+  ],
+  "properties": {
+    "artifactType": {
+      "const": "diff"
+    },
+    "schemaVersion": {
+      "const": "1.0.0"
+    },
+    "gate": {
+      "$ref": "#/definitions/gate"
+    },
+    "baseRunId": {
+      "type": "string"
+    },
+    "headRunId": {
+      "type": "string"
+    },
+    "createdAt": {
+      "type": "string"
+    },
+    "summary": {
+      "$ref": "#/definitions/diffSummary"
+    },
+    "regressions": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/diffEntry"
+      }
+    },
+    "recoveries": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/diffEntry"
+      }
+    },
+    "unchanged": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/diffEntry"
+      }
+    },
+    "added": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/diffEntry"
+      }
+    },
+    "removed": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/diffEntry"
+      }
+    }
+  },
+  "definitions": {
+    "gate": {
+      "type": "string",
+      "enum": ["pass", "fail"]
+    },
+    "checkStatus": {
+      "type": "string",
+      "enum": ["pass", "fail", "partial", "unsupported", "flaky", "skipped"]
+    },
+    "checkId": {
+      "type": "string",
+      "enum": ["tools", "prompts", "resources", "semantics"]
+    },
+    "diffEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "capability", "message"],
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/checkId"
+        },
+        "capability": {
+          "$ref": "#/definitions/checkId"
+        },
+        "fromStatus": {
+          "$ref": "#/definitions/checkStatus"
+        },
+        "toStatus": {
+          "$ref": "#/definitions/checkStatus"
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    },
+    "diffSummary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "regressions",
+        "recoveries",
+        "unchanged",
+        "added",
+        "removed",
+        "gate"
+      ],
+      "properties": {
+        "regressions": { "type": "integer", "minimum": 0 },
+        "recoveries": { "type": "integer", "minimum": 0 },
+        "unchanged": { "type": "integer", "minimum": 0 },
+        "added": { "type": "integer", "minimum": 0 },
+        "removed": { "type": "integer", "minimum": 0 },
+        "gate": {
+          "$ref": "#/definitions/gate"
+        }
+      }
+    }
+  }
+}

--- a/schemas/run-artifact.schema.json
+++ b/schemas/run-artifact.schema.json
@@ -1,0 +1,245 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/KryptosAI/mcp-observatory/schemas/run-artifact.schema.json",
+  "title": "MCP Observatory Run Artifact",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifactType",
+    "schemaVersion",
+    "gate",
+    "runId",
+    "createdAt",
+    "toolVersion",
+    "target",
+    "environment",
+    "summary",
+    "checks"
+  ],
+  "properties": {
+    "artifactType": {
+      "const": "run"
+    },
+    "schemaVersion": {
+      "const": "1.0.0"
+    },
+    "gate": {
+      "$ref": "#/definitions/gate"
+    },
+    "runId": {
+      "type": "string"
+    },
+    "createdAt": {
+      "type": "string"
+    },
+    "toolVersion": {
+      "type": "string"
+    },
+    "target": {
+      "$ref": "#/definitions/targetSnapshot"
+    },
+    "environment": {
+      "$ref": "#/definitions/environmentSnapshot"
+    },
+    "summary": {
+      "$ref": "#/definitions/runSummary"
+    },
+    "checks": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/checkResult"
+      }
+    },
+    "fatalError": {
+      "type": "string"
+    }
+  },
+  "definitions": {
+    "gate": {
+      "type": "string",
+      "enum": ["pass", "fail"]
+    },
+    "checkStatus": {
+      "type": "string",
+      "enum": ["pass", "fail", "partial", "unsupported", "flaky", "skipped"]
+    },
+    "checkId": {
+      "type": "string",
+      "enum": ["tools", "prompts", "resources", "semantics"]
+    },
+    "evidenceSummary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "endpoint",
+        "advertised",
+        "responded",
+        "minimalShapePresent"
+      ],
+      "properties": {
+        "endpoint": {
+          "type": "string"
+        },
+        "advertised": {
+          "type": "boolean"
+        },
+        "responded": {
+          "type": "boolean"
+        },
+        "minimalShapePresent": {
+          "type": "boolean"
+        },
+        "itemCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "identifiers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "diagnostics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "checkResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "capability",
+        "status",
+        "durationMs",
+        "message",
+        "evidence"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/checkId"
+        },
+        "capability": {
+          "$ref": "#/definitions/checkId"
+        },
+        "status": {
+          "$ref": "#/definitions/checkStatus"
+        },
+        "durationMs": {
+          "type": "number",
+          "minimum": 0
+        },
+        "message": {
+          "type": "string"
+        },
+        "evidence": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/evidenceSummary"
+          }
+        }
+      }
+    },
+    "statusCounts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "total",
+        "pass",
+        "fail",
+        "partial",
+        "unsupported",
+        "flaky",
+        "skipped"
+      ],
+      "properties": {
+        "total": { "type": "integer", "minimum": 0 },
+        "pass": { "type": "integer", "minimum": 0 },
+        "fail": { "type": "integer", "minimum": 0 },
+        "partial": { "type": "integer", "minimum": 0 },
+        "unsupported": { "type": "integer", "minimum": 0 },
+        "flaky": { "type": "integer", "minimum": 0 },
+        "skipped": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "runSummary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "total",
+        "pass",
+        "fail",
+        "partial",
+        "unsupported",
+        "flaky",
+        "skipped",
+        "gate"
+      ],
+      "properties": {
+        "total": { "type": "integer", "minimum": 0 },
+        "pass": { "type": "integer", "minimum": 0 },
+        "fail": { "type": "integer", "minimum": 0 },
+        "partial": { "type": "integer", "minimum": 0 },
+        "unsupported": { "type": "integer", "minimum": 0 },
+        "flaky": { "type": "integer", "minimum": 0 },
+        "skipped": { "type": "integer", "minimum": 0 },
+        "gate": {
+          "$ref": "#/definitions/gate"
+        }
+      }
+    },
+    "targetSnapshot": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["targetId", "adapter", "command", "args"],
+      "properties": {
+        "targetId": {
+          "type": "string"
+        },
+        "adapter": {
+          "const": "local-process"
+        },
+        "command": {
+          "type": "string"
+        },
+        "args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "cwd": {
+          "type": "string"
+        },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "serverVersion": {
+          "type": "string"
+        },
+        "serverName": {
+          "type": "string"
+        }
+      }
+    },
+    "environmentSnapshot": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["platform", "nodeVersion"],
+      "properties": {
+        "platform": {
+          "type": "string"
+        },
+        "nodeVersion": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/scripts/validate-artifacts.ts
+++ b/scripts/validate-artifacts.ts
@@ -1,0 +1,94 @@
+import { readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+
+import { Ajv, type ErrorObject, type ValidateFunction } from "ajv";
+
+type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue };
+
+interface ArtifactFile {
+  path: string;
+  content: { artifactType?: string };
+}
+
+type JsonObject = { [key: string]: JsonValue };
+
+async function readJson(filePath: string): Promise<JsonValue> {
+  return JSON.parse(await readFile(filePath, "utf8")) as JsonValue;
+}
+
+async function collectArtifactFiles(root: string): Promise<ArtifactFile[]> {
+  const files = [
+    path.join(root, "tests", "fixtures", "sample-run-a.json"),
+    path.join(root, "tests", "fixtures", "sample-run-b.json")
+  ];
+
+  const examplesDir = path.join(root, "examples", "artifacts");
+  for (const fileName of await readdir(examplesDir)) {
+    if (fileName.endsWith(".json")) {
+      files.push(path.join(examplesDir, fileName));
+    }
+  }
+
+  const results: ArtifactFile[] = [];
+  for (const filePath of files) {
+    const content = await readJson(filePath);
+    if (typeof content !== "object" || content === null || Array.isArray(content)) {
+      throw new Error(`Artifact at ${filePath} is not a JSON object.`);
+    }
+    results.push({
+      path: filePath,
+      content: content as ArtifactFile["content"]
+    });
+  }
+  return results;
+}
+
+async function main(): Promise<void> {
+  const root = process.cwd();
+  const ajv = new Ajv({
+    allErrors: true,
+    strict: false
+  });
+
+  const runSchema = await readJson(path.join(root, "schemas", "run-artifact.schema.json"));
+  const diffSchema = await readJson(path.join(root, "schemas", "diff-artifact.schema.json"));
+
+  if (typeof runSchema !== "object" || runSchema === null || Array.isArray(runSchema)) {
+    throw new Error("Run artifact schema must be a JSON object.");
+  }
+  if (typeof diffSchema !== "object" || diffSchema === null || Array.isArray(diffSchema)) {
+    throw new Error("Diff artifact schema must be a JSON object.");
+  }
+
+  const validateRun = ajv.compile(runSchema as JsonObject) as ValidateFunction<ArtifactFile["content"]>;
+  const validateDiff = ajv.compile(diffSchema as JsonObject) as ValidateFunction<ArtifactFile["content"]>;
+
+  const artifactFiles = await collectArtifactFiles(root);
+  let hasErrors = false;
+
+  for (const artifact of artifactFiles) {
+    const validate =
+      artifact.content.artifactType === "diff" ? validateDiff : validateRun;
+    const valid = validate(artifact.content);
+    if (!valid) {
+      hasErrors = true;
+      process.stderr.write(`Schema validation failed for ${artifact.path}\n`);
+      const errors: ErrorObject[] = validate.errors ?? [];
+      for (const error of errors) {
+        process.stderr.write(`- ${error.instancePath || "/"} ${error.message ?? "invalid"}\n`);
+      }
+    } else {
+      process.stdout.write(`validated ${artifact.path}\n`);
+    }
+  }
+
+  if (hasErrors) {
+    process.exitCode = 1;
+  }
+}
+
+void main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`${message}\n`);
+  process.exitCode = 1;
+});

--- a/tests/schema.test.ts
+++ b/tests/schema.test.ts
@@ -1,0 +1,17 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+import { describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+
+describe("artifact schemas", () => {
+  it("validate checked-in sample and real-server artifacts", async () => {
+    const { stderr } = await execFileAsync("npm", ["run", "validate:artifacts"], {
+      cwd: process.cwd(),
+      env: process.env
+    });
+
+    expect(stderr).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary
- publish stable JSON Schemas for run and diff artifacts and validate checked-in artifacts in CI
- upgrade the README and release docs into adoption-focused public surfaces
- add CODEOWNERS plus a separate nightly/manual real-server matrix workflow

## Testing
- npm run lint
- npm run typecheck
- npm run build
- npm test
- npm run smoke
- npm run validate:artifacts
- npm run integration:real

Closes #7
Closes #9