### PR TITLE
Fix matrix CI hang and security maintenance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      dev-tooling:
+        dependency-type: "development"
+      runtime-dependencies:
+        dependency-type: "production"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -5,7 +5,9 @@ on:
   workflow_dispatch:
 
 permissions:
+  contents: read
   pull-requests: write
+  statuses: write
 
 jobs:
   test-action:

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -31,4 +31,5 @@ jobs:
           command: npx -y @modelcontextprotocol/server-everything
           security: true
           fail-on-regression: false
+          set-status: false
           comment-on-pr: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/real-server-matrix.yml
+++ b/.github/workflows/real-server-matrix.yml
@@ -28,6 +28,7 @@ jobs:
 
       - name: Run real-server matrix
         id: matrix
+        continue-on-error: true
         timeout-minutes: 10
         env:
           MCP_OBSERVATORY_MATRIX_TIMEOUT_MS: "300000"
@@ -60,3 +61,9 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dashboard
           publish_branch: gh-pages
+
+      - name: Fail if matrix found issues
+        if: steps.matrix.outcome == 'failure'
+        run: |
+          echo "::error::Real-server matrix completed with failing target(s). See uploaded artifacts and dashboard output for details."
+          exit 1

--- a/.github/workflows/real-server-matrix.yml
+++ b/.github/workflows/real-server-matrix.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   matrix:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -27,6 +28,9 @@ jobs:
 
       - name: Run real-server matrix
         id: matrix
+        timeout-minutes: 10
+        env:
+          MCP_OBSERVATORY_MATRIX_TIMEOUT_MS: "300000"
         run: npm run integration:real
 
       - name: Build dashboard

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,6 @@ coverage/
 .DS_Store
 *.log
 logs/
+reports/
+telemetry-exports/
 .mcpregistry_*

--- a/COMMERCIAL.md
+++ b/COMMERCIAL.md
@@ -24,6 +24,7 @@ Paid pilots can include:
 - Hosted CI history and private-repo reporting
 - MCP security reports and production monitoring
 - Fleet inventory across teams, repos, and environments
+- Static enterprise reports generated from existing run artifacts
 - Certification language for MCP servers that pass agreed checks
 - Support for production incidents and rollout planning
 - Manual account review and implementation guidance
@@ -43,6 +44,19 @@ Run:
 
 ```bash
 npx @kryptosai/mcp-observatory cloud
+```
+
+Generate the first report before a hosted dashboard exists:
+
+```bash
+npx @kryptosai/mcp-observatory enterprise-report --account "Customer Name" --format html --output observatory-report.html
+```
+
+For account-level pilot reporting in CI:
+
+```bash
+MCP_OBSERVATORY_ORG=customer.com
+MCP_OBSERVATORY_CONTACT=mcp-owner@customer.com
 ```
 
 ## Enterprise Framing

--- a/COMMERCIAL.md
+++ b/COMMERCIAL.md
@@ -1,0 +1,50 @@
+# MCP Observatory Commercial Pilots
+
+MCP Observatory helps teams test, secure, and monitor MCP servers before agents depend on them.
+
+The open source CLI and MCP server remain free for local OSS use under the MIT license. Paid pilots are for production use cases where a team needs hosted reporting, private repository CI, security reports, certification, support, or fleet visibility.
+
+## Pilot Pricing
+
+These are starting points for current pilots, not permanent fixed plans.
+
+| Pilot | Starting Price | Best Fit |
+| --- | ---: | --- |
+| Team Pilot | $299/month | Small teams adding MCP regression checks to CI |
+| Business Pilot | $999/month | Private repos, recurring security reports, and shared reporting |
+| Enterprise Pilot | $3k/month | Production MCP monitoring, support, and fleet visibility |
+| Strategic Accounts | Custom, $250k+/year | Major platforms, AI labs, and companies running MCP in production at scale |
+
+Contact: william@banksey.com
+
+## Paid Production Use
+
+Paid pilots can include:
+
+- Hosted CI history and private-repo reporting
+- MCP security reports and production monitoring
+- Fleet inventory across teams, repos, and environments
+- Certification language for MCP servers that pass agreed checks
+- Support for production incidents and rollout planning
+- Manual account review and implementation guidance
+
+## What Stays Free
+
+- Local OSS use of the CLI and MCP server
+- Running checks in public open source projects
+- Self-managed artifacts and local reports
+- Existing MIT-licensed code
+
+## Upgrade Path
+
+The CLI recognizes `MCP_OBSERVATORY_CLOUD_TOKEN` as the future hosted-upload credential. During pilots, hosted reports and account mapping may be enabled manually before any self-serve SaaS flow exists.
+
+Run:
+
+```bash
+npx @kryptosai/mcp-observatory cloud
+```
+
+## Enterprise Framing
+
+For production MCP usage, private repo CI, compliance/security reporting, or large company deployments, contact us before selecting a plan. Major company usage is routed to Enterprise or Strategic pricing rather than Team or Business pilots.

--- a/COMMERCIAL.md
+++ b/COMMERCIAL.md
@@ -59,6 +59,8 @@ MCP_OBSERVATORY_ORG=customer.com
 MCP_OBSERVATORY_CONTACT=mcp-owner@customer.com
 ```
 
+Use the [enterprise outreach playbook](./docs/enterprise-outreach-playbook.md) to route high-confidence company usage to manual pilots without sending generic low-tier pricing to major accounts.
+
 ## Enterprise Framing
 
 For production MCP usage, private repo CI, compliance/security reporting, or large company deployments, contact us before selecting a plan. Major company usage is routed to Enterprise or Strategic pricing rather than Team or Business pilots.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -8,6 +8,7 @@ MCP Observatory collects product usage telemetry unless telemetry is disabled. T
 - MCP target or server names
 - Counts of tools, prompts, resources, servers, checks, and failures
 - CI environment signals such as provider and repository metadata when available
+- Declared account attribution from `MCP_OBSERVATORY_ORG` and `MCP_OBSERVATORY_CONTACT` when operators set them
 - Git metadata such as `gitEmail` and `gitRemoteUrl` when available
 - Hostname and operating system metadata
 - Session identifiers and timestamps
@@ -27,6 +28,13 @@ Inspect telemetry status with:
 
 ```bash
 npx @kryptosai/mcp-observatory telemetry --verbose
+```
+
+Production teams can make account reporting clearer without relying on inferred git metadata:
+
+```bash
+MCP_OBSERVATORY_ORG=example.com
+MCP_OBSERVATORY_CONTACT=mcp-owner@example.com
 ```
 
 ## Internal Account Intelligence

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,42 @@
+# Privacy And Telemetry
+
+MCP Observatory collects product usage telemetry unless telemetry is disabled. Telemetry helps us understand which commands are used, where the tool fails, and whether teams need CI, security, reporting, or fleet-monitoring support.
+
+## Telemetry May Include
+
+- Command names and feature flags
+- MCP target or server names
+- Counts of tools, prompts, resources, servers, checks, and failures
+- CI environment signals such as provider and repository metadata when available
+- Git metadata such as `gitEmail` and `gitRemoteUrl` when available
+- Hostname and operating system metadata
+- Session identifiers and timestamps
+- Error categories and scan outcomes
+
+Telemetry does not intentionally collect secrets, tool response bodies, environment variable values, cassette contents, or full private source code.
+
+## Opt Out
+
+Disable telemetry with:
+
+```bash
+npx @kryptosai/mcp-observatory telemetry off
+```
+
+Inspect telemetry status with:
+
+```bash
+npx @kryptosai/mcp-observatory telemetry --verbose
+```
+
+## Internal Account Intelligence
+
+We may use telemetry internally to identify likely company or organization usage, including by deriving company domains from git email domains, git remote URLs, CI usage, target names, repeated sessions, and production-looking command patterns.
+
+Raw emails are not intended for public reporting. Account intelligence outputs should use company domains, GitHub organizations, aggregate counts, confidence levels, and outreach status rather than raw personal identifiers.
+
+## Enterprise Controls
+
+Enterprise customers can request telemetry review, reduced collection, private deployment, or enterprise-controlled telemetry modes as part of a paid pilot.
+
+Contact: william@banksey.com

--- a/README.md
+++ b/README.md
@@ -22,11 +22,28 @@
 
 Use it as a CLI, a CI action, or give it to your agent as an MCP server and let it test your other servers for you.
 
+MCP Observatory helps teams test, secure, and monitor MCP servers before agents depend on them.
+
 <p align="center">
   <img src="./docs/demo.svg" alt="MCP Observatory scan output" width="820">
 </p>
 
 [![Observatory MCP server](https://glama.ai/mcp/servers/KryptosAI/mcp-observatory/badges/card.svg)](https://glama.ai/mcp/servers/KryptosAI/mcp-observatory)
+
+## Production / Enterprise
+
+Free for local OSS use. Paid pilots are available for hosted reporting, private repo CI, security reports, production monitoring, certification, support, and MCP fleet visibility.
+
+| Pilot | Starts At | Best Fit |
+|-------|----------:|----------|
+| Team Pilot | $299/month | Small teams adding MCP checks to CI |
+| Business Pilot | $999/month | Private repos and recurring security reports |
+| Enterprise Pilot | $3k/month | Production monitoring, support, and fleet visibility |
+| Strategic Accounts | Custom, $250k+/year | Major companies running MCP in production |
+
+Run `npx @kryptosai/mcp-observatory cloud` or contact `william@banksey.com` for production MCP usage.
+
+See [commercial pilots](./COMMERCIAL.md), [privacy and telemetry](./PRIVACY.md), and [terms for production use](./TERMS.md).
 
 ## Quick Start
 
@@ -87,6 +104,7 @@ Or add it manually to your config:
 | `ci-report` | Generate CI report for GitHub issue creation |
 | `score <cmd>` | Score an MCP server's health (0-100) |
 | `badge <cmd>` | Generate an SVG health score badge for README |
+| `cloud` | Show hosted reporting, production monitoring, and enterprise pilot options |
 
 Run with no arguments for an interactive menu:
 
@@ -183,6 +201,8 @@ Action inputs:
 | `github-token` | Token for PR comments and commit statuses | `${{ github.token }}` |
 
 The action runs checks on every PR, comments a markdown report, and blocks merge on regressions. See [`action/README.md`](./action/README.md) for all options.
+
+Production teams can add hosted CI history, private-repo reporting, security reports, production monitoring, support, and fleet visibility. Run `npx @kryptosai/mcp-observatory cloud` for pilot options.
 
 ### Lock Files
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Action inputs:
 | `deep` | Also invoke safe tools | `false` |
 | `security` | Run security analysis | `false` |
 | `fail-on-regression` | Fail the action on issues | `true` |
+| `fail-on-baseline-drift` | Fail the action when baseline verification detects drift | `true` |
 | `comment-on-pr` | Post report as PR comment | `true` |
 | `set-status` | Set a commit status check (green/red) on the HEAD SHA | `true` |
 | `github-token` | Token for PR comments and commit statuses | `${{ github.token }}` |
@@ -326,10 +327,15 @@ npx @kryptosai/mcp-observatory run --target ./target.json
   "targetId": "my-remote-server",
   "adapter": "http",
   "url": "http://localhost:3000/mcp",
-  "authToken": "optional-bearer-token",
+  "authToken": "${MCP_SERVER_TOKEN}",
+  "headers": {
+    "X-Api-Key": "$MCP_SERVER_API_KEY"
+  },
   "timeoutMs": 15000
 }
 ```
+
+Target configs support `${VAR}`, `$VAR`, and `env:VAR` references in `authToken`, `headers`, and local-process `env` values.
 
 ## How It Compares
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Or add it manually to your config:
 |---------|-------------|
 | `scan` | Auto-discover servers from config files and check them all (default) |
 | `scan deep` | Scan and also invoke safe tools to verify they execute |
-| `test <cmd>` | Test a specific server by command |
+| `test <cmd>` / `test --target <file>` | Test a specific server by command or target config |
 | `record <cmd>` | Record a server session to a cassette file for offline replay |
 | `replay <cassette>` | Replay a cassette offline — no live server needed |
 | `verify <cassette> <cmd>` | Verify a live server still matches a recorded cassette |
@@ -102,6 +102,7 @@ Or add it manually to your config:
 | `lock verify` | Verify live servers match the lock file |
 | `history` | Show health score trends for your MCP servers |
 | `ci-report` | Generate CI report for GitHub issue creation |
+| `enterprise-report` | Generate a static production/security report from run artifacts |
 | `score <cmd>` | Score an MCP server's health (0-100) |
 | `badge <cmd>` | Generate an SVG health score badge for README |
 | `cloud` | Show hosted reporting, production monitoring, and enterprise pilot options |
@@ -203,6 +204,24 @@ Action inputs:
 The action runs checks on every PR, comments a markdown report, and blocks merge on regressions. See [`action/README.md`](./action/README.md) for all options.
 
 Production teams can add hosted CI history, private-repo reporting, security reports, production monitoring, support, and fleet visibility. Run `npx @kryptosai/mcp-observatory cloud` for pilot options.
+
+Generate a pilot-ready production/security report from local run artifacts:
+
+```bash
+npx @kryptosai/mcp-observatory enterprise-report \
+  --account "Your Company" \
+  --format html \
+  --output observatory-enterprise-report.html
+```
+
+For clearer internal account attribution in CI, set:
+
+```bash
+MCP_OBSERVATORY_ORG=your-company.com
+MCP_OBSERVATORY_CONTACT=mcp-owner@your-company.com
+```
+
+Testing Feishu/Lark integrations? See the [Feishu/Lark MCP guide](./docs/feishu-lark-mcp.md).
 
 ### Lock Files
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please do not open public issues for suspected vulnerabilities.
+
+Use GitHub private vulnerability reporting from this repository's Security tab. If that is unavailable, email the maintainer listed on the repository profile with a short description and a way to contact you privately.
+
+Include:
+
+- affected version or commit
+- steps to reproduce
+- impact and any known exploit constraints
+- whether the report can be shared publicly after a fix is available
+
+We aim to acknowledge valid reports within 72 hours.

--- a/TERMS.md
+++ b/TERMS.md
@@ -1,0 +1,30 @@
+# Terms For Production Use
+
+MCP Observatory is distributed under the MIT license for the open source CLI and MCP server code.
+
+These commercial terms describe optional paid pilots for hosted reporting, private-repo CI, security reports, production monitoring, certification, support, and fleet visibility.
+
+## No Retroactive Billing
+
+Using the open source package locally does not create a paid subscription by itself. Paid services require a separate written agreement, invoice, purchase order, or accepted pilot arrangement.
+
+## Production And Private Use
+
+Teams using MCP Observatory for private repositories, production MCP monitoring, compliance/security reporting, certification, or fleet-level visibility should contact us for a pilot.
+
+Starting pilot pricing:
+
+- Team Pilot: starts at $299/month
+- Business Pilot: starts at $999/month
+- Enterprise Pilot: starts at $3k/month
+- Strategic Accounts: custom, $250k+/year
+
+## Hosted Upload Tokens
+
+`MCP_OBSERVATORY_CLOUD_TOKEN` is reserved for hosted reporting and pilot workflows. Receiving or setting a token does not transfer ownership of local artifacts or private source code.
+
+## Contact
+
+For production MCP usage, private repo CI, enterprise support, or strategic partnerships:
+
+william@banksey.com

--- a/action/README.md
+++ b/action/README.md
@@ -28,6 +28,7 @@ jobs:
 | `deep` | Also invoke safe tools | `false` |
 | `security` | Run security analysis | `false` |
 | `fail-on-regression` | Fail the action on issues | `true` |
+| `fail-on-baseline-drift` | Fail the action when baseline verification detects drift | `true` |
 | `comment-on-pr` | Post report as PR comment | `true` |
 | `set-status` | Set a commit status check (green/red) on the HEAD SHA | `true` |
 | `targets` | Path to MCP config file for multi-server matrix scan | |
@@ -68,6 +69,7 @@ jobs:
   with:
     command: npx -y my-mcp-server
     baseline: .mcp-observatory/cassettes/baseline.cassette.json
