### PR TITLE
fix: make release auth skip warning-only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,13 +53,17 @@ jobs:
 
       - name: Verify npm auth
         id: npm-auth
-        continue-on-error: true
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm whoami
+        run: |
+          if npm whoami; then
+            echo "valid=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "valid=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Release
-        if: steps.npm-auth.outcome == 'success'
+        if: steps.npm-auth.outputs.valid == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -67,6 +71,6 @@ jobs:
         run: npx semantic-release
 
       - name: Skip release when npm auth is invalid
-        if: steps.npm-auth.outcome != 'success'
+        if: steps.npm-auth.outputs.valid != 'true'
         run: |
           echo "::warning::Skipping semantic-release because NPM_TOKEN is missing or invalid. Replace the repository secret, then rerun this workflow or push a conventional release commit."


### PR DESCRIPTION
## Summary\n- changes the release workflow npm auth preflight to set an output instead of returning a failed step\n- keeps semantic-release skipped with a warning while NPM_TOKEN is invalid\n- allows release to run automatically once NPM_TOKEN is replaced\n\n## Validation\n- release workflow syntax inspected\n- previous main release now completes successfully, this removes the red npm auth annotation