### PR TITLE
Replace launch slop with maintainer voice and field evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,15 @@ The format is intentionally simple while the project is pre-1.0:
 
 ### Changed
 
-- reserved for follow-up work after `v0.1.0`
+- README now leads with observed server behavior, explicit non-goals, and project status instead of generic launch framing
+- contributor guidance now emphasizes evidence, smaller opinionated PRs, and the kinds of work likely to be declined
+
+### Docs
+
+- added `docs/field-notes.md` to record launch-day real-server observations and what they changed
+- added `docs/decisions.md` to document the narrow semantics bar, CLI-first posture, and release bar
+- expanded `docs/known-issues.md` with an explicit `unsupported` vs `failed` explanation
+- updated release guidance so future notes stay observational rather than launch-like
 
 ## v0.1.0 - 2026-03-19
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,27 +2,28 @@
 
 Thanks for helping make MCP Observatory sharper and more trustworthy.
 
-## Contribution Paths
+This repo is intentionally small. Good contributions make the evidence clearer. Weak contributions usually add surface area faster than they add trust.
 
-### Small
+## What Good Contributions Look Like
 
-- improve report wording or evidence formatting
-- add or refine README examples
-- tighten issue templates or docs
-- add fixture coverage for an already-supported capability
+- clarity over breadth
+- evidence over feature count
+- smaller, opinionated PRs over speculative scaffolding
+- checked-in artifacts or reports that teach something concrete
+- docs that remove a real confusion, not just add more prose
 
-### Medium
+## Current Priorities
 
