### PR TITLE
chore: stabilize real-server matrix timeouts

### DIFF
--- a/examples/targets/context7-server.json
+++ b/examples/targets/context7-server.json
@@ -7,7 +7,7 @@
     "@upstash/context7-mcp"
   ],
   "cwd": ".",
-  "timeoutMs": 20000,
+  "timeoutMs": 60000,
   "metadata": {
     "package": "@upstash/context7-mcp",
     "purpose": "real-server-smoke",

--- a/examples/targets/everything-server.json
+++ b/examples/targets/everything-server.json
@@ -7,7 +7,7 @@
     "@modelcontextprotocol/server-everything"
   ],
   "cwd": ".",
-  "timeoutMs": 15000,
+  "timeoutMs": 60000,
   "metadata": {
     "package": "@modelcontextprotocol/server-everything",
     "purpose": "real-server-smoke",

--- a/examples/targets/puppeteer-server.json
+++ b/examples/targets/puppeteer-server.json
@@ -7,7 +7,7 @@
     "puppeteer-mcp-server"
   ],
   "cwd": ".",
-  "timeoutMs": 20000,
+  "timeoutMs": 60000,
   "securitySuppressions": [
     "puppeteer_evaluate:shell-injection"
   ],

--- a/examples/targets/ref-tools-server.json
+++ b/examples/targets/ref-tools-server.json
@@ -7,7 +7,7 @@
     "ref-tools-mcp"
   ],
   "cwd": ".",
-  "timeoutMs": 15000,
+  "timeoutMs": 60000,
   "metadata": {
     "package": "ref-tools-mcp",
     "purpose": "real-server-smoke",


### PR DESCRIPTION
## Summary

- Increase cold-start timeouts for real-server proof targets that timed out on GitHub-hosted runners.
- Keeps the matrix bounded by the existing workflow step timeout while avoiding false red runs from first-run `npx` installs/startup.

## Validation

- `npm run validate:artifacts`
