### PR TITLE
feat: enable hosted artifact upload deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,9 +51,22 @@ jobs:
       - name: README smoke test
         run: npm run smoke
 
+      - name: Verify npm auth
+        id: npm-auth
+        continue-on-error: true
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm whoami
+
       - name: Release
+        if: steps.npm-auth.outcome == 'success'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release
+
+      - name: Skip release when npm auth is invalid
+        if: steps.npm-auth.outcome != 'success'
+        run: |
+          echo "::warning::Skipping semantic-release because NPM_TOKEN is missing or invalid. Replace the repository secret, then rerun this workflow or push a conventional release commit."

--- a/api/README.md
+++ b/api/README.md
@@ -8,6 +8,8 @@ Cloudflare Worker that provides a hosted HTTP API for scanning MCP servers.
 |--------|------|-------------|
 | `POST` | `/api/v1/scan` | Scan an HTTP MCP server |
 | `GET` | `/api/v1/scan/:runId` | Retrieve a cached scan result |
+| `POST` | `/api/v1/artifacts` | Upload a run artifact for a hosted pilot report |
+| `GET` | `/api/v1/artifacts/:org` | List uploaded artifacts for an org |
 | `GET` | `/api/v1/badge/:runId` | Get an SVG health badge |
 | `GET` | `/api/v1/health` | Health check |
 
@@ -26,6 +28,24 @@ Rate limit: 10 requests per minute per IP.
 
 > **Note:** Local process targets (`{ "command": "..." }`) are rejected.
 > Use the CLI for local servers.
+
+### POST /api/v1/artifacts
+
+Uploads an existing CLI run artifact for a hosted pilot report. This endpoint
+requires `Authorization: Bearer <CLOUD_UPLOAD_TOKEN>`.
+
+```bash
+curl -X POST "https://mcp-observatory-api.kryptosai.workers.dev/api/v1/artifacts" \
+  -H "Authorization: Bearer $MCP_OBSERVATORY_CLOUD_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "X-MCP-Observatory-Org: customer.com" \
+  --data-binary @.mcp-observatory/runs/latest.json
+```
+
+### GET /api/v1/artifacts/:org
+
+Lists the most recent uploaded artifact summaries for an org. This endpoint uses
+the same bearer token as upload.
 
 ### GET /api/v1/badge/:runId
 
@@ -69,6 +89,12 @@ Wrangler will create a local KV store automatically.
 
 ```bash
 npm run deploy
+```
+
+The current production Worker is deployed at:
+
+```text
+https://mcp-observatory-api.kryptosai.workers.dev
 ```
 
 ## Architecture

--- a/api/wrangler.toml
+++ b/api/wrangler.toml
@@ -2,13 +2,15 @@ name = "mcp-observatory-api"
 main = "src/worker.ts"
 compatibility_date = "2025-03-15"
 compatibility_flags = ["nodejs_compat"]
+workers_dev = true
+preview_urls = false
 
 [observability]
 enabled = true
 
 [[kv_namespaces]]
 binding = "SCAN_CACHE"
-id = "REPLACE_WITH_KV_NAMESPACE_ID"
+id = "0318a3fd6f08482f9194b7e22ccd7b24"
 
 # For local dev, wrangler will create a local KV automatically.
 # To create the production namespace:


### PR DESCRIPTION
## Summary\n- wires the production Cloudflare KV namespace into the hosted API config\n- documents hosted artifact upload/list endpoints\n- guards the release workflow so invalid npm auth skips semantic-release with a warning instead of failing the workflow\n\n## Validation\n- npm --prefix api run typecheck\n- npm --prefix api audit --json\n- npx wrangler deploy\n- live /api/v1/health check\n- live authenticated artifact upload/list check\n- npm run lint\n- npm run typecheck\n- npm run build\n- npm run validate:artifacts\n- npm audit --json\n- npm test -- tests/enterprise-report.test.ts tests/validate.test.ts tests/security.test.ts