-- add a new deterministic fixture server
-- improve diff messaging or artifact ergonomics
-- harden error handling for local-process targets
-- improve CI smoke coverage
+- [#3 Improve artifact output readability in the Markdown report](https://github.com/KryptosAI/mcp-observatory/issues/3)
+- [#6 Improve CLI startup error messaging for connection and setup failures](https://github.com/KryptosAI/mcp-observatory/issues/6)
+- [#1](https://github.com/KryptosAI/mcp-observatory/issues/1) and [#2](https://github.com/KryptosAI/mcp-observatory/issues/2) once a concrete passing server is identified
 
-### Advanced
+## What Will Probably Be Declined
 
-- add a new adapter shape without breaking the current target contract
-- add richer corpus tooling for reproducible interoperability cases
-- evolve the artifact schema in an additive, backwards-compatible way
+- generic dashboard or control-plane ideas
+- speculative adapter abstraction work without a concrete failing target
+- feature additions that do not come with evidence or artifacts
+- broad packaging or workflow churn that does not improve trust, clarity, or report quality
 
 ## Ground Rules
 
@@ -61,6 +62,14 @@ For each path:
 - mention the specific files you plan to touch
 - keep the diff small and obvious
 - include the exact validation commands you ran
+
+## Evidence Bar For Examples And Integrations
+
+If you add or modify anything under `examples/` or a real-server workflow, include:
+
+- a concrete server or workflow, not a hypothetical integration
+- a checked-in artifact or Markdown report when the change affects observable output
+- one sentence explaining what the example teaches us
 
 ## Fixture Contributions
 

--- a/README.md
+++ b/README.md
@@ -6,51 +6,65 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 [![Node >= 22](https://img.shields.io/badge/node-%3E%3D22-339933)](./package.json)
 
-MCP Observatory is a developer confidence harness for MCP authors and integrators.
+MCP Observatory exists because real MCP servers drift in ways conformance does not explain.
 
-It detects, stores, compares, and explains interoperability drift over time so you can answer the question most conformance tooling does not try to answer:
+> Maintainer note, March 19, 2026: I started this repo after running a small real-server matrix and seeing two different truths at once. `@modelcontextprotocol/server-filesystem`, `@modelcontextprotocol/server-everything`, and `ref-tools-mcp` all worked, but they exposed very different capability shapes. At the same time, `@modelcontextprotocol/server-map`, `@modelcontextprotocol/server-pdf`, `@modelcontextprotocol/server-threejs`, and `@jsonresume/mcp` timed out or closed early when treated as plain local-process stdio targets. Official conformance still matters. This repo exists because field evidence matters too.
 
-"What changed, what regressed, what recovered, and what artifact proves it?"
+If the project ever turns into generic MCP theater, that is a regression.
 
-## Why This Exists
+## Working Surface
 
-MCP adoption is accelerating, which means MCP breakage is getting more expensive.
+The product surface is deliberately small:
 
-Official conformance tooling is necessary, but it is not the same as regression intelligence. MCP Observatory exists to preserve historical evidence over time so teams can:
+- `run`: execute checks against one target and always persist a run artifact
+- `diff`: compare two runs and classify regressions and recoveries
+- `report`: turn a saved run artifact into readable terminal, JSON, or Markdown output
 
-- spot capability drift before users do
-- compare runs across versions and server changes
-- publish a clear artifact that explains what broke or recovered
-- build confidence in real-world MCP server behavior without inventing a dashboard first
+That is enough to answer a practical question: what changed, what regressed, what recovered, and what artifact proves it?
 
-## Who It Is For
+## Non-goals
 
-- MCP server authors who want confidence before release
-- integrators who need a repeatable way to compare servers or versions
-- OSS contributors who want a concrete, evidence-driven surface to improve
-- CI owners who need a machine-friendly gate plus a human-readable report
+This repo is not trying to be:
 
-## Why Not Conformance?
+- a dashboard product
+- a spec fork or alternate conformance suite
+- broad MCP certification
+- deep semantic correctness validation
+- a promise that every MCP package is a drop-in stdio target
 
-Official MCP conformance tooling already exists.
+If that is the problem you need solved, this is the wrong tool.
 
-MCP Observatory is not trying to replace conformance or redefine the protocol. It complements conformance by focusing on historical compatibility drift and evidence over time. The framing for this repo is consistent on purpose:
+## 60-Second Start
 
-**This is a developer confidence tool for MCP authors and integrators.**
+```bash
+npm install
+npm run cli -- run --target tests/fixtures/sample-target-config.json
+npm run cli -- diff --base tests/fixtures/sample-run-a.json --head tests/fixtures/sample-run-b.json
+# Observe obvious regression/recovery output in the terminal summary
+```
 
-It is not a generic dashboard, not a trust platform, and not a spec fork.
+This is the shortest path to seeing the project work end-to-end without depending on an external MCP server.
 
-## Where It Fits
+The flagship output is still the Markdown report:
 
-| Surface | Primary question answered | Output style | Positioning |
-| --- | --- | --- | --- |
-| Official conformance | "Does this implementation satisfy the protocol contract right now?" | pass/fail conformance evidence | compliance baseline |
-| MCP Observatory | "What changed over time, what regressed, and what recovered?" | versioned run artifacts, diffs, Markdown reports | developer confidence harness |
-| Ad hoc local testing | "Did my one manual run look okay?" | transient console output | useful but not durable |
+```bash
+npm run cli -- report --run tests/fixtures/sample-run-b.json --format markdown --output examples/results/sample-report.md
+```
+
+## What We Learned From Actual Servers
+
+These are not hypothetical scenarios. They came from launch-day runs on March 19, 2026.
+
+- `@modelcontextprotocol/server-filesystem` passed `tools` and cleanly surfaced `prompts` and `resources` as `unsupported`. That is a legitimate capability shape, not a failure.
+- `@modelcontextprotocol/server-everything` passed `tools`, `prompts`, and `resources`. It is a good wide reference target, but it should not be mistaken for the average package.
+- `ref-tools-mcp` passed `tools` and `prompts` while leaving `resources` unsupported. That is useful third-party diversity.
+- `@modelcontextprotocol/server-map`, `@modelcontextprotocol/server-pdf`, `@modelcontextprotocol/server-threejs`, and `@jsonresume/mcp` did not behave like plain local-process stdio targets under the current harness. That is ecosystem signal first, product bug second.
+
+See [docs/field-notes.md](./docs/field-notes.md) for the full launch-day observations and what they changed about the repo.
 
 ## Visual Proof
 
-The fastest way to understand the product is to look at the artifact surface directly:
+The quickest way to understand the repo is still to look at a diff artifact:
 
 ```text
 MCP Observatory Diff
@@ -65,46 +79,22 @@ Recoveries:
 - prompts: unsupported -> pass (Advertised capability responded with the minimal expected shape (1 item).)
 ```
 
-See the full checked-in reports:
+Checked-in evidence:
 
 - [Sample fixture report](./examples/results/sample-report.md)
 - [Everything server report](./examples/artifacts/everything-server-report.md)
 - [Filesystem server report](./examples/artifacts/filesystem-server-report.md)
-
-## What You Get
-
-- `run`: execute checks against a target config and persist a versioned run artifact
-- `diff`: compare two run artifacts and classify regressions and recoveries
-- `report`: render a saved run artifact as terminal, JSON, or polished Markdown
-- stable artifact fields from day one: `artifactType`, `schemaVersion`, and `gate`
-- focused checks only: `tools`, `prompts`, `resources`, and a narrow `semantics` pass
-
-## 60-Second Start
-
-```bash
-npm install
-npm run cli -- run --target tests/fixtures/sample-target-config.json
-npm run cli -- diff --base tests/fixtures/sample-run-a.json --head tests/fixtures/sample-run-b.json
-# Observe obvious regression/recovery output in the terminal summary
-```
-
-This is the shortest path to seeing the product work end-to-end with no external MCP dependency.
-
-The flagship artifact is the Markdown report:
-
-```bash
-npm run cli -- report --run tests/fixtures/sample-run-b.json --format markdown --output examples/results/sample-report.md
-```
+- [Examples overview](./examples/README.md)
 
 ## Real Server Coverage
 
-The repo includes a small real-world smoke matrix across distinct MCP implementations:
+Current passing matrix:
 
-| Target | Server | Shape | Tools | Prompts | Resources | Notes |
+| Target | Server | Shape observed on 2026-03-19 | Tools | Prompts | Resources | Notes |
 | --- | --- | --- | --- | --- | --- | --- |
-| [filesystem-server.json](./examples/targets/filesystem-server.json) | `@modelcontextprotocol/server-filesystem` | tool-heavy | pass | unsupported | unsupported | good basic stdio smoke |
-| [everything-server.json](./examples/targets/everything-server.json) | `@modelcontextprotocol/server-everything` | resources-heavy | pass | pass | pass | best capability diversity today |
-| [ref-tools-server.json](./examples/targets/ref-tools-server.json) | `ref-tools-mcp` | prompts-heavy | pass | pass | unsupported | third-party implementation signal |
+| [filesystem-server.json](./examples/targets/filesystem-server.json) | `@modelcontextprotocol/server-filesystem` | tool-heavy | pass | unsupported | unsupported | good baseline for unsupported vs failed |
+| [everything-server.json](./examples/targets/everything-server.json) | `@modelcontextprotocol/server-everything` | broad capability reference | pass | pass | pass | best wide target in the current matrix |
+| [ref-tools-server.json](./examples/targets/ref-tools-server.json) | `ref-tools-mcp` | prompts-heavy third-party case | pass | pass | unsupported | useful non-official signal |
 
 Manual recipe:
 
@@ -120,27 +110,35 @@ Repeatable script:
 npm run integration:real
 ```
 
-The real-server matrix also runs in GitHub Actions as a separate nightly and manually-triggered workflow so ecosystem drift is visible without slowing normal PR CI.
+The same matrix also runs in GitHub Actions on a nightly schedule and by manual dispatch. That workflow exists to surface drift, not to make the main PR gate slower.
+
+## Project Status
+
+- Current maturity: useful for local-process stdio targets, local regression checks, and CI smoke gating.
+- Actively improving now: report readability, clearer startup failure messaging, and a more representative real-server matrix.
+- Not ready yet: app-oriented packages, alternate transports, or deep semantic correctness beyond advertised/responded/minimal-shape checks.
+
+If those are the requirements you care about most today, the repo is still early.
 
 ## Artifact Contract
 
-Every artifact is versioned and machine-friendly:
+Every artifact is versioned and intentionally boring:
 
 - `artifactType`: `run` or `diff`
 - `schemaVersion`: currently `1.0.0`
 - `gate`: `pass` or `fail`
 
-Schema compatibility rules:
+Compatibility rules:
 
 - additive changes stay within `1.x`
-- any breaking artifact change requires a major schema bump
+- breaking artifact changes require a major schema bump
 
 Published schemas:
 
 - [schemas/run-artifact.schema.json](./schemas/run-artifact.schema.json)
 - [schemas/diff-artifact.schema.json](./schemas/diff-artifact.schema.json)
 
-Validate checked-in artifacts locally:
+Validate the checked-in artifacts locally:
 
 ```bash
 npm run validate:artifacts
@@ -148,73 +146,43 @@ npm run validate:artifacts
 
 ## Semantics v1
 
-The `semantics` check is intentionally narrow in v1. It only verifies:
+`semantics` is intentionally narrow in v1. It only verifies:
 
 - the capability is advertised
 - the corresponding callable endpoint responds
 - the response contains the minimal expected shape
 
-It does not validate tool correctness, prompt quality, resource content, or protocol behavior beyond those three assertions.
+It does not claim tool correctness, prompt quality, resource validity, or protocol completeness. That is a deliberate decision, not an unfinished sentence. The reasoning is documented in [docs/decisions.md](./docs/decisions.md).
 
-## Target Config
+## Current Priorities
 
-Targets are JSON files with this shape:
+The public queue is intentionally smaller than it was at launch. Current priorities are:
 
-```json
-{
-  "targetId": "fixture-server",
-  "adapter": "local-process",
-  "command": "node",
-  "args": ["tests/fixtures/fixture-server.mjs"],
-  "cwd": ".",
-  "timeoutMs": 10000,
-  "metadata": {
-    "purpose": "golden-path"
-  }
-}
-```
-
-## Architecture
-
-See [docs/architecture.md](./docs/architecture.md) for the short system map and [docs/performance.md](./docs/performance.md) for illustrative timing notes from checked-in artifacts.
-
-## How To Pick An Issue
-
-If you want the highest-leverage starting points, begin here:
-
-- [#1 Add a second resources-heavy real-server smoke target](https://github.com/KryptosAI/mcp-observatory/issues/1)
 - [#3 Improve artifact output readability in the Markdown report](https://github.com/KryptosAI/mcp-observatory/issues/3)
-- [#5 Document unsupported vs failed semantics clearly](https://github.com/KryptosAI/mcp-observatory/issues/5)
-- [#7 Add JSON Schema validation for run artifacts](https://github.com/KryptosAI/mcp-observatory/issues/7)
-- [#10 Add example integrations folder for CI and PR comment usage](https://github.com/KryptosAI/mcp-observatory/issues/10)
-
-The public work queue lives in GitHub Issues, and the `good first issue` label is curated intentionally.
+- [#6 Improve CLI startup error messaging for connection and setup failures](https://github.com/KryptosAI/mcp-observatory/issues/6)
+- [#1 Add a second resources-heavy real-server smoke target](https://github.com/KryptosAI/mcp-observatory/issues/1)
+- [#2 Add a second prompts-capable real-server smoke target](https://github.com/KryptosAI/mcp-observatory/issues/2)
 
 ## Contributing
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md) for small, medium, and advanced contribution paths.
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for the contribution bar and the kinds of work that are likely to be declined.
 
-If you want the quickest useful contribution:
-
-1. add or refine a real-server smoke case
-2. improve one evidence message or report section
-3. add one integration example or artifact validation improvement
-
-See [examples/integrations](./examples/integrations) for lightweight CI and PR-comment wiring examples.
+If you want the shortest path to a useful first contribution, start with one of the current priorities above and keep the diff small enough that the checked-in artifact or report still teaches something obvious.
 
 ## Release Posture
 
-The repo is ready for tagged GitHub releases before npm publishing.
+The repo is GitHub-release-first for now. npm publishing remains deferred on purpose.
 
 - changelog: [CHANGELOG.md](./CHANGELOG.md)
 - release process: [RELEASE.md](./RELEASE.md)
 - release notes template: [docs/release-notes-template.md](./docs/release-notes-template.md)
-- helper script: `npm run release:prep`
-- npm publishing decision tracking: keep scoped for now, revisit later
+- decisions log: [docs/decisions.md](./docs/decisions.md)
+
+The current maintainer rule is simple: every release should include either a real-server learning, a report-quality improvement, or a schema trust improvement.
 
 ## Known Issues
 
-See [docs/known-issues.md](./docs/known-issues.md) for current integration caveats and why they matter to the ecosystem story.
+See [docs/known-issues.md](./docs/known-issues.md) for the difference between `unsupported` and `failed`, plus the current list of packages that do not behave like drop-in stdio targets under the local-process harness.
 
 ## Security
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,18 @@
 
 The repo is GitHub-release-ready before it is npm-publish-ready.
 
+## Release Bar
+
+Do not cut a release just because a branch merged cleanly.
+
+Every release should include at least one of:
+
+- a real-server learning
+- a report-quality improvement
+- a schema trust improvement
+
+If the diff is mostly packaging churn or generic polish, wait.
+
 ## Versioning Approach
 
 - artifact schema is versioned independently through `schemaVersion`
@@ -29,7 +41,7 @@ For now:
 ## Changelog vs Release Notes
 
 - `CHANGELOG.md` is the durable project history
-- GitHub release notes are the launch-facing summary for one tagged release
+- GitHub release notes are the observational summary for one tagged release
 
 Use the changelog for:
 
@@ -39,8 +51,9 @@ Use the changelog for:
 
 Use release notes for:
 
-- the best story of the release
-- highlighted improvements grouped by the categories in `.github/release.yml`
+- what changed
+- what the release taught us
+- what still feels uncertain
 - links to the most important docs, artifacts, and next-step issues
 
 ## Release Notes Template

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1,0 +1,23 @@
+# Decisions
+
+These decisions exist so the repo does not drift into vague feature accumulation.
+
+## 2026-03-19: Semantics v1 stays intentionally narrow
+
+`semantics` only checks advertised capability, callable endpoint response, and minimal expected shape. The first job of MCP Observatory is to explain drift, not to claim semantic correctness it does not yet earn.
+
+## 2026-03-19: The project stays CLI-first
+
+The durable product surface is the artifact plus the report. A dashboard can wait. Until the evidence surface is boringly trustworthy, adding hosted UX would mostly be theater.
+
+## 2026-03-19: `unsupported` and `failed` remain separate
+
+`unsupported` means the target did not advertise the capability. `failed` means the capability path or startup path should have worked and did not. Collapsing those states would hide useful ecosystem truth.
+
+## 2026-03-19: npm publishing is deferred
+
+GitHub releases are enough for now. The package stays scoped as `@kryptosai/mcp-observatory` until there is real demand for broader distribution.
+
+## 2026-03-19: Every release needs a reason to exist
+
+Packaging-only churn is not a release story. Every release should include at least one real-server learning, one report-quality improvement, or one schema trust improvement.

--- a/docs/field-notes.md
+++ b/docs/field-notes.md
@@ -1,0 +1,35 @@
+# Field Notes
+
+These notes are the opposite of launch fluff. They exist to record what the repo learned from actual runs.
+
+## 2026-03-19: Launch hardening matrix
+
+### Passing targets
+
+| Target | Observed result | Why it mattered |
+| --- | --- | --- |
+| `@modelcontextprotocol/server-filesystem` | `tools=pass`, `prompts=unsupported`, `resources=unsupported` | proved that `unsupported` is a useful stable state, not an embarrassment |
+| `@modelcontextprotocol/server-everything` | `tools=pass`, `prompts=pass`, `resources=pass` | gave the repo one wide capability reference target |
+| `ref-tools-mcp` | `tools=pass`, `prompts=pass`, `resources=unsupported` | proved the matrix was not only made of official example servers |
+
+### Failed probes
+
+| Package | Observed behavior | What it taught us |
+| --- | --- | --- |
+| `@modelcontextprotocol/server-map` | timed out during local-process startup | not every MCP package is a drop-in stdio target |
+| `@modelcontextprotocol/server-pdf` | timed out during local-process startup | package-specific startup expectations matter |
+| `@modelcontextprotocol/server-threejs` | connection closed before initialization completed | app-oriented packages need clearer transport assumptions |
+| `@jsonresume/mcp` | connection closed before initialization completed | startup failures should be presented as ecosystem signal, not only raw failure |
+
+### What changed because of these runs
+
+- the repo now treats `unsupported` and `failed` as meaningfully different states
+- the real-server matrix is part of the public story, not a hidden validation step
+- the README now leads with observed behavior instead of generic positioning
+- clearer CLI startup failure messaging is now a real priority, not a hypothetical enhancement
+
+### What still feels uncertain
+
+- how many ecosystem packages should be expected to work as plain local-process stdio targets
+- whether the next useful adapter improvement is transport-related or message-quality-related
+- how broad the real-server matrix should become before it turns into maintenance theater

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -1,5 +1,14 @@
 # Known Issues
 
+## `unsupported` vs `failed`
+
+This distinction is one of the main reasons the repo exists.
+
+- `unsupported` means the target did not advertise the capability. Example: `@modelcontextprotocol/server-filesystem` currently surfaces `prompts` and `resources` as `unsupported`.
+- `failed` means the capability path or startup path should have worked and did not. Example: a target that advertises a capability but errors during the list call, or a package that closes the connection before initialization completes.
+
+Collapsing those states would make the ecosystem look simpler than it is.
+
 ## Not every MCP package is a drop-in stdio target
 
 Some packages in the ecosystem are app-oriented, require additional startup flags, or close immediately when invoked like a plain local-process stdio server. That is not a failure of MCP Observatory; it is useful ecosystem signal.
@@ -16,3 +25,5 @@ These are good candidates for future integration work because they help clarify:
 - stdio vs app/server transport expectations
 - startup requirements for package-specific servers
 - how MCP Observatory should present connection/setup failures clearly
+
+See [docs/field-notes.md](./field-notes.md) for the launch-day observations that pushed these packages onto the known-issues list.

--- a/docs/release-notes-template.md
+++ b/docs/release-notes-template.md
@@ -2,31 +2,26 @@
 
 Use this structure when publishing a tagged GitHub release:
 
-## Highlights
+## What Changed
 
-- the one-sentence release story
-- the biggest user-visible win
+- the short release story
+- the biggest practical user-visible change
 
-## CLI and Core
+## What We Learned
 
-- command or runtime changes
-- adapter/check/diff improvements
+- one concrete field note from real usage
+- one thing the release clarified about the ecosystem or the product
 
-## Reporting and Docs
+## What Still Feels Uncertain
 
-- Markdown report improvements
-- README or contributor-surface upgrades
+- one honest caveat
+- one thing the project still does not do well
 
-## Examples and Contributor Experience
+## Evidence Shipped
 
-- new real-server examples
-- new docs, issue surfacing, or onboarding improvements
+- the most useful report, artifact, or doc added in this release
+- links to the exact artifacts or field notes worth reading
 
-## Release and Packaging
+## Contributor Follow-ups
 
-- versioning or release-process changes
-- npm posture updates, if any
-
-## Next Recommended Issues
-
-- link to 2-4 issues that are good follow-ups after the release lands
+- link to 2-4 issues that are still worth doing next

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # Examples
 
-This directory makes the project tangible quickly.
+These files are meant to be evidence, not marketing samples.
 
 ## Targets
 
@@ -15,3 +15,5 @@ This directory makes the project tangible quickly.
 ## Reports
 
 Markdown reports sit next to their corresponding JSON artifacts so readers can compare machine-friendly and human-friendly output surfaces side by side.
+
+If an example does not teach something specific about a real server, it probably does not belong here.


### PR DESCRIPTION
## Summary
- rewrite the public docs around observed server behavior, explicit non-goals, and project status
- add field notes and a decisions log so the repo shows judgment instead of generic scaffolding
- curate the public queue so the remaining issues are smaller, grounded, and current

## Testing
- npm test
- npm run smoke

Closes #5
Closes #8