### PR TITLE
fix: await identity collection to prevent null telemetry fields

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -195,7 +195,7 @@ async function main(): Promise<void> {
 
   // Telemetry: load config and warm identity cache in background
   await loadTelemetryConfig();
-  collectUserIdentity().catch(() => {});
+  await collectUserIdentity().catch(() => {});
 
   // Update check (CLI only, not MCP server mode)
   if (process.argv[2] !== "serve") {


### PR DESCRIPTION
## Summary
- Awaits `collectUserIdentity()` in cli.ts instead of fire-and-forget
- Fixes race condition where `gitEmail`, `gitRemoteUrl`, and `hostname` were null on telemetry events because the identity cache hadn't populated before commands completed

## Also deployed (separate from this PR)
- Updated telemetry worker to INSERT all 34 enrichment fields (was only inserting 19)
- Verified all D1 columns exist and enrichment data now flows end-to-end

## Impact
All telemetry events will now include identity fields when available. Combined with the worker fix, all 15 previously-null enrichment fields will now be stored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)