+    fail-on-baseline-drift: true
 ```
 
 ### Using target config

--- a/action/action.yml
+++ b/action/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: "Fail the action if the server has issues"
     required: false
     default: "true"
+  fail-on-baseline-drift:
+    description: "Fail the action if baseline verification detects drift"
+    required: false
+    default: "true"
   comment-on-pr:
     description: "Post a report as a PR comment"
     required: false
@@ -81,7 +85,11 @@ runs:
 
         # Multi-server matrix scan
         if [ -n "$INPUT_TARGETS" ]; then
-          SCAN_ARRAY=(mcp-observatory scan --config "$INPUT_TARGETS")
+          if [ "$INPUT_DEEP" = "true" ]; then
+            SCAN_ARRAY=(mcp-observatory scan deep --config "$INPUT_TARGETS")
+          else
+            SCAN_ARRAY=(mcp-observatory scan --config "$INPUT_TARGETS")
+          fi
           if [ "$INPUT_SECURITY" = "true" ]; then
             SCAN_ARRAY+=(--security)
           fi
@@ -110,10 +118,7 @@ runs:
         else
           CMD_ARRAY=()
           if [ -n "$INPUT_TARGET" ]; then
-            CMD_ARRAY=(mcp-observatory run --target "$INPUT_TARGET")
-            if [ "$INPUT_DEEP" = "true" ]; then
-              CMD_ARRAY+=(--invoke)
-            fi
+            CMD_ARRAY=(mcp-observatory test --target "$INPUT_TARGET")
           elif [ -n "$INPUT_COMMAND" ]; then
             read -r -a COMMAND_PARTS <<< "$INPUT_COMMAND"
             CMD_ARRAY=(mcp-observatory test "${COMMAND_PARTS[@]}")
@@ -122,6 +127,9 @@ runs:
             exit 1
           fi
 
+          if [ "$INPUT_DEEP" = "true" ]; then
+            CMD_ARRAY+=(--deep)
+          fi
           if [ "$INPUT_SECURITY" = "true" ]; then
             CMD_ARRAY+=(--security)
           fi
@@ -155,6 +163,7 @@ runs:
         INPUT_BASELINE: ${{ inputs.baseline }}
         INPUT_COMMAND: ${{ inputs.command }}
         INPUT_TARGET: ${{ inputs.target }}
+        INPUT_FAIL_ON_BASELINE_DRIFT: ${{ inputs.fail-on-baseline-drift }}
       run: |
         VERIFY_ARRAY=(mcp-observatory verify "$INPUT_BASELINE")
         if [ -n "$INPUT_TARGET" ]; then
@@ -172,6 +181,10 @@ runs:
 
         if [ $VERIFY_EXIT -ne 0 ]; then
           echo "::warning::Baseline verification detected changes"
+          if [ "$INPUT_FAIL_ON_BASELINE_DRIFT" = "true" ]; then
+            echo "::error::Baseline verification failed"
+            exit $VERIFY_EXIT
+          fi
         fi
 
     - name: Set commit status

--- a/action/action.yml
+++ b/action/action.yml
@@ -115,7 +115,8 @@ runs:
               CMD_ARRAY+=(--invoke)
             fi
           elif [ -n "$INPUT_COMMAND" ]; then
-            CMD_ARRAY=(mcp-observatory test "$INPUT_COMMAND")
+            read -r -a COMMAND_PARTS <<< "$INPUT_COMMAND"
+            CMD_ARRAY=(mcp-observatory test "${COMMAND_PARTS[@]}")
           else
             echo "::error::Either 'command', 'target', or 'targets' input is required"
             exit 1
@@ -143,7 +144,7 @@ runs:
 
           # Generate PR comment report
           if [ -n "$ARTIFACT_PATH" ]; then
-            mcp-observatory report "$ARTIFACT_PATH" --format pr-comment --no-color > "${ARTIFACT_DIR}/report.md" 2>/dev/null || true
+            mcp-observatory report --run "$ARTIFACT_PATH" --format pr-comment --no-color > "${ARTIFACT_DIR}/report.md" 2>/dev/null || true
           fi
         fi
 
@@ -159,7 +160,8 @@ runs:
         if [ -n "$INPUT_TARGET" ]; then
           VERIFY_ARRAY+=(--target "$INPUT_TARGET")
         elif [ -n "$INPUT_COMMAND" ]; then
-          VERIFY_ARRAY+=("$INPUT_COMMAND")
+          read -r -a COMMAND_PARTS <<< "$INPUT_COMMAND"
+          VERIFY_ARRAY+=("${COMMAND_PARTS[@]}")
         fi
         VERIFY_ARRAY+=(--no-color)
 
@@ -204,6 +206,10 @@ runs:
 
         if [ ! -f "$REPORT_FILE" ]; then
           echo "No report file found, skipping PR comment"
+          exit 0
+        fi
+        if [ ! -s "$REPORT_FILE" ]; then
+          echo "Report file is empty, skipping PR comment"
           exit 0
         fi
 

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,0 +1,1528 @@
+{
+  "name": "@kryptosai/mcp-observatory-api",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@kryptosai/mcp-observatory-api",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@cloudflare/workers-types": "^4.20250310.0",
+        "typescript": "^5.7.0",
+        "wrangler": "^4.0.0"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260616.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260616.1.tgz",
+      "integrity": "sha512-8QaDRQABkwkwoeviNiyScol7EQgXfGsPNSyUn52GiXObthY4XPiokoJsgDSDNcAelHjEvDLmdvQBHPK8YvGn4A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260616.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260616.1.tgz",
+      "integrity": "sha512-xEhiZQ62CBJ+vyKSmM13rkK/wB1kLP5sKFkF3+P+3R/c2bmnSG3Vcd5FfXUu9V0PdC+KlR02nByvZjqEw2N6Ag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260616.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260616.1.tgz",
+      "integrity": "sha512-p5laSYPiRUMHaLkneaZ9ZfIkNpmEnGFwgYmXtfcHJutTfEd8o3IBnsUVRSbPL+phcshKqmapLsQSxDEX6WSFfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260616.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260616.1.tgz",
+      "integrity": "sha512-XQ7GonEl8ORvbz5fhe8Eyw2t/j09Li0KbXJxaldA318E+syF+PPTc4IRQudgqPWzzdzkH5nF7PuMOGySLSjFFw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260616.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260616.1.tgz",
+      "integrity": "sha512-RaDVF9bSbPiPTq6vHYrgnv1TcQEcYnOr0WB3hWJ4yg2fBfpi2ygU6cYPuFeDwyFE9aPW5S6FBAkNmpKYueK4DQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260616.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260616.1.tgz",
+      "integrity": "sha512-AHyA0NC2/gNOHiMN6vzS25xenMaQ0XTzfw+MUQSQHXQDjLldxCBwjjtbNfKhBg540qGXIEx31kM1+L84GyECJw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.17",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.17.tgz",
+      "integrity": "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "4.20260616.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260616.0.tgz",
+      "integrity": "sha512-cEpzoNgSWjedzYmhJvttUPmL4Jk6nSzzeNNi118T5zwnmYP9fnM8UXwFU/Qa/1qoQ4SzGqtM1Q7tinHvHvIGtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.34.5",
+        "undici": "7.24.8",
+        "workerd": "1.20260616.1",
+        "ws": "8.20.1",
+        "youch": "4.1.0-beta.10"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
+      "integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260616.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260616.1.tgz",
+      "integrity": "sha512-aRGWYxviSjYZwyu97pCr5GyJ9ObpgmNcfZZs3/o+kG7Wz3SBTqA8d8uhNueY5u7ADeUp2ibJvK6mXkFLrUmPgg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260616.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260616.1",
+        "@cloudflare/workerd-linux-64": "1.20260616.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260616.1",
+        "@cloudflare/workerd-windows-64": "1.20260616.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.101.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.101.0.tgz",
+      "integrity": "sha512-dZDDiRcT7MiA09lBDxWKmiL/iybEZ+SZe3IZmnVx1m1n1DOo730vOY5SeO7z9xFK8a/+vhGKDYB8mDXrvzEr5g==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.27.3",
+        "miniflare": "4.20260616.0",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260616.1"
+      },
+      "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20260616.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    }
+  }
+}

--- a/api/package.json
+++ b/api/package.json
@@ -13,5 +13,9 @@
     "@cloudflare/workers-types": "^4.20250310.0",
     "typescript": "^5.7.0",
     "wrangler": "^4.0.0"
+  },
+  "overrides": {
+    "esbuild": "^0.28.1",
+    "ws": "^8.21.0"
   }
 }

--- a/api/src/worker.ts
+++ b/api/src/worker.ts
@@ -7,26 +7,12 @@
  */
 
 // ---------------------------------------------------------------------------
-// Cloudflare Worker type stubs (provided by @cloudflare/workers-types at build)
-// ---------------------------------------------------------------------------
-
-/* eslint-disable @typescript-eslint/no-empty-interface */
-declare global {
-  interface KVNamespace {
-    get(key: string): Promise<string | null>;
-    put(key: string, value: string, options?: { expirationTtl?: number }): Promise<void>;
-  }
-  interface ExportedHandler<E = unknown> {
-    fetch(request: Request, env: E, ctx?: unknown): Promise<Response>;
-  }
-}
-
-// ---------------------------------------------------------------------------
 // Environment bindings
 // ---------------------------------------------------------------------------
 
 export interface Env {
   SCAN_CACHE: KVNamespace;
+  CLOUD_UPLOAD_TOKEN?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -334,7 +320,7 @@ function corsHeaders(): Record<string, string> {
   return {
     "Access-Control-Allow-Origin": "*",
     "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-    "Access-Control-Allow-Headers": "Content-Type",
+    "Access-Control-Allow-Headers": "Authorization, Content-Type, X-MCP-Observatory-Org",
     "Access-Control-Max-Age": "86400",
   };
 }
@@ -351,6 +337,51 @@ function jsonResponse(body: unknown, status = 200): Response {
 
 function errorResponse(message: string, status: number): Response {
   return jsonResponse({ error: message }, status);
+}
+
+function isBlockedHostedHostname(hostname: string): boolean {
+  const host = hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  if (
+    host === "localhost" ||
+    host === "0.0.0.0" ||
+    host === "::1" ||
+    host.endsWith(".localhost") ||
+    host.endsWith(".local")
+  ) {
+    return true;
+  }
+  const parts = host.split(".").map((part) => Number(part));
+  if (parts.length === 4 && parts.every((part) => Number.isInteger(part) && part >= 0 && part <= 255)) {
+    const [a, b] = parts as [number, number, number, number];
+    return (
+      a === 10 ||
+      a === 127 ||
+      (a === 169 && b === 254) ||
+      (a === 172 && b >= 16 && b <= 31) ||
+      (a === 192 && b === 168)
+    );
+  }
+  return false;
+}
+
+function requireUploadAuth(request: Request, env: Env): Response | null {
+  if (!env.CLOUD_UPLOAD_TOKEN) {
+    return errorResponse("Cloud artifact upload is not configured.", 501);
+  }
+  const expected = `Bearer ${env.CLOUD_UPLOAD_TOKEN}`;
+  if (request.headers.get("Authorization") !== expected) {
+    return errorResponse("Unauthorized", 401);
+  }
+  return null;
+}
+
+function slugifyOrg(raw: string | null | undefined): string {
+  const slug = (raw ?? "unknown")
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
+  return slug || "unknown";
 }
 
 // ---------------------------------------------------------------------------
@@ -739,6 +770,12 @@ async function handlePostScan(
   if (!["http:", "https:"].includes(parsedUrl.protocol)) {
     return errorResponse("Only http:// and https:// URLs are supported", 400);
   }
+  if (isBlockedHostedHostname(parsedUrl.hostname)) {
+    return errorResponse(
+      "Hosted scans cannot target localhost or private network addresses. Run the CLI locally for internal MCP servers.",
+      400,
+    );
+  }
 
   const artifact = await scanHttpTarget(body.url);
 
@@ -750,6 +787,86 @@ async function handlePostScan(
   );
 
   return jsonResponse(artifact);
+}
+
+interface ArtifactUploadRecord {
+  org: string;
+  runId: string;
+  uploadedAt: string;
+  targetId?: string;
+  gate?: Gate;
+  healthScore?: number;
+}
+
+async function handlePostArtifact(
+  request: Request,
+  env: Env,
+): Promise<Response> {
+  const authError = requireUploadAuth(request, env);
+  if (authError) return authError;
+
+  let artifact: RunArtifact & { org?: string };
+  try {
+    artifact = (await request.json()) as RunArtifact & { org?: string };
+  } catch {
+    return errorResponse("Invalid JSON body", 400);
+  }
+
+  if (artifact.artifactType !== "run" || typeof artifact.runId !== "string" || !artifact.target) {
+    return errorResponse("Expected a MCP Observatory run artifact.", 400);
+  }
+
+  const org = slugifyOrg(
+    request.headers.get("X-MCP-Observatory-Org") ??
+    artifact.org ??
+    artifact.target.metadata?.["org"] ??
+    artifact.target.metadata?.["company"],
+  );
+  const uploadedAt = new Date().toISOString();
+  const key = `artifact:${org}:${artifact.runId}`;
+  const record: ArtifactUploadRecord = {
+    org,
+    runId: artifact.runId,
+    uploadedAt,
+    targetId: artifact.target.targetId,
+    gate: artifact.gate,
+    healthScore: artifact.healthScore?.overall,
+  };
+
+  await env.SCAN_CACHE.put(
+    key,
+    JSON.stringify({ ...record, artifact }),
+    { expirationTtl: KV_TTL_SECONDS * 30 },
+  );
+
+  const indexKey = `artifact-index:${org}`;
+  const existing = await env.SCAN_CACHE.get(indexKey);
+  const index = existing ? JSON.parse(existing) as ArtifactUploadRecord[] : [];
+  const nextIndex = [record, ...index.filter((entry) => entry.runId !== artifact.runId)].slice(0, 200);
+  await env.SCAN_CACHE.put(indexKey, JSON.stringify(nextIndex), { expirationTtl: KV_TTL_SECONDS * 30 });
+
+  return jsonResponse({
+    ok: true,
+    org,
+    runId: artifact.runId,
+    key,
+    uploadedAt,
+  });
+}
+
+async function handleGetArtifacts(
+  request: Request,
+  env: Env,
+  orgParam: string,
+): Promise<Response> {
+  const authError = requireUploadAuth(request, env);
+  if (authError) return authError;
+  const org = slugifyOrg(orgParam);
+  const raw = await env.SCAN_CACHE.get(`artifact-index:${org}`);
+  return jsonResponse({
+    org,
+    artifacts: raw ? JSON.parse(raw) : [],
+  });
 }
 
 async function handleGetScan(
@@ -817,6 +934,15 @@ function matchRoute(
   if (method === "POST" && pathname === "/api/v1/scan") {
     return { handler: "postScan", params: {} };
   }
+  if (method === "POST" && pathname === "/api/v1/artifacts") {
+    return { handler: "postArtifact", params: {} };
+  }
+
+  // GET /api/v1/artifacts/:org
+  const artifactMatch = pathname.match(/^\/api\/v1\/artifacts\/([a-zA-Z0-9._-]+)$/);
+  if (method === "GET" && artifactMatch?.[1]) {
+    return { handler: "getArtifacts", params: { org: artifactMatch[1] } };
+  }
 
   // GET /api/v1/scan/:runId
   const scanMatch = pathname.match(/^\/api\/v1\/scan\/([a-z0-9_]+)$/);
@@ -857,6 +983,10 @@ export default {
           return handleHealth();
         case "postScan":
           return await handlePostScan(request, env);
+        case "postArtifact":
+          return await handlePostArtifact(request, env);
+        case "getArtifacts":
+          return await handleGetArtifacts(request, env, route.params.org!);
         case "getScan":
           return await handleGetScan(route.params.runId!, env);
         case "getBadge":

--- a/api/wrangler.toml
+++ b/api/wrangler.toml
@@ -14,3 +14,6 @@ id = "REPLACE_WITH_KV_NAMESPACE_ID"
 # To create the production namespace:
 #   wrangler kv namespace create SCAN_CACHE
 # Then paste the returned id above.
+#
+# Hosted artifact uploads require a pilot token:
+#   wrangler secret put CLOUD_UPLOAD_TOKEN

--- a/docs/distribution-launch.md
+++ b/docs/distribution-launch.md
@@ -2,6 +2,8 @@
 
 Use this as the reversible launch motion for MCP Observatory commercialization.
 
+For the release gate and publication checklist, see [Publish And Distribution Readiness](./publish-readiness.md).
+
 ## Positioning
 
 MCP Observatory helps teams test, secure, and monitor MCP servers before agents depend on them.

--- a/docs/distribution-launch.md
+++ b/docs/distribution-launch.md
@@ -1,0 +1,55 @@
+# Distribution And Pilot Launch
+
+Use this as the reversible launch motion for MCP Observatory commercialization.
+
+## Positioning
+
+MCP Observatory helps teams test, secure, and monitor MCP servers before agents depend on them.
+
+## Public Surface Checklist
+
+- README pricing and enterprise CTA
+- npm description and keywords
+- GitHub repository homepage pointing to the README or commercial page
+- MCP directory listings updated with production/security language
+- Launch post published
+- Badge or certification language available for passing servers
+
+## Launch Post Draft
+
+MCP servers are becoming production dependencies. If an agent depends on a server, that server needs regression tests, security checks, and monitoring before it breaks workflows.
+
+MCP Observatory scans MCP servers, verifies capabilities, detects schema drift, records/replays sessions, and can run in CI or as an MCP server itself.
+
+Free for local OSS use. Paid pilots are available for hosted reporting, private repo CI, security reports, production monitoring, certification, support, and fleet visibility.
+
+Production MCP usage? Contact william@banksey.com.
+
+## Outreach Template
+
+Subject: MCP production testing and security checks
+
+Hi,
+
+I noticed signals that your team may be evaluating or using MCP servers. MCP Observatory helps teams test, secure, and monitor MCP servers before agents depend on them.
+
+We are running a small number of production pilots for hosted reports, private repo CI, security monitoring, certification, support, and fleet visibility.
+
+Would it be useful to compare what your MCP servers look like today and where regressions or production risk could show up?
+
+William
+
+## Account Ranking Inputs
+
+Rank prospects with:
+
+- Company domain or GitHub organization
+- Evidence source: git email domain, git remote URL, hostname domain, CI provider
+- Event count and unique sessions
+- Commands used
+- Targets or servers seen
+- Production signals: CI, private repo naming, repeated scans, security checks, matrix scans
+- Confidence: high, medium, low
+- Tier recommendation: Team, Business, Enterprise, Strategic
+
+Do not publish raw emails. Keep account evidence internal.

--- a/docs/enterprise-outreach-playbook.md
+++ b/docs/enterprise-outreach-playbook.md
@@ -1,0 +1,79 @@
+# Enterprise Outreach Playbook
+
+Use this playbook after running:
+
+```bash
+npm run telemetry:intelligence -- --input telemetry-exports/events-flat-full.json --out-dir reports
+```
+
+Do not include raw personal emails in public issues, posts, or docs. Use account domains, GitHub orgs, and aggregate telemetry evidence.
+
+## Priority Accounts
+
+| Priority | Account | Evidence | Motion |
+| ---: | --- | --- | --- |
+| 1 | `thinkingdata.cn` | High-confidence external usage, repeated sessions, private-network target signal, Feishu/Lark MCP targets | Enterprise pilot |
+| 2 | `kimquy.capital` | Recent light usage across multiple sessions | Business pilot / design partner |
+| 3 | `paperstreetdata.com` | Small usage cluster | Business pilot / testimonial ask |
+| 4 | `cyberneticsplus.com` | Single company signal | Team pilot / feedback ask |
+| 5 | GitHub org/user signals | CI or repo-based usage | Team pilot unless company identity is confirmed |
+
+## ThinkingData First Email
+
+Subject: MCP security reporting for Feishu/Lark production workflows
+
+Hi,
+
+I build MCP Observatory, an open source tool for testing, securing, and monitoring MCP servers before agents depend on them.
+
+We are seeing serious production-style usage patterns around Feishu/Lark MCP workflows and internal HTTP MCP targets. I am opening a small number of enterprise pilots for teams that want hosted MCP security reports, private-repo CI history, and fleet visibility across agent environments.
+
+If your team is running MCP servers in production, I can prepare a short evidence-based report and a pilot proposal focused on:
+
+- Feishu/Lark MCP compatibility
+- private HTTP MCP health checks
+- security findings and schema drift
+- CI history and production monitoring
+- MCP fleet visibility across teams
+
+Would it be useful to compare notes this week?
+
+William
+
+## Pilot Routing
+
+- Repeated sessions + internal/private target: Enterprise Pilot, starts at `$3k/month`.
+- Major platform, AI lab, or very large company: Strategic only, `$250k+/year` anchor.
+- Light but recent company usage: Business Pilot, starts at `$999/month`.
+- GitHub-user-only or hobby-looking usage: Team Pilot, starts at `$299/month`.
+
+## Call Agenda
+
+1. Confirm whether MCP is already in production or only evaluation.
+2. Identify the owner: platform, security, AI infra, developer productivity, or app team.
+3. Ask which value matters most: CI, security report, dashboard, certification, fleet inventory, or private deployment.
+4. Offer to generate a static enterprise report from their first pilot run.
+5. Quote manually. Do not route large companies to self-serve Team/Business pricing.
+
+## Evidence Packet
+
+Prepare this before outreach:
+
+```bash
+npx @kryptosai/mcp-observatory enterprise-report \
+  --account "Account Name" \
+  --format html \
+  --output reports/account-enterprise-report.html
+```
+
+Include only aggregate facts:
+
+- event count
+- unique sessions
+- first seen / last seen
+- commands used
+- targets seen
+- CI/private-network/security signals
+- recommended pilot tier
+
+Do not include raw hostnames, personal emails, tokens, or private URLs in external outreach.

--- a/docs/feishu-lark-mcp.md
+++ b/docs/feishu-lark-mcp.md
@@ -19,7 +19,7 @@ For an internal HTTP MCP endpoint, create a target file:
   "targetId": "feishu-doc-mcp",
   "adapter": "http",
   "url": "https://internal.example.com/mcp",
-  "authToken": "redacted-bearer-token",
+  "authToken": "${FEISHU_MCP_TOKEN}",
   "timeoutMs": 30000
 }
 ```
@@ -27,6 +27,7 @@ For an internal HTTP MCP endpoint, create a target file:
 Then run:
 
 ```bash
+export FEISHU_MCP_TOKEN="..."
 npx @kryptosai/mcp-observatory test --target feishu-target.json --security
 ```
 

--- a/docs/feishu-lark-mcp.md
+++ b/docs/feishu-lark-mcp.md
@@ -1,0 +1,64 @@
+# Testing Feishu/Lark MCP Servers
+
+Feishu and Lark workflows often put documents, approvals, project data, and internal knowledge behind MCP servers. MCP Observatory helps teams test those servers before agents depend on them.
+
+## Local Server Check
+
+```bash
+npx @kryptosai/mcp-observatory test --security npx -y feishu-doc-mcp
+```
+
+Use `--security` when the server exposes document search, write actions, internal URLs, or credential-backed tools.
+
+## Internal HTTP MCP Check
+
+For an internal HTTP MCP endpoint, create a target file:
+
+```json
+{
+  "targetId": "feishu-doc-mcp",
+  "adapter": "http",
+  "url": "https://internal.example.com/mcp",
+  "authToken": "redacted-bearer-token",
+  "timeoutMs": 30000
+}
+```
+
+Then run:
+
+```bash
+npx @kryptosai/mcp-observatory test --target feishu-target.json --security
+```
+
+## CI Report
+
+```yaml
+name: Feishu MCP Check
+on: [pull_request]
+
+jobs:
+  observatory:
+    runs-on: ubuntu-latest
+    env:
+      MCP_OBSERVATORY_ORG: your-company.com
+      MCP_OBSERVATORY_CONTACT: mcp-owner@your-company.com
+    steps:
+      - uses: actions/checkout@v4
+      - uses: KryptosAI/mcp-observatory/action@main
+        with:
+          target: feishu-target.json
+          security: true
+```
+
+## Enterprise Report
+
+```bash
+npx @kryptosai/mcp-observatory enterprise-report \
+  --account "Feishu MCP production fleet" \
+  --format html \
+  --output feishu-mcp-report.html
+```
+
+Production teams can use the report for MCP owner reviews, private-repo CI history, security review, and certification conversations.
+
+Contact `william@banksey.com` for production Feishu/Lark MCP usage, hosted reporting, private deployment, or fleet visibility.

