### PR TITLE
chore: allow manual release reruns

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: release
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
 


### PR DESCRIPTION
## Summary

- Add `workflow_dispatch` to the release workflow so publishing can be retried manually after npm Trusted Publishing is configured.

## Validation

- Parsed `.github/workflows/release.yml` with Ruby YAML loader.
