### PR TITLE
Update workflow actions for Node 24 readiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/real-server-matrix.yml
+++ b/.github/workflows/real-server-matrix.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -27,7 +27,7 @@ jobs:
 
       - name: Upload matrix artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: real-server-matrix-artifacts
           path: |


### PR DESCRIPTION
## Summary
- move CI and real-server workflows to current maintained `actions/*` major versions
- remove the new Node 20 deprecation warning from the launch surface
- keep the release tag on the same product/docs surface, just with cleaner workflow infra

## Testing
- workflow syntax only; validated against the successful runs from the prior merge