--- a/docs/publish-readiness.md
+++ b/docs/publish-readiness.md
@@ -1,0 +1,70 @@
+# Publish And Distribution Readiness
+
+Use this checklist before a commercialization push. The goal is to increase distribution and start paid conversations without locking the project into a permanent licensing or product shape.
+
+## Release Gate
+
+Run:
+
+```bash
+npm run lint
+npm run typecheck
+npm run build
+npm test
+npm run validate:artifacts
+npm audit --json
+```
+
+Confirm:
+
+- GitHub Action target scans support `deep`, `security`, and baseline drift failure.
+- `schemas/run-artifact.schema.json` and `schemas/diff-artifact.schema.json` validate current artifacts.
+- HTTP target examples use env references instead of inline tokens.
+- Security findings appear in artifact evidence as structured `findings`.
+- Hosted upload is available through `mcp-observatory cloud upload <artifact>` when `MCP_OBSERVATORY_CLOUD_TOKEN` is set.
+
+## Public Distribution
+
+- Merge the health/commercialization PR.
+- Update the GitHub repo homepage to the README or commercial page.
+- Publish npm only after the release gate is green.
+- Refresh MCP directory listings with: “MCP Observatory helps teams test, secure, and monitor MCP servers before agents depend on them.”
+- Include “free for local OSS use; paid for hosted reporting, private repo CI, security reports, production monitoring, certification, support, and fleet visibility.”
+- Link production users to `COMMERCIAL.md` and `william@banksey.com`.
+
+## Sales Operating Loop
+
+1. Export telemetry rows privately.
+2. Run:
+
+```bash
+npx tsx scripts/telemetry-company-intelligence.ts --input telemetry-events.jsonl --out-dir reports
+```
+
+3. Review `reports/telemetry-company-intelligence.html`.
+4. Contact the top 25 high-confidence company/org candidates.
+5. For large or strategic domains, quote Strategic only and ask for a security/procurement path.
+6. Use hosted artifact upload or static enterprise reports before building a full SaaS dashboard.
+
+## Hosted Upload
+
+CLI:
+
+```bash
+export MCP_OBSERVATORY_CLOUD_TOKEN="pilot-token"
+export MCP_OBSERVATORY_ORG="customer.com"
+npx @kryptosai/mcp-observatory cloud upload .mcp-observatory/runs/<run>.json
+```
+
+Worker:
+
+- `POST /api/v1/artifacts` stores a run artifact behind bearer-token auth.
+- `GET /api/v1/artifacts/:org` returns the org artifact index behind the same auth.
+- Hosted scans reject localhost/private-network targets; use local CLI for internal MCP servers.
+
+## What Not To Do Yet
+
+- Do not change the MIT license until paid signal demands it.
+- Do not hard-paywall existing local OSS checks.
+- Do not build a full dashboard before a buyer asks for dashboard workflows.
+- Do not publish raw telemetry emails or individual PII in public materials.

--- a/github-app/README.md
+++ b/github-app/README.md
@@ -1,8 +1,8 @@
 # MCP Observatory GitHub App
 
-> **Status**: Planned feature — not yet deployed. This is the future hosted Observatory GitHub App.
+> **Status**: Config-lint prototype. It is not the production monitoring surface yet.
 
-A GitHub App that automatically analyzes MCP server configurations in pull requests and posts health score reports as PR comments.
+This app detects MCP configuration changes in pull requests and posts lightweight config review comments. For production MCP testing today, use the GitHub Action, CLI artifacts, enterprise reports, or hosted artifact upload.
 
 ## Setup
 
@@ -47,7 +47,7 @@ Use a tunnel (e.g. ngrok, cloudflared) to expose your local server for webhook d
 ngrok http 3000
 ```
 
-## What It Checks
+## What It Checks Today
 
 The app detects MCP config files (`.mcp.json`, `mcp-config.json`, etc.) in PR diffs and runs:
 
@@ -55,6 +55,15 @@ The app detects MCP config files (`.mcp.json`, `mcp-config.json`, etc.) in PR di
 - **Schema**: Presence of `mcpServers` key, valid server entries
 - **Transport**: Each server has a `command` (stdio) or `url` (http)
 - **Security**: Detects potential hardcoded secrets in environment variables
+
+It does not currently execute MCP servers, invoke tools, generate Observatory run artifacts, or perform hosted fleet monitoring.
+
+## Production Path
+
+- Use `KryptosAI/mcp-observatory/action` for CI enforcement.
+- Use `mcp-observatory enterprise-report` for pilot-ready reports.
+- Use `mcp-observatory cloud upload <artifact>` after a pilot token is issued.
+- Treat this GitHub App as a future distribution channel once it can run or ingest real Observatory artifacts.
 
 ## Comment Behavior
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kryptosai/mcp-observatory",
-  "version": "0.13.0",
+  "version": "0.20.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kryptosai/mcp-observatory",
-      "version": "0.13.0",
+      "version": "0.20.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
@@ -25,14 +25,14 @@
         "@types/node": "24.10.1",
         "@typescript-eslint/eslint-plugin": "8.46.3",
         "@typescript-eslint/parser": "8.46.3",
-        "ajv": "8.17.1",
+        "ajv": "8.20.0",
         "eslint": "9.39.1",
         "globals": "16.5.0",
         "semantic-release": "^25.0.3",
-        "tsx": "4.20.6",
+        "tsx": "4.22.4",
         "typescript": "5.9.3",
         "typescript-eslint": "8.46.3",
-        "vitest": "4.0.8"
+        "vitest": "4.1.9"
       },
       "engines": {
         "node": ">=20"
@@ -123,10 +123,44 @@
         "node": ">=0.1.90"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
-      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -141,9 +175,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
-      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -158,9 +192,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
-      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -175,9 +209,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
-      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -192,9 +226,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
-      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -209,9 +243,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
-      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -226,9 +260,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -243,9 +277,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
-      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -260,9 +294,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
-      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -277,9 +311,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
-      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -294,9 +328,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
-      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -311,9 +345,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
-      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -328,9 +362,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
-      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -345,9 +379,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
-      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -362,9 +396,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
-      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -379,9 +413,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
-      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -396,9 +430,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
-      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -413,9 +447,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -430,9 +464,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -447,9 +481,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -464,9 +498,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -481,9 +515,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
-      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -498,9 +532,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
-      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -515,9 +549,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
-      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -532,9 +566,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
-      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -549,9 +583,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
-      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -610,9 +644,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -701,9 +735,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -792,9 +826,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -900,6 +934,25 @@
         "zod": {
           "optional": false
         }
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1097,6 +1150,16 @@
         "@octokit/openapi-types": "^27.0.0"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@pnpm/config.env-replace": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz",
@@ -1138,24 +1201,10 @@
         "node": ">=12"
       }
     },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
-      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
-      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
       "cpu": [
         "arm64"
       ],
@@ -1164,12 +1213,15 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
-      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
       "cpu": [
         "arm64"
       ],
@@ -1178,12 +1230,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
-      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
       "cpu": [
         "x64"
       ],
@@ -1192,26 +1247,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
-      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
-      "cpu": [
-        "arm64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
-      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
       "cpu": [
         "x64"
       ],
@@ -1220,12 +1264,15 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
-      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
       "cpu": [
         "arm"
       ],
@@ -1234,26 +1281,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
-      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
-      "cpu": [
-        "arm"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
-      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
       "cpu": [
         "arm64"
       ],
@@ -1262,12 +1298,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
-      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
       "cpu": [
         "arm64"
       ],
@@ -1276,40 +1315,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
-      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
-      "cpu": [
-        "loong64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
-      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
-      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
       "cpu": [
         "ppc64"
       ],
@@ -1318,54 +1332,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
-      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
-      "cpu": [
-        "ppc64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
-      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
-      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
-      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
       "cpu": [
         "s390x"
       ],
@@ -1374,12 +1349,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
-      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
       "cpu": [
         "x64"
       ],
@@ -1388,12 +1366,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
-      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
       "cpu": [
         "x64"
       ],
@@ -1402,26 +1383,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
-      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
-      "cpu": [
-        "x64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
-      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
       "cpu": [
         "arm64"
       ],
@@ -1430,12 +1400,34 @@
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
-      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
       "cpu": [
         "arm64"
       ],
@@ -1444,26 +1436,15 @@
       "optional": true,
       "os": [
         "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
-      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
-      "cpu": [
-        "ia32"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
-      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
       "cpu": [
         "x64"
       ],
@@ -1472,21 +1453,17 @@
       "optional": true,
       "os": [
         "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
-      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
-      "cpu": [
-        "x64"
       ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
+      "license": "MIT"
     },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
@@ -2094,6 +2071,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -2379,31 +2367,31 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.8.tgz",
-      "integrity": "sha512-Rv0eabdP/xjAHQGr8cjBm+NnLHNoL268lMDK85w2aAGLFoVKLd8QGnVon5lLtkXQCoYaNL0wg04EGnyKkkKhPA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.0.8",
-        "@vitest/utils": "4.0.8",
-        "chai": "^6.2.0",
-        "tinyrainbow": "^3.0.3"
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.8.tgz",
-      "integrity": "sha512-9FRM3MZCedXH3+pIh+ME5Up2NBBHDq0wqwhOKkN4VnvCiKbVxddqH9mSGPZeawjd12pCOGnl+lo/ZGHt0/dQSg==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.0.8",
+        "@vitest/spy": "4.1.9",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -2412,7 +2400,7 @@
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0-0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -2424,26 +2412,26 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.8.tgz",
-      "integrity": "sha512-qRrjdRkINi9DaZHAimV+8ia9Gq6LeGz2CgIEmMLz3sBDYV53EsnLZbJMR1q84z1HZCMsf7s0orDgZn7ScXsZKg==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^3.0.3"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.8.tgz",
-      "integrity": "sha512-mdY8Sf1gsM8hKJUQfiPT3pn1n8RF4QBcJYFslgWh41JTfrK1cbqY8whpGCFzBl45LN028g0njLCYm0d7XxSaQQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.0.8",
+        "@vitest/utils": "4.1.9",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -2451,13 +2439,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.8.tgz",
-      "integrity": "sha512-Nar9OTU03KGiubrIOFhcfHg8FYaRaNT+bh5VUlNz8stFhCZPNrJvmZkhsr1jtaYvuefYFwK2Hwrq026u4uPWCw==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.8",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -2466,9 +2455,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.8.tgz",
-      "integrity": "sha512-nvGVqUunyCgZH7kmo+Ord4WgZ7lN0sOULYXUOYuHr55dvg9YvMz3izfB189Pgp28w0vWFbEEfNc/c3VTrqrXeA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2476,14 +2465,15 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.8.tgz",
-      "integrity": "sha512-pdk2phO5NDvEFfUTxcTP8RFYjVj/kfLSPIN5ebP2Mu9kcIMeAQTbknqcFEyBcC4z2pJlJI9aS5UQjcYfhmKAow==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.8",
-        "tinyrainbow": "^3.0.3"
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -2550,9 +2540,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -2804,9 +2794,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3351,6 +3341,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cookie": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
@@ -3503,6 +3500,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dir-glob": {
@@ -3795,9 +3802,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -3814,9 +3821,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
-      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -3827,32 +3834,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.12",
-        "@esbuild/android-arm": "0.25.12",
-        "@esbuild/android-arm64": "0.25.12",
-        "@esbuild/android-x64": "0.25.12",
-        "@esbuild/darwin-arm64": "0.25.12",
-        "@esbuild/darwin-x64": "0.25.12",
-        "@esbuild/freebsd-arm64": "0.25.12",
-        "@esbuild/freebsd-x64": "0.25.12",
-        "@esbuild/linux-arm": "0.25.12",
-        "@esbuild/linux-arm64": "0.25.12",
-        "@esbuild/linux-ia32": "0.25.12",
-        "@esbuild/linux-loong64": "0.25.12",
-        "@esbuild/linux-mips64el": "0.25.12",
-        "@esbuild/linux-ppc64": "0.25.12",
-        "@esbuild/linux-riscv64": "0.25.12",
-        "@esbuild/linux-s390x": "0.25.12",
-        "@esbuild/linux-x64": "0.25.12",
-        "@esbuild/netbsd-arm64": "0.25.12",
-        "@esbuild/netbsd-x64": "0.25.12",
-        "@esbuild/openbsd-arm64": "0.25.12",
-        "@esbuild/openbsd-x64": "0.25.12",
-        "@esbuild/openharmony-arm64": "0.25.12",
-        "@esbuild/sunos-x64": "0.25.12",
-        "@esbuild/win32-arm64": "0.25.12",
-        "@esbuild/win32-ia32": "0.25.12",
-        "@esbuild/win32-x64": "0.25.12"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escalade": {
@@ -4004,9 +4011,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4252,12 +4259,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
-      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -4337,9 +4344,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -4646,19 +4653,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/get-tsconfig": {
-      "version": "4.13.6",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
-      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "resolve-pkg-maps": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
-      }
-    },
     "node_modules/git-log-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/git-log-parser/-/git-log-parser-1.2.1.tgz",
@@ -4741,9 +4735,9 @@
       "license": "MIT"
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4807,9 +4801,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.8",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
-      "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -5033,9 +5027,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -5266,10 +5260,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -5389,6 +5393,267 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -5443,16 +5708,16 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "dev": true,
       "license": "MIT"
     },
@@ -5753,9 +6018,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -5846,9 +6111,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-11.12.0.tgz",
-      "integrity": "sha512-xPhOap4ZbJWyd7DAOukP564WFwNSGu/2FeTRFHhiiKthcauxhH/NpkJAQm24xD+cAn8av5tQ00phi98DqtfLsg==",
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-11.17.0.tgz",
+      "integrity": "sha512-PurxiZexEHDTE4SSaLI3ZrnbAGiZfeyUcQcxcP5D+hfytNAze/D1IzDuInTn9XVLIbAQUnQuSPXJx02LHjLvQw==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -5927,8 +6192,8 @@
       ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^9.4.2",
-        "@npmcli/config": "^10.8.0",
+        "@npmcli/arborist": "^9.8.0",
+        "@npmcli/config": "^10.11.0",
         "@npmcli/fs": "^5.0.0",
         "@npmcli/map-workspaces": "^5.0.3",
         "@npmcli/metavuln-calculator": "^9.0.3",
@@ -5946,27 +6211,27 @@
         "fs-minipass": "^3.0.3",
         "glob": "^13.0.6",
         "graceful-fs": "^4.2.11",
-        "hosted-git-info": "^9.0.2",
+        "hosted-git-info": "^9.0.3",
         "ini": "^6.0.0",
         "init-package-json": "^8.2.5",
-        "is-cidr": "^6.0.3",
+        "is-cidr": "^6.0.4",
         "json-parse-even-better-errors": "^5.0.0",
         "libnpmaccess": "^10.0.3",
-        "libnpmdiff": "^8.1.5",
-        "libnpmexec": "^10.2.5",
-        "libnpmfund": "^7.0.19",
+        "libnpmdiff": "^8.1.10",
+        "libnpmexec": "^10.3.0",
+        "libnpmfund": "^7.0.24",
         "libnpmorg": "^8.0.1",
-        "libnpmpack": "^9.1.5",
-        "libnpmpublish": "^11.1.3",
+        "libnpmpack": "^9.1.10",
+        "libnpmpublish": "^11.2.0",
         "libnpmsearch": "^9.0.1",
         "libnpmteam": "^8.0.2",
-        "libnpmversion": "^8.0.3",
-        "make-fetch-happen": "^15.0.5",
-        "minimatch": "^10.2.4",
+        "libnpmversion": "^8.0.4",
+        "make-fetch-happen": "^15.0.6",
+        "minimatch": "^10.2.5",
         "minipass": "^7.1.3",
         "minipass-pipeline": "^1.2.4",
         "ms": "^2.1.2",
-        "node-gyp": "^12.2.0",
+        "node-gyp": "^12.4.0",
         "nopt": "^9.0.0",
         "npm-audit-report": "^7.0.0",
         "npm-install-checks": "^8.0.0",
@@ -5976,16 +6241,16 @@
         "npm-registry-fetch": "^19.1.1",
         "npm-user-validate": "^4.0.0",
         "p-map": "^7.0.4",
-        "pacote": "^21.5.0",
+        "pacote": "^21.5.1",
         "parse-conflict-json": "^5.0.1",
         "proc-log": "^6.1.0",
         "qrcode-terminal": "^0.12.0",
         "read": "^5.0.1",
-        "semver": "^7.7.4",
+        "semver": "^7.8.4",
         "spdx-expression-parse": "^4.0.0",
         "ssri": "^13.0.1",
         "supports-color": "^10.2.2",
-        "tar": "^7.5.11",
+        "tar": "^7.5.16",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^2.0.2",
         "treeverse": "^3.0.0",
@@ -6041,7 +6306,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/agent": {
-      "version": "4.0.0",
+      "version": "4.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -6057,7 +6322,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "9.4.2",
+      "version": "9.8.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -6105,7 +6370,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "10.8.0",
+      "version": "10.11.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -6299,7 +6564,7 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/core": {
-      "version": "3.2.0",
+      "version": "3.2.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -6308,7 +6573,7 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -6347,13 +6612,13 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/verify": {
-      "version": "3.1.0",
+      "version": "3.1.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@sigstore/bundle": "^4.0.0",
-        "@sigstore/core": "^3.1.0",
+        "@sigstore/core": "^3.2.1",
         "@sigstore/protobuf-specs": "^0.5.0"
       },
       "engines": {
@@ -6422,7 +6687,7 @@
       }
     },
     "node_modules/npm/node_modules/bin-links": {
-      "version": "6.0.0",
+      "version": "6.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -6450,7 +6715,7 @@
       }
     },
     "node_modules/npm/node_modules/brace-expansion": {
-      "version": "5.0.4",
+      "version": "5.0.6",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6519,7 +6784,7 @@
       }
     },
     "node_modules/npm/node_modules/cidr-regex": {
-      "version": "5.0.3",
+      "version": "5.0.5",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -6575,7 +6840,7 @@
       }
     },
     "node_modules/npm/node_modules/diff": {
-      "version": "8.0.3",
+      "version": "8.0.4",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -6643,7 +6908,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/hosted-git-info": {
-      "version": "9.0.2",
+      "version": "9.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -6742,7 +7007,7 @@
       }
     },
     "node_modules/npm/node_modules/ip-address": {
-      "version": "10.1.0",
+      "version": "10.2.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6751,12 +7016,12 @@
       }
     },
     "node_modules/npm/node_modules/is-cidr": {
-      "version": "6.0.3",
+      "version": "6.0.4",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "cidr-regex": "^5.0.1"
+        "cidr-regex": "^5.0.4"
       },
       "engines": {
         "node": ">=20"
@@ -6824,12 +7089,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "8.1.5",
+      "version": "8.1.10",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.2",
+        "@npmcli/arborist": "^9.8.0",
         "@npmcli/installed-package-contents": "^4.0.0",
         "binary-extensions": "^3.0.0",
         "diff": "^8.0.2",
@@ -6843,13 +7108,13 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "10.2.5",
+      "version": "10.3.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@gar/promise-retry": "^1.0.0",
-        "@npmcli/arborist": "^9.4.2",
+        "@npmcli/arborist": "^9.8.0",
         "@npmcli/package-json": "^7.0.0",
         "@npmcli/run-script": "^10.0.0",
         "ci-info": "^4.0.0",
@@ -6866,12 +7131,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "7.0.19",
+      "version": "7.0.24",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.2"
+        "@npmcli/arborist": "^9.8.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -6891,12 +7156,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "9.1.5",
+      "version": "9.1.10",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.2",
+        "@npmcli/arborist": "^9.8.0",
         "@npmcli/run-script": "^10.0.0",
         "npm-package-arg": "^13.0.0",
         "pacote": "^21.0.2"
@@ -6906,7 +7171,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpublish": {
-      "version": "11.1.3",
+      "version": "11.2.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -6950,7 +7215,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmversion": {
-      "version": "8.0.3",
+      "version": "8.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -6966,7 +7231,7 @@
       }
     },
     "node_modules/npm/node_modules/lru-cache": {
-      "version": "11.2.7",
+      "version": "11.5.1",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -6975,7 +7240,7 @@
       }
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
-      "version": "15.0.5",
+      "version": "15.0.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -6998,12 +7263,12 @@
       }
     },
     "node_modules/npm/node_modules/minimatch": {
-      "version": "10.2.4",
+      "version": "10.2.5",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -7051,34 +7316,16 @@
       }
     },
     "node_modules/npm/node_modules/minipass-flush": {
-      "version": "1.0.5",
+      "version": "1.0.6",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "minipass": "^3.0.0"
+        "minipass": "^7.1.3"
       },
       "engines": {
-        "node": ">= 8"
+        "node": ">=16 || 14 >=14.17"
       }
-    },
-    "node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
-      "version": "3.3.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-flush/node_modules/yallist": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
     },
     "node_modules/npm/node_modules/minipass-pipeline": {
       "version": "1.2.4",
@@ -7159,7 +7406,7 @@
       }
     },
     "node_modules/npm/node_modules/node-gyp": {
-      "version": "12.2.0",
+      "version": "12.4.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7167,12 +7414,12 @@
         "env-paths": "^2.2.0",
         "exponential-backoff": "^3.1.1",
         "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^15.0.0",
         "nopt": "^9.0.0",
         "proc-log": "^6.0.0",
         "semver": "^7.3.5",
         "tar": "^7.5.4",
         "tinyglobby": "^0.2.12",
+        "undici": "^6.25.0",
         "which": "^6.0.0"
       },
       "bin": {
@@ -7336,7 +7583,7 @@
       }
     },
     "node_modules/npm/node_modules/pacote": {
-      "version": "21.5.0",
+      "version": "21.5.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -7397,7 +7644,7 @@
       }
     },
     "node_modules/npm/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
+      "version": "7.1.4",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7494,7 +7741,7 @@
       "optional": true
     },
     "node_modules/npm/node_modules/semver": {
-      "version": "7.7.4",
+      "version": "7.8.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -7518,17 +7765,17 @@
       }
     },
     "node_modules/npm/node_modules/sigstore": {
-      "version": "4.1.0",
+      "version": "4.1.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@sigstore/bundle": "^4.0.0",
-        "@sigstore/core": "^3.1.0",
+        "@sigstore/core": "^3.2.1",
         "@sigstore/protobuf-specs": "^0.5.0",
-        "@sigstore/sign": "^4.1.0",
-        "@sigstore/tuf": "^4.0.1",
-        "@sigstore/verify": "^3.1.0"
+        "@sigstore/sign": "^4.1.1",
+        "@sigstore/tuf": "^4.0.2",
+        "@sigstore/verify": "^3.1.1"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -7545,12 +7792,12 @@
       }
     },
     "node_modules/npm/node_modules/socks": {
-      "version": "2.8.7",
+      "version": "2.8.9",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ip-address": "^10.0.1",
+        "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -7619,7 +7866,7 @@
       }
     },
     "node_modules/npm/node_modules/tar": {
-      "version": "7.5.11",
+      "version": "7.5.16",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -7647,13 +7894,13 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/tinyglobby": {
-      "version": "0.2.15",
+      "version": "0.2.17",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -7680,7 +7927,7 @@
       }
     },
     "node_modules/npm/node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
+      "version": "4.0.4",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7712,6 +7959,15 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/undici": {
+      "version": "6.26.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/npm/node_modules/util-deprecate": {
@@ -7793,6 +8049,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/on-finished": {
@@ -8099,9 +8369,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -8133,9 +8403,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8242,9 +8512,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -8262,7 +8532,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -8348,9 +8618,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -8610,16 +8880,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/resolve-pkg-maps": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
-      }
-    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -8631,49 +8891,38 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/rollup": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
-      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+    "node_modules/rolldown": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.8"
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
-        "rollup": "dist/bin/rollup"
+        "rolldown": "bin/cli.mjs"
       },
       "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.59.0",
-        "@rollup/rollup-android-arm64": "4.59.0",
-        "@rollup/rollup-darwin-arm64": "4.59.0",
-        "@rollup/rollup-darwin-x64": "4.59.0",
-        "@rollup/rollup-freebsd-arm64": "4.59.0",
-        "@rollup/rollup-freebsd-x64": "4.59.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
-        "@rollup/rollup-linux-arm64-musl": "4.59.0",
-        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
-        "@rollup/rollup-linux-loong64-musl": "4.59.0",
-        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
-        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
-        "@rollup/rollup-linux-x64-gnu": "4.59.0",
-        "@rollup/rollup-linux-x64-musl": "4.59.0",
-        "@rollup/rollup-openbsd-x64": "4.59.0",
-        "@rollup/rollup-openharmony-arm64": "4.59.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
-        "@rollup/rollup-win32-x64-gnu": "4.59.0",
-        "@rollup/rollup-win32-x64-msvc": "4.59.0",
-        "fsevents": "~2.3.2"
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
     "node_modules/router": {
@@ -9392,9 +9641,9 @@
       }
     },
     "node_modules/std-env": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -9673,21 +9922,24 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
-      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -9715,9 +9967,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9785,15 +10037,22 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/tsx": {
-      "version": "4.20.6",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.6.tgz",
-      "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "~0.25.0",
-        "get-tsconfig": "^4.7.5"
+        "esbuild": "~0.28.0"
       },
       "bin": {
         "tsx": "dist/cli.mjs"
@@ -10072,18 +10331,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.27.0",
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.6",
-        "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.15"
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -10099,9 +10357,10 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
-        "lightningcss": "^1.21.0",
         "sass": "^1.70.0",
         "sass-embedded": "^1.70.0",
         "stylus": ">=0.54.8",
@@ -10114,13 +10373,16 @@
         "@types/node": {
           "optional": true
         },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
         "jiti": {
           "optional": true
         },
         "less": {
-          "optional": true
-        },
-        "lightningcss": {
           "optional": true
         },
         "sass": {
@@ -10146,512 +10408,10 @@
         }
       }
     },
-    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
-      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-arm": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
-      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
-      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
-      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
-      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
-      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
-      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-arm": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
-      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
-      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
-      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
-      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
-      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
-      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
-      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
-      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
-      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
-      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
-      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
-      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
-      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
-      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
-      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
-      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/esbuild": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
-      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.4",
-        "@esbuild/android-arm": "0.27.4",
-        "@esbuild/android-arm64": "0.27.4",
-        "@esbuild/android-x64": "0.27.4",
-        "@esbuild/darwin-arm64": "0.27.4",
-        "@esbuild/darwin-x64": "0.27.4",
-        "@esbuild/freebsd-arm64": "0.27.4",
-        "@esbuild/freebsd-x64": "0.27.4",
-        "@esbuild/linux-arm": "0.27.4",
-        "@esbuild/linux-arm64": "0.27.4",
-        "@esbuild/linux-ia32": "0.27.4",
-        "@esbuild/linux-loong64": "0.27.4",
-        "@esbuild/linux-mips64el": "0.27.4",
-        "@esbuild/linux-ppc64": "0.27.4",
-        "@esbuild/linux-riscv64": "0.27.4",
-        "@esbuild/linux-s390x": "0.27.4",
-        "@esbuild/linux-x64": "0.27.4",
-        "@esbuild/netbsd-arm64": "0.27.4",
-        "@esbuild/netbsd-x64": "0.27.4",
-        "@esbuild/openbsd-arm64": "0.27.4",
-        "@esbuild/openbsd-x64": "0.27.4",
-        "@esbuild/openharmony-arm64": "0.27.4",
-        "@esbuild/sunos-x64": "0.27.4",
-        "@esbuild/win32-arm64": "0.27.4",
-        "@esbuild/win32-ia32": "0.27.4",
-        "@esbuild/win32-x64": "0.27.4"
-      }
-    },
-    "node_modules/vite/node_modules/fdir": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10662,31 +10422,31 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.8.tgz",
-      "integrity": "sha512-urzu3NCEV0Qa0Y2PwvBtRgmNtxhj5t5ULw7cuKhIHh3OrkKTLlut0lnBOv9qe5OvbkMH2g38G7KPDCTpIytBVg==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.0.8",
-        "@vitest/mocker": "4.0.8",
-        "@vitest/pretty-format": "4.0.8",
-        "@vitest/runner": "4.0.8",
-        "@vitest/snapshot": "4.0.8",
-        "@vitest/spy": "4.0.8",
-        "@vitest/utils": "4.0.8",
-        "debug": "^4.4.3",
-        "es-module-lexer": "^1.7.0",
-        "expect-type": "^1.2.2",
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
         "pathe": "^2.0.3",
         "picomatch": "^4.0.3",
-        "std-env": "^3.10.0",
+        "std-env": "^4.0.0-rc.1",
         "tinybench": "^2.9.0",
-        "tinyexec": "^0.3.2",
+        "tinyexec": "^1.0.2",
         "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.0.3",
-        "vite": "^6.0.0 || ^7.0.0",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -10700,20 +10460,23 @@
       },
       "peerDependencies": {
         "@edge-runtime/vm": "*",
-        "@types/debug": "^4.1.12",
+        "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.0.8",
-        "@vitest/browser-preview": "4.0.8",
-        "@vitest/browser-webdriverio": "4.0.8",
-        "@vitest/ui": "4.0.8",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
         "happy-dom": "*",
-        "jsdom": "*"
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
           "optional": true
         },
-        "@types/debug": {
+        "@opentelemetry/api": {
           "optional": true
         },
         "@types/node": {
@@ -10728,6 +10491,12 @@
         "@vitest/browser-webdriverio": {
           "optional": true
         },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
         "@vitest/ui": {
           "optional": true
         },
@@ -10736,13 +10505,16 @@
         },
         "jsdom": {
           "optional": true
+        },
+        "vite": {
+          "optional": false
         }
       }
     },
     "node_modules/vitest/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kryptosai/mcp-observatory",
-  "version": "0.13.0",
+  "version": "0.20.3",
   "description": "Test your MCP servers for breaking changes. Checks capabilities, invokes tools, detects schema drift between versions.",
   "mcpName": "io.github.KryptosAI/mcp-observatory",
   "license": "MIT",
@@ -84,13 +84,13 @@
     "@types/node": "24.10.1",
     "@typescript-eslint/eslint-plugin": "8.46.3",
     "@typescript-eslint/parser": "8.46.3",
-    "ajv": "8.17.1",
+    "ajv": "8.20.0",
     "eslint": "9.39.1",
     "globals": "16.5.0",
     "semantic-release": "^25.0.3",
-    "tsx": "4.20.6",
+    "tsx": "4.22.4",
     "typescript": "5.9.3",
     "typescript-eslint": "8.46.3",
-    "vitest": "4.0.8"
+    "vitest": "4.1.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -77,6 +77,9 @@
     "github-action",
     "production-monitoring",
     "enterprise",
+    "enterprise-report",
+    "feishu",
+    "lark",
     "schema-drift"
   ],
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kryptosai/mcp-observatory",
   "version": "0.20.3",
-  "description": "Test your MCP servers for breaking changes. Checks capabilities, invokes tools, detects schema drift between versions.",
+  "description": "Test, secure, and monitor MCP servers before agents depend on them.",
   "mcpName": "io.github.KryptosAI/mcp-observatory",
   "license": "MIT",
   "type": "module",
@@ -31,7 +31,11 @@
   "files": [
     "dist/src",
     "README.md",
+    "COMMERCIAL.md",
+    "PRIVACY.md",
+    "TERMS.md",
     "LICENSE",
+    "docs",
     "schemas"
   ],
   "scripts": {
@@ -47,7 +51,8 @@
     "test": "vitest run",
     "validate:artifacts": "tsx scripts/validate-artifacts.ts",
     "verify:packed-install": "node scripts/verify-packed-install.mjs",
-    "smoke": "npm run cli -- run --target tests/fixtures/sample-target-config.json && npm run cli -- diff tests/fixtures/sample-run-a.json tests/fixtures/sample-run-b.json"
+    "smoke": "npm run cli -- run --target tests/fixtures/sample-target-config.json && npm run cli -- diff tests/fixtures/sample-run-a.json tests/fixtures/sample-run-b.json",
+    "telemetry:intelligence": "tsx scripts/telemetry-company-intelligence.ts"
   },
   "keywords": [
     "mcp",
@@ -66,8 +71,12 @@
     "vcr",
     "mcp-testing",
     "security",
+    "mcp-security",
     "ci-cd",
+    "mcp-ci",
     "github-action",
+    "production-monitoring",
+    "enterprise",
     "schema-drift"
   ],
   "dependencies": {

--- a/schemas/diff-artifact.schema.json
+++ b/schemas/diff-artifact.schema.json
@@ -19,113 +19,109 @@
     "removed"
   ],
   "properties": {
-    "artifactType": {
-      "const": "diff"
-    },
-    "schemaVersion": {
-      "const": "1.0.0"
-    },
-    "gate": {
-      "$ref": "#/definitions/gate"
-    },
-    "baseRunId": {
-      "type": "string"
-    },
-    "headRunId": {
-      "type": "string"
-    },
-    "createdAt": {
-      "type": "string"
-    },
-    "summary": {
-      "$ref": "#/definitions/diffSummary"
-    },
+    "artifactType": { "const": "diff" },
+    "schemaVersion": { "const": "1.0.0" },
+    "gate": { "$ref": "#/definitions/gate" },
+    "baseRunId": { "type": "string" },
+    "headRunId": { "type": "string" },
+    "createdAt": { "type": "string" },
+    "summary": { "$ref": "#/definitions/diffSummary" },
     "regressions": {
       "type": "array",
-      "items": {
-        "$ref": "#/definitions/diffEntry"
-      }
+      "items": { "$ref": "#/definitions/diffEntry" }
     },
     "recoveries": {
       "type": "array",
-      "items": {
-        "$ref": "#/definitions/diffEntry"
-      }
+      "items": { "$ref": "#/definitions/diffEntry" }
     },
     "unchanged": {
       "type": "array",
-      "items": {
-        "$ref": "#/definitions/diffEntry"
-      }
+      "items": { "$ref": "#/definitions/diffEntry" }
     },
     "added": {
       "type": "array",
-      "items": {
-        "$ref": "#/definitions/diffEntry"
-      }
+      "items": { "$ref": "#/definitions/diffEntry" }
     },
     "removed": {
       "type": "array",
-      "items": {
-        "$ref": "#/definitions/diffEntry"
-      }
+      "items": { "$ref": "#/definitions/diffEntry" }
+    },
+    "schemaDrift": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/schemaDriftEntry" }
+    },
+    "responseChanges": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/responseChangeEntry" }
     }
   },
   "definitions": {
-    "gate": {
-      "type": "string",
-      "enum": ["pass", "fail"]
-    },
+    "gate": { "type": "string", "enum": ["pass", "fail"] },
     "checkStatus": {
       "type": "string",
       "enum": ["pass", "fail", "partial", "unsupported", "flaky", "skipped"]
     },
     "checkId": {
       "type": "string",
-      "enum": ["tools", "prompts", "resources"]
+      "enum": [
+        "tools",
+        "prompts",
+        "resources",
+        "tools-invoke",
+        "security",
+        "security-lite",
+        "conformance",
+        "schema-quality"
+      ]
     },
     "diffEntry": {
       "type": "object",
       "additionalProperties": false,
       "required": ["id", "capability", "message"],
       "properties": {
-        "id": {
-          "$ref": "#/definitions/checkId"
-        },
-        "capability": {
-          "$ref": "#/definitions/checkId"
-        },
-        "fromStatus": {
-          "$ref": "#/definitions/checkStatus"
-        },
-        "toStatus": {
-          "$ref": "#/definitions/checkStatus"
-        },
-        "message": {
-          "type": "string"
+        "id": { "$ref": "#/definitions/checkId" },
+        "capability": { "$ref": "#/definitions/checkId" },
+        "fromStatus": { "$ref": "#/definitions/checkStatus" },
+        "toStatus": { "$ref": "#/definitions/checkStatus" },
+        "message": { "type": "string" }
+      }
+    },
+    "schemaDriftEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["capability", "name", "changes"],
+      "properties": {
+        "capability": { "$ref": "#/definitions/checkId" },
+        "name": { "type": "string" },
+        "changes": {
+          "type": "array",
+          "items": { "type": "string" }
         }
+      }
+    },
+    "responseChangeEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["capability", "name", "change"],
+      "properties": {
+        "capability": { "$ref": "#/definitions/checkId" },
+        "name": { "type": "string" },
+        "change": { "type": "string" }
       }
     },
     "diffSummary": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "regressions",
-        "recoveries",
-        "unchanged",
-        "added",
-        "removed",
-        "gate"
-      ],
+      "required": ["regressions", "recoveries", "unchanged", "added", "removed", "gate"],
       "properties": {
         "regressions": { "type": "integer", "minimum": 0 },
         "recoveries": { "type": "integer", "minimum": 0 },
         "unchanged": { "type": "integer", "minimum": 0 },
         "added": { "type": "integer", "minimum": 0 },
         "removed": { "type": "integer", "minimum": 0 },
-        "gate": {
-          "$ref": "#/definitions/gate"
-        }
+        "schemaDriftCount": { "type": "integer", "minimum": 0 },
+        "responseChangeCount": { "type": "integer", "minimum": 0 },
+        "gate": { "$ref": "#/definitions/gate" }
       }
     }
   }

--- a/schemas/run-artifact.schema.json
+++ b/schemas/run-artifact.schema.json
@@ -17,92 +17,73 @@
     "checks"
   ],
   "properties": {
-    "artifactType": {
-      "const": "run"
-    },
-    "schemaVersion": {
-      "const": "1.0.0"
-    },
-    "gate": {
-      "$ref": "#/definitions/gate"
-    },
-    "runId": {
-      "type": "string"
-    },
-    "createdAt": {
-      "type": "string"
-    },
-    "toolVersion": {
-      "type": "string"
-    },
-    "target": {
-      "$ref": "#/definitions/targetSnapshot"
-    },
-    "environment": {
-      "$ref": "#/definitions/environmentSnapshot"
-    },
-    "summary": {
-      "$ref": "#/definitions/runSummary"
-    },
+    "artifactType": { "const": "run" },
+    "schemaVersion": { "const": "1.0.0" },
+    "gate": { "$ref": "#/definitions/gate" },
+    "runId": { "type": "string" },
+    "createdAt": { "type": "string" },
+    "toolVersion": { "type": "string" },
+    "target": { "$ref": "#/definitions/targetSnapshot" },
+    "environment": { "$ref": "#/definitions/environmentSnapshot" },
+    "summary": { "$ref": "#/definitions/runSummary" },
     "checks": {
       "type": "array",
-      "items": {
-        "$ref": "#/definitions/checkResult"
-      }
+      "items": { "$ref": "#/definitions/checkResult" }
     },
-    "fatalError": {
-      "type": "string"
-    }
+    "healthScore": { "$ref": "#/definitions/healthScore" },
+    "performanceMetrics": { "$ref": "#/definitions/performanceMetrics" },
+    "fatalError": { "type": "string" }
   },
   "definitions": {
-    "gate": {
-      "type": "string",
-      "enum": ["pass", "fail"]
-    },
+    "gate": { "type": "string", "enum": ["pass", "fail"] },
     "checkStatus": {
       "type": "string",
       "enum": ["pass", "fail", "partial", "unsupported", "flaky", "skipped"]
     },
     "checkId": {
       "type": "string",
-      "enum": ["tools", "prompts", "resources"]
+      "enum": [
+        "tools",
+        "prompts",
+        "resources",
+        "tools-invoke",
+        "security",
+        "security-lite",
+        "conformance",
+        "schema-quality"
+      ]
     },
     "evidenceSummary": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "endpoint",
-        "advertised",
-        "responded",
-        "minimalShapePresent"
-      ],
+      "required": ["endpoint", "advertised", "responded", "minimalShapePresent"],
       "properties": {
-        "endpoint": {
-          "type": "string"
-        },
-        "advertised": {
-          "type": "boolean"
-        },
-        "responded": {
-          "type": "boolean"
-        },
-        "minimalShapePresent": {
-          "type": "boolean"
-        },
-        "itemCount": {
-          "type": "integer",
-          "minimum": 0
-        },
+        "endpoint": { "type": "string" },
+        "advertised": { "type": "boolean" },
+        "responded": { "type": "boolean" },
+        "minimalShapePresent": { "type": "boolean" },
+        "itemCount": { "type": "integer", "minimum": 0 },
         "identifiers": {
           "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "items": { "type": "string" }
         },
         "diagnostics": {
           "type": "array",
+          "items": { "type": "string" }
+        },
+        "schemas": {
+          "type": "object",
+          "additionalProperties": { "type": "object" }
+        },
+        "responseSnapshots": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "findings": {
+          "type": "array",
           "items": {
-            "type": "string"
+            "type": "object",
+            "additionalProperties": true
           }
         }
       }
@@ -110,51 +91,23 @@
     "checkResult": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "id",
-        "capability",
-        "status",
-        "durationMs",
-        "message",
-        "evidence"
-      ],
+      "required": ["id", "capability", "status", "durationMs", "message", "evidence"],
       "properties": {
-        "id": {
-          "$ref": "#/definitions/checkId"
-        },
-        "capability": {
-          "$ref": "#/definitions/checkId"
-        },
-        "status": {
-          "$ref": "#/definitions/checkStatus"
-        },
-        "durationMs": {
-          "type": "number",
-          "minimum": 0
-        },
-        "message": {
-          "type": "string"
-        },
+        "id": { "$ref": "#/definitions/checkId" },
+        "capability": { "$ref": "#/definitions/checkId" },
+        "status": { "$ref": "#/definitions/checkStatus" },
+        "durationMs": { "type": "number", "minimum": 0 },
+        "message": { "type": "string" },
         "evidence": {
           "type": "array",
-          "items": {
-            "$ref": "#/definitions/evidenceSummary"
-          }
+          "items": { "$ref": "#/definitions/evidenceSummary" }
         }
       }
     },
     "statusCounts": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "total",
-        "pass",
-        "fail",
-        "partial",
-        "unsupported",
-        "flaky",
-        "skipped"
-      ],
+      "required": ["total", "pass", "fail", "partial", "unsupported", "flaky", "skipped"],
       "properties": {
         "total": { "type": "integer", "minimum": 0 },
         "pass": { "type": "integer", "minimum": 0 },
@@ -168,16 +121,7 @@
     "runSummary": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "total",
-        "pass",
-        "fail",
-        "partial",
-        "unsupported",
-        "flaky",
-        "skipped",
-        "gate"
-      ],
+      "required": ["total", "pass", "fail", "partial", "unsupported", "flaky", "skipped", "gate"],
       "properties": {
         "total": { "type": "integer", "minimum": 0 },
         "pass": { "type": "integer", "minimum": 0 },
@@ -186,9 +130,7 @@
         "unsupported": { "type": "integer", "minimum": 0 },
         "flaky": { "type": "integer", "minimum": 0 },
         "skipped": { "type": "integer", "minimum": 0 },
-        "gate": {
-          "$ref": "#/definitions/gate"
-        }
+        "gate": { "$ref": "#/definitions/gate" }
       }
     },
     "targetSnapshot": {
@@ -196,36 +138,21 @@
       "additionalProperties": false,
       "required": ["targetId", "adapter", "command", "args"],
       "properties": {
-        "targetId": {
-          "type": "string"
-        },
-        "adapter": {
-          "const": "local-process"
-        },
-        "command": {
-          "type": "string"
-        },
+        "targetId": { "type": "string" },
+        "adapter": { "type": "string", "enum": ["local-process", "http"] },
+        "command": { "type": "string" },
         "args": {
           "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "items": { "type": "string" }
         },
-        "cwd": {
-          "type": "string"
-        },
+        "url": { "type": "string" },
+        "cwd": { "type": "string" },
         "metadata": {
           "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
+          "additionalProperties": { "type": "string" }
         },
-        "serverVersion": {
-          "type": "string"
-        },
-        "serverName": {
-          "type": "string"
-        }
+        "serverVersion": { "type": "string" },
+        "serverName": { "type": "string" }
       }
     },
     "environmentSnapshot": {
@@ -233,11 +160,49 @@
       "additionalProperties": false,
       "required": ["platform", "nodeVersion"],
       "properties": {
-        "platform": {
-          "type": "string"
-        },
-        "nodeVersion": {
-          "type": "string"
+        "platform": { "type": "string" },
+        "nodeVersion": { "type": "string" }
+      }
+    },
+    "scoreDimension": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "weight", "score", "details"],
+      "properties": {
+        "name": { "type": "string" },
+        "weight": { "type": "number" },
+        "score": { "type": "number" },
+        "details": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "healthScore": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["overall", "grade", "dimensions"],
+      "properties": {
+        "overall": { "type": "number" },
+        "grade": { "type": "string", "enum": ["A", "B", "C", "D", "F"] },
+        "dimensions": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/scoreDimension" }
+        }
+      }
+    },
+    "performanceMetrics": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["connectMs"],
+      "properties": {
+        "connectMs": { "type": "number", "minimum": 0 },
+        "toolsListMs": { "type": "number", "minimum": 0 },
+        "promptsListMs": { "type": "number", "minimum": 0 },
+        "resourcesListMs": { "type": "number", "minimum": 0 },
+        "toolInvokeMs": {
+          "type": "object",
+          "additionalProperties": { "type": "number", "minimum": 0 }
         }
       }
     }

--- a/scripts/run-real-server-matrix.ts
+++ b/scripts/run-real-server-matrix.ts
@@ -14,6 +14,26 @@ const artifactsDir = path.join(root, "examples", "artifacts");
 const matrixSummaryPath = path.join(root, "examples", "matrix-summary.json");
 const matrixHistoryPath = path.join(root, "examples", "matrix-history.json");
 const proofIndexPath = path.join(root, "examples", "INDEX.md");
+const DEFAULT_MATRIX_TIMEOUT_MS = 5 * 60_000;
+
+function readMatrixTimeoutMs(): number {
+  const raw = process.env["MCP_OBSERVATORY_MATRIX_TIMEOUT_MS"];
+  if (raw === undefined) return DEFAULT_MATRIX_TIMEOUT_MS;
+
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_MATRIX_TIMEOUT_MS;
+  }
+  return parsed;
+}
+
+const matrixTimeoutMs = readMatrixTimeoutMs();
+const matrixWatchdog = setTimeout(() => {
+  process.stderr.write(
+    `Real-server matrix exceeded ${matrixTimeoutMs}ms; forcing exit before GitHub Actions' job limit.\n`,
+  );
+  process.exit(124);
+}, matrixTimeoutMs);
 
 interface MatrixSummaryEntry {
   targetId: string;
@@ -93,6 +113,7 @@ async function main(): Promise<void> {
     const target = JSON.parse(
       await readFile(targetPath, "utf8"),
     ) as TargetConfig;
+    process.stdout.write(`${target.targetId}: starting\n`);
     const artifact = await runTarget(target);
     const artifactPath = path.join(
       artifactsDir,
@@ -149,6 +170,9 @@ async function main(): Promise<void> {
   await writeFile(matrixHistoryPath, JSON.stringify(history, null, 2) + "\n", "utf8");
 
   if (sawFailure) {
+    process.stderr.write(
+      "Real-server matrix completed with failing target(s). See uploaded artifacts for details.\n",
+    );
     process.exitCode = 1;
   }
 }
@@ -156,5 +180,10 @@ async function main(): Promise<void> {
 void main().catch((error: unknown) => {
   const message = error instanceof Error ? error.message : String(error);
   process.stderr.write(`${message}\n`);
-  process.exitCode = 1;
+  process.exit(1);
+}).then(() => {
+  clearTimeout(matrixWatchdog);
+  // Some third-party MCP servers leave handles open after the SDK transport
+  // closes; force the script to end once all matrix artifacts are written.
+  process.exit(process.exitCode ?? 0);
 });

--- a/scripts/telemetry-company-intelligence.ts
+++ b/scripts/telemetry-company-intelligence.ts
@@ -1,0 +1,298 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+interface TelemetryRow {
+  session_id?: string;
+  sessionId?: string;
+  git_email?: string | null;
+  gitEmail?: string | null;
+  git_remote_url?: string | null;
+  gitRemoteUrl?: string | null;
+  hostname?: string | null;
+  ci_provider?: string | null;
+  ciProvider?: string | null;
+  command?: string | null;
+  target_ids?: string | null;
+  targetIds?: string[] | string | null;
+  installed_servers?: string | null;
+  installedServers?: string[] | string | null;
+  server_commands?: string | null;
+  serverCommands?: string[] | string | null;
+  created_at?: string | null;
+  timestamp?: string | null;
+}
+
+interface Account {
+  domain: string;
+  evidence: Set<string>;
+  events: number;
+  sessions: Set<string>;
+  commands: Set<string>;
+  targets: Set<string>;
+  firstSeen?: string;
+  lastSeen?: string;
+}
+
+interface AccountOutput {
+  company_domain: string;
+  evidence: string;
+  event_count: number;
+  unique_sessions: number;
+  commands_used: string;
+  targets_seen: string;
+  confidence: "high" | "medium" | "low";
+  tier_recommendation: "Strategic" | "Enterprise" | "Business" | "Team" | "Unknown";
+  outreach_status: "not_contacted";
+  first_seen: string;
+  last_seen: string;
+}
+
+const FREE_EMAIL_DOMAINS = new Set([
+  "aol.com",
+  "duck.com",
+  "fastmail.com",
+  "gmail.com",
+  "googlemail.com",
+  "hey.com",
+  "hotmail.com",
+  "icloud.com",
+  "live.com",
+  "mail.com",
+  "me.com",
+  "msn.com",
+  "outlook.com",
+  "pm.me",
+  "proton.me",
+  "protonmail.com",
+  "yahoo.com",
+]);
+
+const STRATEGIC_DOMAINS = new Set([
+  "adobe.com",
+  "amazon.com",
+  "anthropic.com",
+  "apple.com",
+  "atlassian.com",
+  "google.com",
+  "ibm.com",
+  "meta.com",
+  "microsoft.com",
+  "netflix.com",
+  "nvidia.com",
+  "openai.com",
+  "oracle.com",
+  "salesforce.com",
+  "stripe.com",
+  "tesla.com",
+]);
+
+function argValue(name: string): string | undefined {
+  const idx = process.argv.indexOf(name);
+  if (idx === -1) return undefined;
+  return process.argv[idx + 1];
+}
+
+function splitList(value: string[] | string | null | undefined): string[] {
+  if (Array.isArray(value)) return value;
+  if (typeof value !== "string") return [];
+  const trimmed = value.trim();
+  if (!trimmed) return [];
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    if (Array.isArray(parsed)) return parsed.filter((entry): entry is string => typeof entry === "string");
+  } catch {
+    // Fall through to comma-separated parsing.
+  }
+  return trimmed.split(",").map((entry) => entry.trim()).filter(Boolean);
+}
+
+function normalizeDomain(raw: string): string | undefined {
+  const domain = raw.trim().toLowerCase().replace(/^www\./, "");
+  if (!domain.includes(".")) return undefined;
+  if (FREE_EMAIL_DOMAINS.has(domain)) return undefined;
+  if (domain.endsWith(".local") || domain.endsWith(".localhost")) return undefined;
+  return domain;
+}
+
+function emailDomain(email: string | null | undefined): string | undefined {
+  if (!email) return undefined;
+  const at = email.lastIndexOf("@");
+  if (at === -1) return undefined;
+  return normalizeDomain(email.slice(at + 1));
+}
+
+function remoteOrgOrDomain(remote: string | null | undefined): string | undefined {
+  if (!remote) return undefined;
+  const raw = remote.trim();
+  try {
+    const url = new URL(raw.replace(/^git@([^:]+):/, "ssh://git@$1/"));
+    const host = normalizeDomain(url.hostname);
+    const parts = url.pathname.split("/").filter(Boolean);
+    if (host === "github.com" && parts[0]) return `github:${parts[0].toLowerCase()}`;
+    return host;
+  } catch {
+    const match = raw.match(/git@([^:]+):([^/]+)\//);
+    if (match?.[1] === "github.com" && match[2]) return `github:${match[2].toLowerCase()}`;
+  }
+  return undefined;
+}
+
+function hostnameDomain(hostname: string | null | undefined): string | undefined {
+  if (!hostname) return undefined;
+  const parts = hostname.toLowerCase().split(".").filter(Boolean);
+  if (parts.length < 2) return undefined;
+  return normalizeDomain(parts.slice(-2).join("."));
+}
+
+function parseRows(raw: string): TelemetryRow[] {
+  const trimmed = raw.trim();
+  if (!trimmed) return [];
+  if (trimmed.startsWith("[")) return JSON.parse(trimmed) as TelemetryRow[];
+  if (trimmed.startsWith("{")) {
+    try {
+      const parsed = JSON.parse(trimmed) as { results?: TelemetryRow[]; rows?: TelemetryRow[]; events?: TelemetryRow[] };
+      return parsed.results ?? parsed.rows ?? parsed.events ?? [parsed as TelemetryRow];
+    } catch {
+      // Fall through to JSONL parsing.
+    }
+  }
+  return trimmed.split(/\r?\n/).map((line) => JSON.parse(line) as TelemetryRow);
+}
+
+function touch(account: Account, row: TelemetryRow, evidence: string[]): void {
+  account.events += 1;
+  for (const item of evidence) account.evidence.add(item);
+  const session = row.session_id ?? row.sessionId;
+  if (session) account.sessions.add(session);
+  if (row.command) account.commands.add(row.command);
+  for (const target of splitList(row.target_ids ?? row.targetIds)) account.targets.add(target);
+  for (const server of splitList(row.installed_servers ?? row.installedServers)) account.targets.add(server);
+  const seen = row.created_at ?? row.timestamp ?? "";
+  if (seen) {
+    if (!account.firstSeen || seen < account.firstSeen) account.firstSeen = seen;
+    if (!account.lastSeen || seen > account.lastSeen) account.lastSeen = seen;
+  }
+}
+
+function confidence(account: Account): "high" | "medium" | "low" {
+  if (account.sessions.size >= 3 || account.events >= 25) return "high";
+  if (account.sessions.size >= 2 || account.events >= 8) return "medium";
+  return "low";
+}
+
+function tier(account: Account): AccountOutput["tier_recommendation"] {
+  if (STRATEGIC_DOMAINS.has(account.domain)) return "Strategic";
+  if (account.domain.startsWith("github:")) {
+    if (account.events >= 25 || account.sessions.size >= 3) return "Enterprise";
+    if (account.events >= 8) return "Business";
+    return "Team";
+  }
+  if (account.events >= 50 || account.sessions.size >= 5) return "Enterprise";
+  if (account.events >= 15 || account.sessions.size >= 2) return "Business";
+  return "Team";
+}
+
+function toOutput(account: Account): AccountOutput {
+  return {
+    company_domain: account.domain,
+    evidence: [...account.evidence].sort().join(";"),
+    event_count: account.events,
+    unique_sessions: account.sessions.size,
+    commands_used: [...account.commands].sort().slice(0, 20).join(";"),
+    targets_seen: [...account.targets].sort().slice(0, 30).join(";"),
+    confidence: confidence(account),
+    tier_recommendation: tier(account),
+    outreach_status: "not_contacted",
+    first_seen: account.firstSeen ?? "",
+    last_seen: account.lastSeen ?? "",
+  };
+}
+
+function csvEscape(value: string | number): string {
+  const s = String(value);
+  if (!/[",\n]/.test(s)) return s;
+  return `"${s.replaceAll("\"", "\"\"")}"`;
+}
+
+function renderCsv(rows: AccountOutput[]): string {
+  const headers = [
+    "company_domain",
+    "evidence",
+    "event_count",
+    "unique_sessions",
+    "commands_used",
+    "targets_seen",
+    "confidence",
+    "tier_recommendation",
+    "outreach_status",
+    "first_seen",
+    "last_seen",
+  ] as const;
+  return [
+    headers.join(","),
+    ...rows.map((row) => headers.map((header) => csvEscape(row[header])).join(",")),
+  ].join("\n") + "\n";
+}
+
+async function main(): Promise<void> {
+  const input = argValue("--input");
+  const outDir = argValue("--out-dir") ?? "reports";
+  if (!input) {
+    process.stderr.write("Usage: tsx scripts/telemetry-company-intelligence.ts --input <events.json|events.jsonl> [--out-dir reports]\n");
+    process.exitCode = 1;
+    return;
+  }
+
+  const rows = parseRows(await readFile(input, "utf8"));
+  const accounts = new Map<string, Account>();
+
+  function accountFor(domain: string): Account {
+    let account = accounts.get(domain);
+    if (!account) {
+      account = { domain, evidence: new Set(), events: 0, sessions: new Set(), commands: new Set(), targets: new Set() };
+      accounts.set(domain, account);
+    }
+    return account;
+  }
+
+  for (const row of rows) {
+    const signals = [
+      { domain: emailDomain(row.git_email ?? row.gitEmail), evidence: "git_email_domain" },
+      { domain: remoteOrgOrDomain(row.git_remote_url ?? row.gitRemoteUrl), evidence: "git_remote_url" },
+      { domain: hostnameDomain(row.hostname), evidence: "hostname_domain" },
+    ];
+
+    const rowAccounts = new Map<string, string[]>();
+    for (const signal of signals) {
+      if (!signal.domain) continue;
+      const evidence = rowAccounts.get(signal.domain) ?? [];
+      evidence.push(signal.evidence);
+      rowAccounts.set(signal.domain, evidence);
+    }
+
+    for (const [domain, evidence] of rowAccounts) {
+      touch(accountFor(domain), row, evidence);
+    }
+  }
+
+  const outputs = [...accounts.values()]
+    .map(toOutput)
+    .sort((a, b) => b.event_count - a.event_count || b.unique_sessions - a.unique_sessions || a.company_domain.localeCompare(b.company_domain));
+
+  await mkdir(outDir, { recursive: true });
+  const jsonPath = path.join(outDir, "telemetry-company-intelligence.json");
+  const csvPath = path.join(outDir, "telemetry-company-intelligence.csv");
+  await writeFile(jsonPath, JSON.stringify(outputs, null, 2) + "\n", "utf8");
+  await writeFile(csvPath, renderCsv(outputs), "utf8");
+
+  process.stdout.write(`Analyzed ${rows.length} telemetry rows.\n`);
+  process.stdout.write(`Identified ${outputs.length} company/org candidates.\n`);
+  process.stdout.write(`Wrote ${jsonPath}\n`);
+  process.stdout.write(`Wrote ${csvPath}\n`);
+}
+
+void main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`${message}\n`);
+  process.exitCode = 1;
+});

--- a/scripts/telemetry-company-intelligence.ts
+++ b/scripts/telemetry-company-intelligence.ts
@@ -292,6 +292,98 @@ function renderCsv(rows: AccountOutput[]): string {
   ].join("\n") + "\n";
 }
 
+function htmlEscape(value: string | number): string {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll("\"", "&quot;");
+}
+
+function renderHtml(rows: AccountOutput[]): string {
+  const strategic = rows.filter((row) => row.tier_recommendation === "Strategic").length;
+  const enterprise = rows.filter((row) => row.tier_recommendation === "Enterprise").length;
+  const highConfidence = rows.filter((row) => row.confidence === "high").length;
+  const generatedAt = new Date().toISOString();
+  const cells = (row: AccountOutput): string => [
+    row.company_domain,
+    row.tier_recommendation,
+    row.confidence,
+    row.event_count,
+    row.unique_sessions,
+    row.ci_events,
+    row.production_signals,
+    row.commands_used,
+    row.targets_seen,
+    row.evidence,
+    row.first_seen,
+    row.last_seen,
+  ].map((value) => `<td>${htmlEscape(value)}</td>`).join("");
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>MCP Observatory Telemetry Intelligence</title>
+  <style>
+    :root { color-scheme: light; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    body { margin: 0; color: #17202a; background: #f7f8fb; }
+    main { max-width: 1320px; margin: 0 auto; padding: 32px 20px 48px; }
+    h1 { margin: 0 0 8px; font-size: 28px; letter-spacing: 0; }
+    .meta { color: #5a6675; margin-bottom: 24px; }
+    .summary { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 12px; margin-bottom: 24px; }
+    .metric { background: #fff; border: 1px solid #dfe5ee; border-radius: 8px; padding: 14px 16px; }
+    .metric strong { display: block; font-size: 24px; }
+    .metric span { color: #5a6675; font-size: 13px; }
+    .table-wrap { overflow-x: auto; background: #fff; border: 1px solid #dfe5ee; border-radius: 8px; }
+    table { border-collapse: collapse; width: 100%; min-width: 1180px; font-size: 13px; }
+    th, td { border-bottom: 1px solid #edf1f6; padding: 10px 12px; text-align: left; vertical-align: top; }
+    th { position: sticky; top: 0; background: #eef3f8; font-size: 12px; text-transform: uppercase; color: #425166; }
+    td:nth-child(1), td:nth-child(2), td:nth-child(3) { white-space: nowrap; }
+    tr:last-child td { border-bottom: 0; }
+    @media (max-width: 760px) { .summary { grid-template-columns: repeat(2, minmax(0, 1fr)); } main { padding: 20px 12px 36px; } }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>MCP Observatory Telemetry Intelligence</h1>
+    <div class="meta">Generated ${htmlEscape(generatedAt)}. Raw emails are excluded from this report.</div>
+    <section class="summary" aria-label="Summary">
+      <div class="metric"><strong>${rows.length}</strong><span>company/org candidates</span></div>
+      <div class="metric"><strong>${strategic}</strong><span>strategic accounts</span></div>
+      <div class="metric"><strong>${enterprise}</strong><span>enterprise accounts</span></div>
+      <div class="metric"><strong>${highConfidence}</strong><span>high-confidence accounts</span></div>
+    </section>
+    <div class="table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th>Company/Org</th>
+            <th>Tier</th>
+            <th>Confidence</th>
+            <th>Events</th>
+            <th>Sessions</th>
+            <th>CI</th>
+            <th>Production Signals</th>
+            <th>Commands</th>
+            <th>Targets</th>
+            <th>Evidence</th>
+            <th>First Seen</th>
+            <th>Last Seen</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${rows.map((row) => `<tr>${cells(row)}</tr>`).join("\n          ")}
+        </tbody>
+      </table>
+    </div>
+  </main>
+</body>
+</html>
+`;
+}
+
 function rank(row: AccountOutput): number {
   const confidenceScore = row.confidence === "high" ? 1000 : row.confidence === "medium" ? 500 : 0;
   const tierScore = row.tier_recommendation === "Strategic"
@@ -375,13 +467,16 @@ async function main(): Promise<void> {
   await mkdir(outDir, { recursive: true });
   const jsonPath = path.join(outDir, "telemetry-company-intelligence.json");
   const csvPath = path.join(outDir, "telemetry-company-intelligence.csv");
+  const htmlPath = path.join(outDir, "telemetry-company-intelligence.html");
   await writeFile(jsonPath, JSON.stringify(outputs, null, 2) + "\n", "utf8");
   await writeFile(csvPath, renderCsv(outputs), "utf8");
+  await writeFile(htmlPath, renderHtml(outputs), "utf8");
 
   process.stdout.write(`Analyzed ${rows.length} telemetry rows.\n`);
   process.stdout.write(`Identified ${outputs.length} company/org candidates.\n`);
   process.stdout.write(`Wrote ${jsonPath}\n`);
   process.stdout.write(`Wrote ${csvPath}\n`);
+  process.stdout.write(`Wrote ${htmlPath}\n`);
 }
 
 void main().catch((error: unknown) => {

--- a/scripts/telemetry-company-intelligence.ts
+++ b/scripts/telemetry-company-intelligence.ts
@@ -4,6 +4,8 @@ import path from "node:path";
 interface TelemetryRow {
   session_id?: string;
   sessionId?: string;
+  org?: string | null;
+  contact?: string | null;
   git_email?: string | null;
   gitEmail?: string | null;
   git_remote_url?: string | null;
@@ -11,6 +13,8 @@ interface TelemetryRow {
   hostname?: string | null;
   ci_provider?: string | null;
   ciProvider?: string | null;
+  is_ci?: number | boolean | null;
+  isCI?: boolean | null;
   command?: string | null;
   target_ids?: string | null;
   targetIds?: string[] | string | null;
@@ -18,6 +22,8 @@ interface TelemetryRow {
   installedServers?: string[] | string | null;
   server_commands?: string | null;
   serverCommands?: string[] | string | null;
+  security_finding_count?: number | null;
+  securityFindingCount?: number | null;
   created_at?: string | null;
   timestamp?: string | null;
 }
@@ -29,6 +35,9 @@ interface Account {
   sessions: Set<string>;
   commands: Set<string>;
   targets: Set<string>;
+  ciEvents: number;
+  securityEvents: number;
+  privateSignals: Set<string>;
   firstSeen?: string;
   lastSeen?: string;
 }
@@ -40,6 +49,8 @@ interface AccountOutput {
   unique_sessions: number;
   commands_used: string;
   targets_seen: string;
+  ci_events: number;
+  production_signals: string;
   confidence: "high" | "medium" | "low";
   tier_recommendation: "Strategic" | "Enterprise" | "Business" | "Team" | "Unknown";
   outreach_status: "not_contacted";
@@ -86,10 +97,21 @@ const STRATEGIC_DOMAINS = new Set([
   "tesla.com",
 ]);
 
+const INTERNAL_DOMAINS = new Set([
+  "banksey.com",
+  "example.com",
+  "github:kryptosai",
+  "kryptosai.com",
+]);
+
 function argValue(name: string): string | undefined {
   const idx = process.argv.indexOf(name);
   if (idx === -1) return undefined;
   return process.argv[idx + 1];
+}
+
+function hasFlag(name: string): boolean {
+  return process.argv.includes(name);
 }
 
 function splitList(value: string[] | string | null | undefined): string[] {
@@ -144,6 +166,16 @@ function hostnameDomain(hostname: string | null | undefined): string | undefined
   return normalizeDomain(parts.slice(-2).join("."));
 }
 
+function orgDomain(org: string | null | undefined): string | undefined {
+  if (!org) return undefined;
+  const normalized = org.trim().toLowerCase();
+  if (!normalized) return undefined;
+  const domain = normalizeDomain(normalized);
+  if (domain) return domain;
+  const slug = normalized.replace(/[^a-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
+  return slug ? `org:${slug}` : undefined;
+}
+
 function parseRows(raw: string): TelemetryRow[] {
   const trimmed = raw.trim();
   if (!trimmed) return [];
@@ -167,6 +199,25 @@ function touch(account: Account, row: TelemetryRow, evidence: string[]): void {
   if (row.command) account.commands.add(row.command);
   for (const target of splitList(row.target_ids ?? row.targetIds)) account.targets.add(target);
   for (const server of splitList(row.installed_servers ?? row.installedServers)) account.targets.add(server);
+  const ciProvider = row.ci_provider ?? row.ciProvider;
+  const isCi = row.is_ci === 1 || row.is_ci === true || row.isCI === true || Boolean(ciProvider);
+  if (isCi) {
+    account.ciEvents += 1;
+    account.privateSignals.add(ciProvider ? `ci:${ciProvider}` : "ci");
+  }
+  const command = row.command ?? "";
+  if (command === "ci-report" || command === "watch") account.privateSignals.add(`command:${command}`);
+  const targetText = [
+    ...splitList(row.target_ids ?? row.targetIds),
+    ...splitList(row.server_commands ?? row.serverCommands),
+  ].join(" ");
+  if (/https?:\/\/(10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.|localhost|127\.)/i.test(targetText)) {
+    account.privateSignals.add("private-network-target");
+  }
+  if (command.includes("security") || row.security_finding_count || row.securityFindingCount) {
+    account.securityEvents += 1;
+    account.privateSignals.add("security-scan");
+  }
   const seen = row.created_at ?? row.timestamp ?? "";
   if (seen) {
     if (!account.firstSeen || seen < account.firstSeen) account.firstSeen = seen;
@@ -175,6 +226,7 @@ function touch(account: Account, row: TelemetryRow, evidence: string[]): void {
 }
 
 function confidence(account: Account): "high" | "medium" | "low" {
+  if (account.privateSignals.size >= 2 && account.sessions.size >= 2) return "high";
   if (account.sessions.size >= 3 || account.events >= 25) return "high";
   if (account.sessions.size >= 2 || account.events >= 8) return "medium";
   return "low";
@@ -182,6 +234,8 @@ function confidence(account: Account): "high" | "medium" | "low" {
 
 function tier(account: Account): AccountOutput["tier_recommendation"] {
   if (STRATEGIC_DOMAINS.has(account.domain)) return "Strategic";
+  if (account.privateSignals.has("private-network-target") && account.events >= 25) return "Enterprise";
+  if (account.ciEvents >= 10 && account.sessions.size >= 2) return "Enterprise";
   if (account.domain.startsWith("github:")) {
     if (account.events >= 25 || account.sessions.size >= 3) return "Enterprise";
     if (account.events >= 8) return "Business";
@@ -200,6 +254,8 @@ function toOutput(account: Account): AccountOutput {
     unique_sessions: account.sessions.size,
     commands_used: [...account.commands].sort().slice(0, 20).join(";"),
     targets_seen: [...account.targets].sort().slice(0, 30).join(";"),
+    ci_events: account.ciEvents,
+    production_signals: [...account.privateSignals].sort().join(";"),
     confidence: confidence(account),
     tier_recommendation: tier(account),
     outreach_status: "not_contacted",
@@ -222,6 +278,8 @@ function renderCsv(rows: AccountOutput[]): string {
     "unique_sessions",
     "commands_used",
     "targets_seen",
+    "ci_events",
+    "production_signals",
     "confidence",
     "tier_recommendation",
     "outreach_status",
@@ -234,11 +292,27 @@ function renderCsv(rows: AccountOutput[]): string {
   ].join("\n") + "\n";
 }
 
+function rank(row: AccountOutput): number {
+  const confidenceScore = row.confidence === "high" ? 1000 : row.confidence === "medium" ? 500 : 0;
+  const tierScore = row.tier_recommendation === "Strategic"
+    ? 2000
+    : row.tier_recommendation === "Enterprise"
+      ? 1500
+      : row.tier_recommendation === "Business"
+        ? 700
+        : row.tier_recommendation === "Team"
+          ? 200
+          : 0;
+  const productionScore = row.production_signals ? 400 : 0;
+  return tierScore + confidenceScore + productionScore + row.event_count + row.unique_sessions * 5 + row.ci_events * 2;
+}
+
 async function main(): Promise<void> {
   const input = argValue("--input");
   const outDir = argValue("--out-dir") ?? "reports";
+  const includeInternal = hasFlag("--include-internal");
   if (!input) {
-    process.stderr.write("Usage: tsx scripts/telemetry-company-intelligence.ts --input <events.json|events.jsonl> [--out-dir reports]\n");
+    process.stderr.write("Usage: tsx scripts/telemetry-company-intelligence.ts --input <events.json|events.jsonl> [--out-dir reports] [--include-internal]\n");
     process.exitCode = 1;
     return;
   }
@@ -249,7 +323,17 @@ async function main(): Promise<void> {
   function accountFor(domain: string): Account {
     let account = accounts.get(domain);
     if (!account) {
-      account = { domain, evidence: new Set(), events: 0, sessions: new Set(), commands: new Set(), targets: new Set() };
+      account = {
+        domain,
+        evidence: new Set(),
+        events: 0,
+        sessions: new Set(),
+        commands: new Set(),
+        targets: new Set(),
+        ciEvents: 0,
+        securityEvents: 0,
+        privateSignals: new Set(),
+      };
       accounts.set(domain, account);
     }
     return account;
@@ -258,6 +342,8 @@ async function main(): Promise<void> {
   for (const row of rows) {
     const signals = [
       { domain: emailDomain(row.git_email ?? row.gitEmail), evidence: "git_email_domain" },
+      { domain: orgDomain(row.org), evidence: "declared_org" },
+      { domain: emailDomain(row.contact), evidence: "declared_contact_domain" },
       { domain: remoteOrgOrDomain(row.git_remote_url ?? row.gitRemoteUrl), evidence: "git_remote_url" },
       { domain: hostnameDomain(row.hostname), evidence: "hostname_domain" },
     ];
@@ -275,9 +361,16 @@ async function main(): Promise<void> {
     }
   }
 
-  const outputs = [...accounts.values()]
+  const accountValues = includeInternal
+    ? [...accounts.values()]
+    : [...accounts.values()].filter((account) => !INTERNAL_DOMAINS.has(account.domain));
+
+  const outputs = accountValues
     .map(toOutput)
-    .sort((a, b) => b.event_count - a.event_count || b.unique_sessions - a.unique_sessions || a.company_domain.localeCompare(b.company_domain));
+    .sort((a, b) =>
+      rank(b) - rank(a) ||
+      a.company_domain.localeCompare(b.company_domain),
+    );
 
   await mkdir(outDir, { recursive: true });
   const jsonPath = path.join(outDir, "telemetry-company-intelligence.json");

--- a/server.json
+++ b/server.json
@@ -6,16 +6,18 @@
     "url": "https://github.com/KryptosAI/mcp-observatory",
     "source": "github"
   },
-  "version": "0.14.7",
+  "version": "0.20.3",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@kryptosai/mcp-observatory",
-      "version": "0.14.7",
+      "version": "0.20.3",
       "transport": {
         "type": "stdio"
       },
-      "arguments": ["serve"],
+      "arguments": [
+        "serve"
+      ],
       "environmentVariables": []
     }
   ]

--- a/src/checks/security.ts
+++ b/src/checks/security.ts
@@ -58,6 +58,23 @@ function scanResponsesForCredentials(
   return findings;
 }
 
+function filterSuppressedFindings(findings: SecurityFinding[], target: TargetConfig): SecurityFinding[] {
+  const suppressions = new Set(target.securitySuppressions ?? []);
+  if (suppressions.size === 0) return findings;
+  return findings.filter((finding) => {
+    return !(
+      suppressions.has(finding.ruleId) ||
+      suppressions.has(finding.toolName) ||
+      suppressions.has(`${finding.toolName}:${finding.ruleId}`)
+    );
+  });
+}
+
+function structuredFindings(findings: SecurityFinding[]): Array<Record<string, unknown>> | undefined {
+  if (findings.length === 0) return undefined;
+  return findings.map((finding) => ({ ...finding }));
+}
+
 export function runLightweightSecurityCheck(
   tools: Tool[],
   target: TargetConfig,
@@ -78,9 +95,11 @@ export function runLightweightSecurityCheck(
     }
   }
 
+  const activeFindings = filterSuppressedFindings(findings, target);
+
   // Determine status based on highest severity
-  const hasHigh = findings.some(f => f.severity === "high");
-  const hasMedium = findings.some(f => f.severity === "medium");
+  const hasHigh = activeFindings.some(f => f.severity === "high");
+  const hasMedium = activeFindings.some(f => f.severity === "medium");
   let status: "pass" | "partial" | "fail";
   if (hasHigh) {
     status = "fail";
@@ -90,21 +109,22 @@ export function runLightweightSecurityCheck(
     status = "pass";
   }
 
-  const diagnostics = findings.map(f => `[${f.severity}] ${f.message}`);
-  const toolNames = [...new Set(findings.map(f => f.toolName))];
+  const diagnostics = activeFindings.map(f => `[${f.severity}] ${f.message}`);
+  const toolNames = [...new Set(activeFindings.map(f => f.toolName))];
 
-  const message = findings.length === 0
+  const message = activeFindings.length === 0
     ? "No security issues detected (lightweight scan)."
-    : `Found ${findings.length} security finding(s): ${findings.filter(f => f.severity === "high").length} high, ${findings.filter(f => f.severity === "medium").length} medium, ${findings.filter(f => f.severity === "low").length} low.`;
+    : `Found ${activeFindings.length} security finding(s): ${activeFindings.filter(f => f.severity === "high").length} high, ${activeFindings.filter(f => f.severity === "medium").length} medium, ${activeFindings.filter(f => f.severity === "low").length} low.`;
 
   const evidence: EvidenceSummary = {
     endpoint: "security/scan-lite",
     advertised: true,
     responded: true,
     minimalShapePresent: true,
-    itemCount: findings.length,
+    itemCount: activeFindings.length,
     identifiers: toolNames.length > 0 ? toolNames : undefined,
     diagnostics: diagnostics.length > 0 ? diagnostics : undefined,
+    findings: structuredFindings(activeFindings),
   };
 
   return {
@@ -151,9 +171,11 @@ export async function runSecurityCheck(
   const credentialFindings = scanResponsesForCredentials(previousChecks);
   findings.push(...credentialFindings);
 
+  const activeFindings = filterSuppressedFindings(findings, context.target);
+
   // Determine status based on highest severity
-  const hasHigh = findings.some(f => f.severity === "high");
-  const hasMedium = findings.some(f => f.severity === "medium");
+  const hasHigh = activeFindings.some(f => f.severity === "high");
+  const hasMedium = activeFindings.some(f => f.severity === "medium");
   let status: "pass" | "partial" | "fail";
   if (hasHigh) {
     status = "fail";
@@ -163,21 +185,22 @@ export async function runSecurityCheck(
     status = "pass";
   }
 
-  const diagnostics = findings.map(f => `[${f.severity}] ${f.message}`);
-  const toolNames = [...new Set(findings.map(f => f.toolName))];
+  const diagnostics = activeFindings.map(f => `[${f.severity}] ${f.message}`);
+  const toolNames = [...new Set(activeFindings.map(f => f.toolName))];
 
-  const message = findings.length === 0
+  const message = activeFindings.length === 0
     ? "No security issues detected."
-    : `Found ${findings.length} security finding(s): ${findings.filter(f => f.severity === "high").length} high, ${findings.filter(f => f.severity === "medium").length} medium, ${findings.filter(f => f.severity === "low").length} low.`;
+    : `Found ${activeFindings.length} security finding(s): ${activeFindings.filter(f => f.severity === "high").length} high, ${activeFindings.filter(f => f.severity === "medium").length} medium, ${activeFindings.filter(f => f.severity === "low").length} low.`;
 
   const evidence: EvidenceSummary = {
     endpoint: "security/scan",
     advertised: true,
     responded: true,
     minimalShapePresent: true,
-    itemCount: findings.length,
+    itemCount: activeFindings.length,
     identifiers: toolNames.length > 0 ? toolNames : undefined,
     diagnostics: diagnostics.length > 0 ? diagnostics : undefined,
+    findings: structuredFindings(activeFindings),
   };
 
   return {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,6 +18,7 @@ import { registerWatchCommands } from "./commands/watch.js";
 import { registerHistoryCommands } from "./commands/history.js";
 import { registerCiReportCommands } from "./commands/ci-report.js";
 import { registerLockCommands } from "./commands/lock.js";
+import { printCloudInfo } from "./commercial.js";
 import { runTarget } from "./index.js";
 import type { RunArtifact, TargetConfig } from "./types.js";
 import { loadTelemetryConfig, collectUserIdentity, recordEvent, buildEvent } from "./telemetry.js";
@@ -257,6 +258,13 @@ async function main(): Promise<void> {
   registerHistoryCommands(program);
   registerCiReportCommands(program);
   registerLockCommands(program);
+
+  program
+    .command("cloud")
+    .description("Show hosted reporting, production monitoring, and enterprise pilot options.")
+    .action(() => {
+      printCloudInfo();
+    });
 
   // ── smithery ─────────────────────────────────────────────────────────
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { writeFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
 import { Command } from "commander";
 
 import { isCI } from "./ci.js";
@@ -19,7 +19,7 @@ import { registerHistoryCommands } from "./commands/history.js";
 import { registerCiReportCommands } from "./commands/ci-report.js";
 import { registerEnterpriseReportCommands } from "./commands/enterprise-report.js";
 import { registerLockCommands } from "./commands/lock.js";
-import { printCloudInfo } from "./commercial.js";
+import { DEFAULT_CLOUD_UPLOAD_ENDPOINT, printCloudInfo } from "./commercial.js";
 import { runTarget } from "./index.js";
 import type { RunArtifact, TargetConfig } from "./types.js";
 import { loadTelemetryConfig, collectUserIdentity, recordEvent, buildEvent } from "./telemetry.js";
@@ -263,11 +263,44 @@ async function main(): Promise<void> {
   registerEnterpriseReportCommands(program);
   registerLockCommands(program);
 
-  program
+  const cloudCmd = program
     .command("cloud")
     .description("Show hosted reporting, production monitoring, and enterprise pilot options.")
     .action(() => {
       printCloudInfo();
+    });
+
+  cloudCmd
+    .command("upload")
+    .description("Upload a run artifact to MCP Observatory Cloud for a hosted pilot report.")
+    .argument("<artifact>", "Path to a run artifact JSON file.")
+    .option("--org <org>", "Customer or organization slug. Defaults to MCP_OBSERVATORY_ORG.")
+    .option("--endpoint <url>", "Hosted upload endpoint.", DEFAULT_CLOUD_UPLOAD_ENDPOINT)
+    .action(async (artifactPath: string, options: { org?: string; endpoint: string }) => {
+      const token = process.env["MCP_OBSERVATORY_CLOUD_TOKEN"];
+      if (!token) {
+        throw new Error("MCP_OBSERVATORY_CLOUD_TOKEN is required for cloud uploads.");
+      }
+      const org = options.org ?? process.env["MCP_OBSERVATORY_ORG"];
+      const raw = await readFile(artifactPath, "utf8");
+      const response = await fetch(options.endpoint, {
+        method: "POST",
+        headers: {
+          "Authorization": `Bearer ${token}`,
+          "Content-Type": "application/json",
+          ...(org ? { "X-MCP-Observatory-Org": org } : {}),
+        },
+        body: raw,
+      });
+      const text = await response.text();
+      if (!response.ok) {
+        throw new Error(`Cloud upload failed (${response.status}): ${text}`);
+      }
+      process.stdout.write(`${text}\n`);
+      recordEvent(buildEvent("command_complete", "cloud-upload", "cli", {
+        cloudUpload: true,
+        org,
+      }));
     });
 
   // ── smithery ─────────────────────────────────────────────────────────

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,6 +17,7 @@ import { registerTestCommands } from "./commands/test.js";
 import { registerWatchCommands } from "./commands/watch.js";
 import { registerHistoryCommands } from "./commands/history.js";
 import { registerCiReportCommands } from "./commands/ci-report.js";
+import { registerEnterpriseReportCommands } from "./commands/enterprise-report.js";
 import { registerLockCommands } from "./commands/lock.js";
 import { printCloudInfo } from "./commercial.js";
 import { runTarget } from "./index.js";
@@ -55,6 +56,7 @@ const MENU_GROUPS: MenuGroup[] = [
       { command: ["lock", "verify"], label: "lock verify",  outcome: "Verify servers match the lock file" },
       { command: ["diff"],           label: "diff",         outcome: "Compare two run artifacts for regressions" },
       { command: ["history"],        label: "history",      outcome: "Show health score trends over time" },
+      { command: ["enterprise-report"], label: "enterprise-report", outcome: "Generate a production/security report" },
     ],
   },
   {
@@ -228,6 +230,7 @@ async function main(): Promise<void> {
         `  ${c(ANSI.bold, "Quick Start")}`,
         "",
         `  ${c(ANSI.dim, "$")} ${c(ANSI.cyan, `${bin} test`)} ${c(ANSI.dim, "<cmd>")}         Test a specific MCP server`,
+        `  ${c(ANSI.dim, "$")} ${c(ANSI.cyan, `${bin} test --target`)} ${c(ANSI.dim, "<file>")} Test an HTTP or local target config`,
         `  ${c(ANSI.dim, "$")} ${c(ANSI.cyan, `${bin} scan`)}               Check all your configured servers`,
         `  ${c(ANSI.dim, "$")} ${c(ANSI.cyan, `${bin} scan deep`)}          ^ plus invoke tools to verify they work`,
         "",
@@ -257,6 +260,7 @@ async function main(): Promise<void> {
   registerTelemetryCommands(program);
   registerHistoryCommands(program);
   registerCiReportCommands(program);
+  registerEnterpriseReportCommands(program);
   registerLockCommands(program);
 
   program

--- a/src/commands/ci-report.ts
+++ b/src/commands/ci-report.ts
@@ -5,6 +5,7 @@ import type { RunArtifact } from "../types.js";
 import { buildEvent, recordEvent } from "../telemetry.js";
 import { validateRunArtifact } from "../validate.js";
 import { defaultRunsDirectory } from "../storage.js";
+import { maybePrintCloudCta } from "../commercial.js";
 
 // ── Report shape ─────────────────────────────────────────────────────────────
 
@@ -103,6 +104,10 @@ export function registerCiReportCommands(program: Command): void {
           matrixServerCount: report.serverCount,
           matrixFailCount: report.failCount,
         }));
+
+        if (options.format === "markdown") {
+          maybePrintCloudCta("ci");
+        }
 
         if (report.hasRegressions) {
           process.exitCode = 1;

--- a/src/commands/enterprise-report.ts
+++ b/src/commands/enterprise-report.ts
@@ -1,0 +1,207 @@
+import { readdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import type { Command } from "commander";
+
+import { maybePrintCloudCta } from "../commercial.js";
+import { defaultRunsDirectory } from "../storage.js";
+import type { CheckResult, RunArtifact } from "../types.js";
+import { validateRunArtifact } from "../validate.js";
+import { buildEvent, recordEvent } from "../telemetry.js";
+
+export interface EnterpriseReportSummary {
+  serverCount: number;
+  passCount: number;
+  failCount: number;
+  securityFindings: number;
+  averageHealthScore: number | null;
+}
+
+function latestArtifactsByTarget(artifacts: RunArtifact[]): RunArtifact[] {
+  const byTarget = new Map<string, RunArtifact>();
+  for (const artifact of artifacts) {
+    const previous = byTarget.get(artifact.target.targetId);
+    if (!previous || artifact.createdAt > previous.createdAt) {
+      byTarget.set(artifact.target.targetId, artifact);
+    }
+  }
+  return [...byTarget.values()];
+}
+
+function checkCount(artifact: RunArtifact, id: CheckResult["id"]): number {
+  return artifact.checks
+    .filter((check) => check.id === id)
+    .reduce((sum, check) => sum + (check.evidence[0]?.itemCount ?? 0), 0);
+}
+
+function securityFindings(artifact: RunArtifact): number {
+  const securityChecks = artifact.checks.filter((check) => check.id === "security" || check.id === "security-lite");
+  return securityChecks.reduce((sum, check) => {
+    const diagnosticCount = check.evidence.reduce((innerSum, evidence) => innerSum + (evidence.diagnostics?.length ?? 0), 0);
+    return sum + diagnosticCount + (check.status === "fail" ? 1 : 0);
+  }, 0);
+}
+
+function summarize(artifacts: RunArtifact[]): EnterpriseReportSummary {
+  const scores = artifacts
+    .map((artifact) => artifact.healthScore?.overall)
+    .filter((score): score is number => typeof score === "number");
+  return {
+    serverCount: artifacts.length,
+    passCount: artifacts.filter((artifact) => artifact.gate === "pass").length,
+    failCount: artifacts.filter((artifact) => artifact.gate === "fail").length,
+    securityFindings: artifacts.reduce((sum, artifact) => sum + securityFindings(artifact), 0),
+    averageHealthScore: scores.length > 0
+      ? Math.round(scores.reduce((sum, score) => sum + score, 0) / scores.length)
+      : null,
+  };
+}
+
+function esc(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll("\"", "&quot;");
+}
+
+export function buildEnterpriseReport(artifacts: RunArtifact[], account = "MCP team"): string {
+  const today = new Date().toISOString().slice(0, 10);
+  const fleet = latestArtifactsByTarget(artifacts);
+  const summary = summarize(fleet);
+  const score = summary.averageHealthScore === null ? "n/a" : `${summary.averageHealthScore}/100`;
+  const rows = fleet
+    .sort((a, b) => a.target.targetId.localeCompare(b.target.targetId))
+    .map((artifact) => {
+      const checks = artifact.checks.filter((check) => check.status === "fail" || check.status === "partial");
+      const issues = artifact.fatalError
+        ? (artifact.fatalError.split("\n")[0] ?? artifact.fatalError)
+        : checks.map((check) => `${check.id}: ${check.message}`).slice(0, 3).join("; ") || "No blocking issues";
+      const health = artifact.healthScore ? `${artifact.healthScore.grade} (${artifact.healthScore.overall}/100)` : "n/a";
+      return [
+        `| ${artifact.target.targetId}`,
+        artifact.gate,
+        health,
+        String(checkCount(artifact, "tools")),
+        String(checkCount(artifact, "prompts")),
+        String(checkCount(artifact, "resources")),
+        String(securityFindings(artifact)),
+        `${issues.replaceAll("|", "\\|")} |`,
+      ].join(" | ");
+    });
+
+  return [
+    `# MCP Observatory Enterprise Report`,
+    "",
+    `Account: ${account}`,
+    `Generated: ${today}`,
+    "",
+    "## Executive Summary",
+    "",
+    `- Servers tested: ${summary.serverCount}`,
+    `- Passing servers: ${summary.passCount}`,
+    `- Failing servers: ${summary.failCount}`,
+    `- Average health score: ${score}`,
+    `- Security findings: ${summary.securityFindings}`,
+    "",
+    "## Production Risk",
+    "",
+    summary.failCount === 0
+      ? "No blocking regressions were detected in the supplied run artifacts."
+      : `${summary.failCount} server${summary.failCount === 1 ? " needs" : "s need"} remediation before relying on them in production agent workflows.`,
+    "",
+    "## Fleet Inventory",
+    "",
+    "| Server | Gate | Health | Tools | Prompts | Resources | Security Findings | Notes |",
+    "| --- | --- | ---: | ---: | ---: | ---: | ---: | --- |",
+    ...rows,
+    "",
+    "## Recommended Pilot Scope",
+    "",
+    "- Hosted CI history for private repositories",
+    "- Recurring security reports for production MCP servers",
+    "- Fleet visibility across teams, repos, and agent environments",
+    "- Support and certification review for servers that agents depend on",
+    "",
+    "Contact: william@banksey.com",
+  ].join("\n");
+}
+
+export function renderEnterpriseReportHtml(markdown: string): string {
+  const body = markdown
+    .split("\n")
+    .map((line) => {
+      if (line.startsWith("# ")) return `<h1>${esc(line.slice(2))}</h1>`;
+      if (line.startsWith("## ")) return `<h2>${esc(line.slice(3))}</h2>`;
+      if (line.startsWith("- ")) return `<li>${esc(line.slice(2))}</li>`;
+      if (line.startsWith("|")) return `<pre>${esc(line)}</pre>`;
+      if (!line.trim()) return "";
+      return `<p>${esc(line)}</p>`;
+    })
+    .join("\n");
+  return [
+    "<!doctype html>",
+    "<html lang=\"en\">",
+    "<head>",
+    "<meta charset=\"utf-8\">",
+    "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">",
+    "<title>MCP Observatory Enterprise Report</title>",
+    "<style>body{font-family:Inter,Arial,sans-serif;margin:40px;line-height:1.5;color:#18202a}h1,h2{line-height:1.15}pre{padding:8px 0;border-bottom:1px solid #dde3ea;white-space:pre-wrap}li{margin:4px 0}</style>",
+    "</head>",
+    "<body>",
+    body,
+    "</body>",
+    "</html>",
+  ].join("\n");
+}
+
+export function registerEnterpriseReportCommands(program: Command): void {
+  program
+    .command("enterprise-report")
+    .description("Generate a static production/security report from run artifacts.")
+    .option("--artifacts-dir <path>", "Directory containing run artifacts.", defaultRunsDirectory(process.cwd()))
+    .option("--account <name>", "Account, team, or company name for the report.", "MCP team")
+    .option("--format <format>", "Output format: markdown or html.", "markdown")
+    .option("--output <path>", "Write report to file instead of stdout.")
+    .action(async (options: { artifactsDir: string; account: string; format: string; output?: string }) => {
+      const artifacts = await loadArtifactsFromDir(options.artifactsDir);
+      const markdown = buildEnterpriseReport(artifacts, options.account);
+      const output = options.format === "html" ? renderEnterpriseReportHtml(markdown) : markdown;
+
+      if (options.output) {
+        await writeFile(options.output, output, "utf8");
+        process.stdout.write(`  Enterprise report written to ${options.output}\n\n`);
+      } else {
+        process.stdout.write(`${output}\n`);
+      }
+
+      recordEvent(buildEvent("command_complete", "enterprise-report", "cli", {
+        matrixServerCount: artifacts.length,
+        matrixPassCount: artifacts.filter((artifact) => artifact.gate === "pass").length,
+        matrixFailCount: artifacts.filter((artifact) => artifact.gate === "fail").length,
+        securityFindingCount: artifacts.reduce((sum, artifact) => sum + securityFindings(artifact), 0),
+      }));
+      if (options.output) {
+        maybePrintCloudCta("ci");
+      }
+    });
+}
+
+async function loadArtifactsFromDir(dir: string): Promise<RunArtifact[]> {
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch {
+    return [];
+  }
+
+  const artifacts: RunArtifact[] = [];
+  for (const file of entries.filter((entry) => entry.endsWith(".json")).sort()) {
+    try {
+      const data = JSON.parse(await readFile(path.join(dir, file), "utf8")) as unknown;
+      artifacts.push(validateRunArtifact(data));
+    } catch {
+      // Ignore invalid artifacts so one bad file does not block the report.
+    }
+  }
+  return artifacts;
+}

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -9,6 +9,7 @@ import { appendHistory, buildHistoryEntry } from "../history.js";
 import { buildEvent, recordEvent } from "../telemetry.js";
 import type { RunArtifact } from "../types.js";
 import { TOOL_VERSION } from "../version.js";
+import { maybePrintCloudCta } from "../commercial.js";
 import { ANSI, LOGO, c, useColor } from "./helpers.js";
 
 // ── Scan implementation ─────────────────────────────────────────────────────
@@ -171,6 +172,10 @@ async function runScan(bin: string, configPath: string | undefined, invokeTools:
     const { renderMatrixComment } = await import("../reporters/pr-comment-matrix.js");
     const rows = artifacts.map(a => ({ artifact: a }));
     process.stdout.write(renderMatrixComment(rows) + "\n");
+  }
+
+  if (format === "terminal") {
+    maybePrintCloudCta(results.length > 1 ? "fleet" : securityCheck ? "security" : "general");
   }
 
   recordEvent(buildEvent("command_complete", "scan", "cli", {

--- a/src/commands/score.ts
+++ b/src/commands/score.ts
@@ -9,6 +9,7 @@ import {
 } from "../index.js";
 import { defaultRunsDirectory } from "../storage.js";
 import { buildEvent, recordEvent } from "../telemetry.js";
+import { maybePrintCloudCta } from "../commercial.js";
 import { ANSI, c, formatOutput, targetFromCommand, writeOutput } from "./helpers.js";
 
 export function registerScoreCommands(program: Command): void {
@@ -99,6 +100,7 @@ export function registerScoreCommands(program: Command): void {
         }
       }
       process.stdout.write("\n");
+      maybePrintCloudCta("security");
 
       if (artifact.gate === "fail") {
         process.exitCode = 1;

--- a/src/commands/telemetry.ts
+++ b/src/commands/telemetry.ts
@@ -2,12 +2,49 @@ import type { Command } from "commander";
 
 import { loadTelemetryConfig, saveTelemetryConfig, isTelemetryEnabled } from "../telemetry.js";
 
+const TELEMETRY_FIELDS = [
+  "sessionId",
+  "timestamp",
+  "version",
+  "command",
+  "transport",
+  "os",
+  "arch",
+  "nodeVersion",
+  "isCI",
+  "ciName",
+  "ciProvider",
+  "gitEmail",
+  "gitRemoteUrl",
+  "hostname",
+  "serversScanned",
+  "toolsFound",
+  "promptsFound",
+  "resourcesFound",
+  "gateResult",
+  "executionMs",
+  "securityFlag",
+  "targetIds",
+  "installedServers",
+  "serverCommands",
+  "healthScore",
+  "healthGrade",
+  "securityFindingCount",
+  "connectMs",
+  "fatalError",
+  "checkStatuses",
+  "suggestedServers",
+  "detectedLanguages",
+  "detectedFrameworks",
+];
+
 export function registerTelemetryCommands(program: Command): void {
   program
     .command("telemetry")
-    .description("Manage anonymous usage telemetry.")
+    .description("Manage product usage telemetry.")
     .argument("[action]", "enable, disable, stats, or status (default: status)")
-    .action(async (action?: string) => {
+    .option("--verbose", "Show the telemetry fields that may be collected.", false)
+    .action(async (action?: string, options?: { verbose?: boolean }) => {
       const config = await loadTelemetryConfig();
       const envDisabled = process.env["DO_NOT_TRACK"] === "1" ||
         process.env["MCP_OBSERVATORY_TELEMETRY_DISABLED"] === "1";
@@ -57,6 +94,13 @@ export function registerTelemetryCommands(program: Command): void {
           process.stdout.write(`  Override:  disabled via environment variable\n`);
         }
         process.stdout.write(`  Session:   ${config.sessionId}\n\n`);
+        if (options?.verbose) {
+          process.stdout.write("  Fields that may be sent when available:\n");
+          for (const field of TELEMETRY_FIELDS) {
+            process.stdout.write(`    - ${field}\n`);
+          }
+          process.stdout.write("\n  See PRIVACY.md for details and opt-out options.\n\n");
+        }
       }
     });
 }

--- a/src/commands/telemetry.ts
+++ b/src/commands/telemetry.ts
@@ -14,6 +14,8 @@ const TELEMETRY_FIELDS = [
   "isCI",
   "ciName",
   "ciProvider",
+  "org",
+  "contact",
   "gitEmail",
   "gitRemoteUrl",
   "hostname",

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -8,19 +8,20 @@ import { defaultRunsDirectory } from "../storage.js";
 import { appendHistory, buildHistoryEntry, getTrend, readHistory } from "../history.js";
 import { buildEvent, recordEvent } from "../telemetry.js";
 import { maybePrintCloudCta } from "../commercial.js";
-import { ANSI, c, targetFromCommand } from "./helpers.js";
+import { ANSI, c, resolveTarget, targetFromCommand } from "./helpers.js";
 
 export function registerTestCommands(program: Command): void {
   program
     .command("test")
     .passThroughOptions()
     .description("Test a specific server by command.")
-    .argument("<command...>", "Server command and arguments to run.")
+    .argument("[command...]", "Server command and arguments to run.")
+    .option("--target <config>", "Path to a target config JSON file.")
     .option("--security", "Run deep security scan (credential patterns, response analysis). Lightweight security is always included.")
     .option("--no-color", "Disable colored output.")
-    .action(async (commandArgs: string[], options: { security?: boolean }) => {
+    .action(async (commandArgs: string[], options: { security?: boolean; target?: string }) => {
       const t0 = Date.now();
-      const target = targetFromCommand(commandArgs);
+      const target = options.target ? await resolveTarget({ target: options.target }) : targetFromCommand(commandArgs);
       process.stdout.write(`  ${c(ANSI.dim, "⟳")} Checking ${c(ANSI.bold, target.targetId)}...`);
       const artifact = await runTarget(target, { securityCheck: options.security });
       const outPath = await writeRunArtifact(artifact, defaultRunsDirectory(process.cwd()));
@@ -64,7 +65,7 @@ export function registerTestCommands(program: Command): void {
         executionMs: Date.now() - t0,
         securityFlag: options.security,
         targetIds: [target.targetId],
-        serverCommands: [commandArgs.join(" ")],
+        serverCommands: [target.adapter === "http" ? target.url : `${target.command} ${target.args.join(" ")}`],
         healthScore: artifact.healthScore?.overall,
         healthGrade: artifact.healthScore?.grade,
         connectMs: artifact.performanceMetrics?.connectMs,

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -7,6 +7,7 @@ import {
 import { defaultRunsDirectory } from "../storage.js";
 import { appendHistory, buildHistoryEntry, getTrend, readHistory } from "../history.js";
 import { buildEvent, recordEvent } from "../telemetry.js";
+import { maybePrintCloudCta } from "../commercial.js";
 import { ANSI, c, targetFromCommand } from "./helpers.js";
 
 export function registerTestCommands(program: Command): void {
@@ -74,5 +75,6 @@ export function registerTestCommands(program: Command): void {
       if (artifact.gate === "fail") {
         process.exitCode = 1;
       }
+      maybePrintCloudCta(options.security ? "security" : "general");
     });
 }

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -17,13 +17,15 @@ export function registerTestCommands(program: Command): void {
     .description("Test a specific server by command.")
     .argument("[command...]", "Server command and arguments to run.")
     .option("--target <config>", "Path to a target config JSON file.")
+    .option("--deep", "Also invoke safe tools to verify they execute.")
+    .option("--invoke-tools", "Alias for --deep.")
     .option("--security", "Run deep security scan (credential patterns, response analysis). Lightweight security is always included.")
     .option("--no-color", "Disable colored output.")
-    .action(async (commandArgs: string[], options: { security?: boolean; target?: string }) => {
+    .action(async (commandArgs: string[], options: { deep?: boolean; invokeTools?: boolean; security?: boolean; target?: string }) => {
       const t0 = Date.now();
       const target = options.target ? await resolveTarget({ target: options.target }) : targetFromCommand(commandArgs);
       process.stdout.write(`  ${c(ANSI.dim, "⟳")} Checking ${c(ANSI.bold, target.targetId)}...`);
-      const artifact = await runTarget(target, { securityCheck: options.security });
+      const artifact = await runTarget(target, { invokeTools: options.deep || options.invokeTools, securityCheck: options.security });
       const outPath = await writeRunArtifact(artifact, defaultRunsDirectory(process.cwd()));
 
       const toolsEvidence = artifact.checks.find(ch => ch.id === "tools");
@@ -63,6 +65,7 @@ export function registerTestCommands(program: Command): void {
         resourcesFound: resourceCount,
         gateResult: artifact.gate,
         executionMs: Date.now() - t0,
+        deepFlag: options.deep || options.invokeTools,
         securityFlag: options.security,
         targetIds: [target.targetId],
         serverCommands: [target.adapter === "http" ? target.url : `${target.command} ${target.args.join(" ")}`],

--- a/src/commercial.ts
+++ b/src/commercial.ts
@@ -1,6 +1,7 @@
 import { ANSI, c, getBinName } from "./commands/helpers.js";
 
 const CONTACT = "william@banksey.com";
+export const DEFAULT_CLOUD_UPLOAD_ENDPOINT = "https://mcp-observatory-api.kryptosai.workers.dev/api/v1/artifacts";
 
 export function hasCloudToken(): boolean {
   return Boolean(process.env["MCP_OBSERVATORY_CLOUD_TOKEN"]);
@@ -44,6 +45,7 @@ export function printCloudInfo(): void {
       "  Strategic:        custom, $250k+/year",
       "",
       "To enable hosted uploads, set MCP_OBSERVATORY_CLOUD_TOKEN after receiving a pilot token.",
+      `Upload an artifact: ${getBinName()} cloud upload .mcp-observatory/runs/<run>.json`,
       `Contact: ${CONTACT}`,
       "",
     ].join("\n"),

--- a/src/commercial.ts
+++ b/src/commercial.ts
@@ -1,0 +1,51 @@
+import { ANSI, c, getBinName } from "./commands/helpers.js";
+
+const CONTACT = "william@banksey.com";
+
+export function hasCloudToken(): boolean {
+  return Boolean(process.env["MCP_OBSERVATORY_CLOUD_TOKEN"]);
+}
+
+export function cloudUpgradeLine(context: "ci" | "security" | "fleet" | "general" = "general"): string {
+  const bin = getBinName();
+  const value =
+    context === "ci"
+      ? "hosted CI history, private-repo reporting, and production badges"
+      : context === "security"
+        ? "hosted security reports, certification, and production monitoring"
+        : context === "fleet"
+          ? "MCP fleet visibility, drift reports, and production support"
+          : "hosted reporting, production monitoring, and enterprise support";
+
+  return [
+    c(ANSI.dim, `  Production MCP teams: ${value}.`),
+    c(ANSI.dim, `  Run ${c(ANSI.cyan, `${bin} cloud`)} or contact ${CONTACT}.`),
+  ].join("\n");
+}
+
+export function maybePrintCloudCta(context: "ci" | "security" | "fleet" | "general" = "general"): void {
+  if (hasCloudToken()) return;
+  process.stdout.write(`${cloudUpgradeLine(context)}\n\n`);
+}
+
+export function printCloudInfo(): void {
+  process.stdout.write(
+    [
+      "",
+      c(ANSI.bold, "MCP Observatory Cloud"),
+      "",
+      "Free local OSS use remains available. Production teams can add hosted reporting,",
+      "private-repo CI, security reports, certification, support, and MCP fleet visibility.",
+      "",
+      "Pilot pricing:",
+      "  Team Pilot:       starts at $299/month",
+      "  Business Pilot:   starts at $999/month",
+      "  Enterprise Pilot: starts at $3k/month",
+      "  Strategic:        custom, $250k+/year",
+      "",
+      "To enable hosted uploads, set MCP_OBSERVATORY_CLOUD_TOKEN after receiving a pilot token.",
+      `Contact: ${CONTACT}`,
+      "",
+    ].join("\n"),
+  );
+}

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -28,7 +28,9 @@ export interface TelemetryEnrichment {
   resourcesFound?: number;
   gateResult?: string;
   executionMs?: number;
+  deepFlag?: boolean;
   securityFlag?: boolean;
+  cloudUpload?: boolean;
   targetIds?: string[];
   installedServers?: string[];
   serverCommands?: string[];

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -19,6 +19,8 @@ export interface TelemetryConfig {
 }
 
 export interface TelemetryEnrichment {
+  org?: string;
+  contact?: string;
   ciProvider?: string;
   serversScanned?: number;
   toolsFound?: number;
@@ -154,6 +156,7 @@ export async function showFirstRunNotice(): Promise<void> {
     "  │                                                            │",
     "  │  It may include command names, server IDs/commands, CI     │",
     "  │  info, git email/remote, hostname, and scan outcomes.      │",
+    "  │  Set MCP_OBSERVATORY_ORG / CONTACT for account reports.    │",
     "  │  To opt out: mcp-observatory telemetry disable             │",
     "  │  Or set:     DO_NOT_TRACK=1                                │",
     "  └─────────────────────────────────────────────────────────────┘",
@@ -220,6 +223,8 @@ interface UserIdentity {
   gitEmail?: string;
   gitRemoteUrl?: string;
   hostname: string;
+  org?: string;
+  contact?: string;
 }
 
 let _cachedIdentity: UserIdentity | null = null;
@@ -231,6 +236,10 @@ export function collectUserIdentity(): Promise<UserIdentity> {
 
   _identityPromise = (async () => {
     const identity: UserIdentity = { hostname: os.hostname() };
+    const org = process.env["MCP_OBSERVATORY_ORG"]?.trim();
+    const contact = process.env["MCP_OBSERVATORY_CONTACT"]?.trim();
+    if (org) identity.org = org;
+    if (contact) identity.contact = contact;
 
     try {
       const { stdout } = await execFileAsync("git", ["config", "user.email"], { timeout: 2000 });
@@ -276,6 +285,8 @@ export function buildEvent(
     ciName: ci.ciName,
     transport,
     ciProvider: enrichment?.ciProvider ?? detectCiProvider(),
+    org: enrichment?.org ?? identity?.org,
+    contact: enrichment?.contact ?? identity?.contact,
     gitEmail: identity?.gitEmail,
     gitRemoteUrl: identity?.gitRemoteUrl,
     hostname: identity?.hostname,

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -150,9 +150,10 @@ export async function showFirstRunNotice(): Promise<void> {
   const notice = [
     "",
     "  ┌─────────────────────────────────────────────────────────────┐",
-    "  │  MCP Observatory collects anonymous usage telemetry.       │",
+    "  │  MCP Observatory collects product usage telemetry.         │",
     "  │                                                            │",
-    "  │  No personal data, file paths, or server content is sent.  │",
+    "  │  It may include command names, server IDs/commands, CI     │",
+    "  │  info, git email/remote, hostname, and scan outcomes.      │",
     "  │  To opt out: mcp-observatory telemetry disable             │",
     "  │  Or set:     DO_NOT_TRACK=1                                │",
     "  └─────────────────────────────────────────────────────────────┘",

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,8 @@ export interface LocalProcessTargetConfig {
   env?: Record<string, string>;
   timeoutMs?: number;
   metadata?: Record<string, string>;
+  /** Suppress known security findings by rule id, tool name, or toolName:ruleId. */
+  securitySuppressions?: string[];
   /** Skip tool invocation checks for this target even with `scan deep`. */
   skipInvoke?: boolean;
 }
@@ -36,6 +38,8 @@ export interface HttpTargetConfig {
   headers?: Record<string, string>;
   timeoutMs?: number;
   metadata?: Record<string, string>;
+  /** Suppress known security findings by rule id, tool name, or toolName:ruleId. */
+  securitySuppressions?: string[];
   /** Skip tool invocation checks for this target even with `scan deep`. */
   skipInvoke?: boolean;
 }
@@ -69,6 +73,7 @@ export interface EvidenceSummary {
   diagnostics?: string[];
   schemas?: Record<string, object>;
   responseSnapshots?: Record<string, unknown>;
+  findings?: Array<Record<string, unknown>>;
 }
 
 export interface CheckResult {

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -20,6 +20,48 @@ function requireArray(obj: Record<string, unknown>, field: string, label: string
   return value;
 }
 
+function expandEnvValue(value: string, label: string): string {
+  const match =
+    value.match(/^\$\{([A-Za-z_][A-Za-z0-9_]*)\}$/) ??
+    value.match(/^\$([A-Za-z_][A-Za-z0-9_]*)$/) ??
+    value.match(/^env:([A-Za-z_][A-Za-z0-9_]*)$/);
+  if (!match) return value;
+  const name = match[1]!;
+  const envValue = process.env[name];
+  if (envValue === undefined) {
+    throw new Error(`${label} references missing environment variable '${name}'.`);
+  }
+  return envValue;
+}
+
+function optionalStringRecord(value: unknown, label: string, expand = false): Record<string, string> | undefined {
+  if (value === undefined) return undefined;
+  if (!isObject(value)) {
+    throw new Error(`${label} must be an object with string values.`);
+  }
+  const result: Record<string, string> = {};
+  for (const [key, raw] of Object.entries(value)) {
+    if (typeof raw !== "string") {
+      throw new Error(`${label}.${key} must be a string.`);
+    }
+    result[key] = expand ? expandEnvValue(raw, `${label}.${key}`) : raw;
+  }
+  return result;
+}
+
+function optionalStringArray(value: unknown, label: string): string[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value)) {
+    throw new Error(`${label} must be an array of strings.`);
+  }
+  return value.map((entry, i) => {
+    if (typeof entry !== "string" || entry.length === 0) {
+      throw new Error(`${label}[${i}] must be a non-empty string.`);
+    }
+    return entry;
+  });
+}
+
 export function validateTargetConfig(data: unknown): TargetConfig {
   if (!isObject(data)) {
     throw new Error("Target config must be a JSON object.");
@@ -34,10 +76,11 @@ export function validateTargetConfig(data: unknown): TargetConfig {
       targetId,
       adapter: "http",
       url,
-      authToken: typeof data["authToken"] === "string" ? data["authToken"] : undefined,
-      headers: isObject(data["headers"]) ? data["headers"] as Record<string, string> : undefined,
+      authToken: typeof data["authToken"] === "string" ? expandEnvValue(data["authToken"], "Target config authToken") : undefined,
+      headers: optionalStringRecord(data["headers"], "Target config headers", true),
       timeoutMs: typeof data["timeoutMs"] === "number" ? data["timeoutMs"] : undefined,
-      metadata: isObject(data["metadata"]) ? data["metadata"] as Record<string, string> : undefined,
+      metadata: optionalStringRecord(data["metadata"], "Target config metadata"),
+      securitySuppressions: optionalStringArray(data["securitySuppressions"], "Target config securitySuppressions"),
       skipInvoke: data["skipInvoke"] === true ? true : undefined,
     };
   }
@@ -61,9 +104,10 @@ export function validateTargetConfig(data: unknown): TargetConfig {
     command,
     args,
     cwd: typeof data["cwd"] === "string" ? data["cwd"] : undefined,
-    env: isObject(data["env"]) ? data["env"] as Record<string, string> : undefined,
+    env: optionalStringRecord(data["env"], "Target config env", true),
     timeoutMs: typeof data["timeoutMs"] === "number" ? data["timeoutMs"] : undefined,
-    metadata: isObject(data["metadata"]) ? data["metadata"] as Record<string, string> : undefined,
+    metadata: optionalStringRecord(data["metadata"], "Target config metadata"),
+    securitySuppressions: optionalStringArray(data["securitySuppressions"], "Target config securitySuppressions"),
     skipInvoke: data["skipInvoke"] === true ? true : undefined,
   };
 }

--- a/tests/cli-entrypoint.test.ts
+++ b/tests/cli-entrypoint.test.ts
@@ -104,6 +104,13 @@ describe("CLI entrypoint", () => {
     expect(stdout).toContain("report");
   });
 
+  it("cloud subcommand prints pilot info", () => {
+    const { stdout, exitCode } = runCli(["cloud"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("MCP Observatory Cloud");
+    expect(stdout).toContain("Enterprise Pilot");
+  });
+
   it("diff runs two sample artifacts", () => {
     const { stdout, exitCode } = runCli([
       "diff",

--- a/tests/cli-mcp-parity.test.ts
+++ b/tests/cli-mcp-parity.test.ts
@@ -168,10 +168,11 @@ describe("CLI/MCP Parity", () => {
       "watch",
       "report",    // no MCP equivalent (intentional)
       "serve",     // starts the MCP server itself
+      "cloud",     // CLI-only commercial pilot info
     ];
 
     // Intentional CLI-only commands:
-    const intentionalCliOnly = ["run", "report", "serve", "badge"];
+    const intentionalCliOnly = ["run", "report", "serve", "badge", "cloud"];
     // Intentional MCP-only tools:
     const intentionalMcpOnly = ["get_last_run"];
     // Name mappings:
@@ -216,6 +217,7 @@ describe("CLI/MCP Parity", () => {
       "run": "CLI-only command that reads target config files; MCP tools accept inline params",
       "get_last_run": "MCP-only convenience tool; CLI users use ls + diff manually",
       "badge": "CLI-only command that generates SVG badge from health score",
+      "cloud": "CLI-only command that explains hosted reporting and paid pilot options",
     };
 
     expect(Object.keys(intentionalDifferences).length).toBeGreaterThanOrEqual(5);

--- a/tests/enterprise-report.test.ts
+++ b/tests/enterprise-report.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import { buildEnterpriseReport, renderEnterpriseReportHtml } from "../src/commands/enterprise-report.js";
+import type { CheckResult, RunArtifact } from "../src/types.js";
+
+function makeCheck(id: CheckResult["id"], status: CheckResult["status"], itemCount = 0, message = `${id} ${status}`): CheckResult {
+  return {
+    id,
+    capability: id,
+    status,
+    durationMs: 50,
+    message,
+    evidence: [{ endpoint: id, advertised: true, responded: status !== "fail", minimalShapePresent: status !== "fail", itemCount }],
+  };
+}
+
+function makeArtifact(targetId: string, gate: "pass" | "fail", checks: CheckResult[]): RunArtifact {
+  return {
+    artifactType: "run",
+    schemaVersion: "1.0.0",
+    gate,
+    runId: `run-${targetId}`,
+    createdAt: "2026-06-16T00:00:00Z",
+    toolVersion: "0.20.3",
+    target: {
+      targetId,
+      adapter: "local-process",
+      command: "node",
+      args: ["server.js"],
+    },
+    environment: { platform: "darwin", nodeVersion: "v24.0.0" },
+    summary: {
+      gate,
+      total: checks.length,
+      pass: checks.filter((check) => check.status === "pass").length,
+      fail: checks.filter((check) => check.status === "fail").length,
+      partial: checks.filter((check) => check.status === "partial").length,
+      unsupported: 0,
+      flaky: 0,
+      skipped: 0,
+    },
+    checks,
+    healthScore: {
+      overall: gate === "pass" ? 92 : 61,
+      grade: gate === "pass" ? "A" : "D",
+      dimensions: [],
+    },
+  };
+}
+
+describe("enterprise report", () => {
+  it("summarizes fleet health and pilot scope", () => {
+    const report = buildEnterpriseReport([
+      makeArtifact("feishu-doc-mcp", "pass", [
+        makeCheck("tools", "pass", 12),
+        makeCheck("prompts", "pass", 2),
+        makeCheck("resources", "pass", 1),
+      ]),
+      makeArtifact("internal-http-mcp", "fail", [
+        makeCheck("tools", "fail", 0, "tools list failed"),
+        makeCheck("security", "partial", 0, "missing auth metadata"),
+      ]),
+    ], "ThinkingData pilot");
+
+    expect(report).toContain("Account: ThinkingData pilot");
+    expect(report).toContain("Servers tested: 2");
+    expect(report).toContain("Failing servers: 1");
+    expect(report).toContain("feishu-doc-mcp");
+    expect(report).toContain("Hosted CI history");
+  });
+
+  it("renders a standalone html document", () => {
+    const html = renderEnterpriseReportHtml("# Title\n\nBody");
+    expect(html).toContain("<!doctype html>");
+    expect(html).toContain("<h1>Title</h1>");
+    expect(html).toContain("<p>Body</p>");
+  });
+});

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { runLightweightSecurityCheck } from "../src/checks/security.js";
 import { SECURITY_RULES, CREDENTIAL_PATTERNS, type ToolInfo } from "../src/checks/security-rules.js";
 
 function findRule(id: string) {
@@ -138,5 +139,45 @@ describe("credential patterns", () => {
   it("does not false-positive on normal text", () => {
     const text = "The weather is sunny and 72 degrees.";
     expect(CREDENTIAL_PATTERNS.some(p => p.pattern.test(text))).toBe(false);
+  });
+});
+
+describe("security check evidence", () => {
+  it("emits structured findings", () => {
+    const check = runLightweightSecurityCheck([
+      {
+        name: "exec_query",
+        inputSchema: { type: "object", properties: { command: { type: "string" } } },
+      },
+    ], {
+      targetId: "test",
+      adapter: "local-process",
+      command: "node",
+      args: ["server.js"],
+    });
+
+    const evidence = check.result.evidence[0]!;
+    expect(evidence.findings?.[0]?.["ruleId"]).toBe("shell-injection");
+    expect(check.result.status).toBe("fail");
+  });
+
+  it("honors security suppressions by rule id and tool name", () => {
+    const check = runLightweightSecurityCheck([
+      {
+        name: "exec_query",
+        inputSchema: { type: "object", properties: { command: { type: "string" } } },
+      },
+    ], {
+      targetId: "test",
+      adapter: "local-process",
+      command: "node",
+      args: ["server.js"],
+      securitySuppressions: ["shell-injection"],
+    });
+
+    const evidence = check.result.evidence[0]!;
+    expect(evidence.findings).toBeUndefined();
+    expect(evidence.itemCount).toBe(0);
+    expect(check.result.status).toBe("pass");
   });
 });

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -99,5 +99,16 @@ describe("telemetry", () => {
       expect(event.nodeVersion).toBe(process.version);
       expect(event.version).toBeDefined();
     });
+
+    it("includes declared org and contact when provided", async () => {
+      vi.stubEnv("MCP_OBSERVATORY_ORG", "example.com");
+      vi.stubEnv("MCP_OBSERVATORY_CONTACT", "ops@example.com");
+      const { buildEvent, collectUserIdentity, _resetIdentityCache } = await import("../src/telemetry.js");
+      _resetIdentityCache();
+      await collectUserIdentity();
+      const event = buildEvent("command_run", "scan", "cli");
+      expect(event.org).toBe("example.com");
+      expect(event.contact).toBe("ops@example.com");
+    });
   });
 });

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -1,7 +1,13 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { validateTargetConfig } from "../src/validate.js";
 
 describe("validateTargetConfig", () => {
+  afterEach(() => {
+    delete process.env["MCP_TEST_TOKEN"];
+    delete process.env["MCP_TEST_HEADER"];
+    delete process.env["MCP_TEST_ENV"];
+  });
+
   it("validates a correct local-process config", () => {
     const config = validateTargetConfig({
       targetId: "test",
@@ -25,5 +31,50 @@ describe("validateTargetConfig", () => {
 
   it("throws on non-object input", () => {
     expect(() => validateTargetConfig("not an object")).toThrow();
+  });
+
+  it("expands environment references in HTTP auth fields", () => {
+    process.env["MCP_TEST_TOKEN"] = "token-123";
+    process.env["MCP_TEST_HEADER"] = "header-456";
+    const config = validateTargetConfig({
+      targetId: "http-test",
+      adapter: "http",
+      url: "https://mcp.example.com",
+      authToken: "${MCP_TEST_TOKEN}",
+      headers: {
+        "X-Api-Key": "$MCP_TEST_HEADER",
+      },
+    });
+    expect(config.adapter).toBe("http");
+    if (config.adapter !== "http") throw new Error("Expected http config");
+    expect(config.authToken).toBe("token-123");
+    expect(config.headers?.["X-Api-Key"]).toBe("header-456");
+  });
+
+  it("expands local-process env references", () => {
+    process.env["MCP_TEST_ENV"] = "secret-env";
+    const config = validateTargetConfig({
+      targetId: "local-test",
+      adapter: "local-process",
+      command: "node",
+      args: ["server.js"],
+      env: {
+        API_TOKEN: "env:MCP_TEST_ENV",
+      },
+      securitySuppressions: ["shell-injection", "dangerous_tool:permissive-schema"],
+    });
+    expect(config.adapter).toBe("local-process");
+    if (config.adapter !== "local-process") throw new Error("Expected local-process config");
+    expect(config.env?.["API_TOKEN"]).toBe("secret-env");
+    expect(config.securitySuppressions).toEqual(["shell-injection", "dangerous_tool:permissive-schema"]);
+  });
+
+  it("throws when an env reference is missing", () => {
+    expect(() => validateTargetConfig({
+      targetId: "http-test",
+      adapter: "http",
+      url: "https://mcp.example.com",
+      authToken: "${MCP_TEST_TOKEN}",
+    })).toThrow("MCP_TEST_TOKEN");
   });
 });


### PR DESCRIPTION
## Summary
- fix CI and GitHub Action reliability so real-server matrix jobs fail fast with artifacts instead of hanging
- sync package/server metadata to the published v0.20.3 release
- update vulnerable dev tooling dependencies and add Dependabot maintenance
- add SECURITY.md and close the public security-advisory request after enabling private vulnerability reporting
- add reversible commercialization surfaces: README pricing CTA, `COMMERCIAL.md`, `PRIVACY.md`, `TERMS.md`, and distribution launch materials
- add low-lift production hooks with the `cloud` command, contextual CLI CTAs, and `MCP_OBSERVATORY_CLOUD_TOKEN` placeholder
- add `enterprise-report` for static production/security pilot reports before building SaaS
- make `test --target <config.json>` public for HTTP/internal MCP targets
- add `MCP_OBSERVATORY_ORG` and `MCP_OBSERVATORY_CONTACT` attribution fields
- improve telemetry account-intelligence ranking/filtering for production-looking company signals
- add Feishu/Lark MCP guide and enterprise outreach playbook

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test` (306 passed)
- `npm audit --json` reports 0 vulnerabilities on this branch
- `npm run telemetry:intelligence -- --input telemetry-exports/events-flat-full.json --out-dir reports`
- `npm run cli -- enterprise-report --account "MCP Observatory pilot" --format markdown`
- GitHub PR checks on latest commit: `test-action` passed, `verify` passed

## Operational notes
- PR #88 is mergeable.
- Local telemetry backend was updated separately: D1 now has `org` and `contact` columns, Worker version `47890dab-f1e9-46a3-9df9-f89e920ec280` is deployed, and a synthetic attribution event was verified then deleted.
- Telemetry intelligence outputs are ignored under `reports/` and `telemetry-exports/`; do not commit raw telemetry exports or account maps.
- The strongest external account signal remains `thinkingdata.cn`: 183 events / 119 sessions, Enterprise tier, high confidence, private-network target signal.
