### PR TITLE
Launch MCP Observatory growth blitz

### DIFF
--- a/COMMERCIAL.md
+++ b/COMMERCIAL.md
@@ -60,6 +60,7 @@ MCP_OBSERVATORY_CONTACT=mcp-owner@customer.com
 ```
 
 Use the [enterprise outreach playbook](./docs/enterprise-outreach-playbook.md) to route high-confidence company usage to manual pilots without sending generic low-tier pricing to major accounts.
+Use [public proof](./docs/proof.md) and the [project case study](./docs/project-case-study.md) for customer-safe credibility. Do not expose private telemetry rows in outreach.
 
 ## Enterprise Framing
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -7,7 +7,7 @@ MCP Observatory collects product usage telemetry unless telemetry is disabled. T
 - Command names and feature flags
 - MCP target or server names
 - Counts of tools, prompts, resources, servers, checks, and failures
-- CI environment signals such as provider and repository metadata when available
+- CI environment signals such as provider and GitHub Actions metadata when available, including repository, workflow, run ID, run number, event name, ref, and actor
 - Declared account attribution from `MCP_OBSERVATORY_ORG` and `MCP_OBSERVATORY_CONTACT` when operators set them
 - Git metadata such as `gitEmail` and `gitRemoteUrl` when available
 - Hostname and operating system metadata
@@ -42,6 +42,8 @@ MCP_OBSERVATORY_CONTACT=mcp-owner@example.com
 We may use telemetry internally to identify likely company or organization usage, including by deriving company domains from git email domains, git remote URLs, CI usage, target names, repeated sessions, and production-looking command patterns.
 
 Raw emails are not intended for public reporting. Account intelligence outputs should use company domains, GitHub organizations, aggregate counts, confidence levels, and outreach status rather than raw personal identifiers.
+
+Internal usage reports separate first-party MCP Observatory project activity from external usage. Events from `KryptosAI/mcp-observatory` GitHub Actions are treated as first-party CI so release and test workflows are not counted as external traction.
 
 ## Enterprise Controls
 

--- a/README.md
+++ b/README.md
@@ -18,17 +18,44 @@
 [![Smithery](https://smithery.ai/badge/@kryptosai/mcp-observatory)](https://smithery.ai/server/@kryptosai/mcp-observatory)
 [![mcp-observatory MCP server](https://glama.ai/mcp/servers/KryptosAI/mcp-observatory/badges/score.svg)](https://glama.ai/mcp/servers/KryptosAI/mcp-observatory)
 
-**The first testing tool that is itself an MCP server.** Your AI agent can scan, test, record, replay, and verify other MCP servers autonomously — catching regressions, schema drift, and security issues without human intervention.
+**Test, secure, and monitor MCP servers before agents depend on them.**
 
-Use it as a CLI, a CI action, or give it to your agent as an MCP server and let it test your other servers for you.
+MCP Observatory gives MCP servers the production safety rails every dependency eventually needs: CI checks, security scans, schema drift detection, PR reports, score badges, and agent-accessible diagnostics.
 
-MCP Observatory helps teams test, secure, and monitor MCP servers before agents depend on them.
+Add MCP CI in one command:
+
+```bash
+npx @kryptosai/mcp-observatory init-ci --command "npx -y my-mcp-server" --badge
+```
+
+Or test a server immediately:
+
+```bash
+npx @kryptosai/mcp-observatory test npx -y @modelcontextprotocol/server-everything
+```
+
+Use it as a CLI, a GitHub Action, or an MCP server that lets your AI agent scan, test, record, replay, and verify other MCP servers autonomously.
 
 <p align="center">
   <img src="./docs/demo.svg" alt="MCP Observatory scan output" width="820">
 </p>
 
 [![Observatory MCP server](https://glama.ai/mcp/servers/KryptosAI/mcp-observatory/badges/card.svg)](https://glama.ai/mcp/servers/KryptosAI/mcp-observatory)
+
+## Why MCP Observatory
+
+MCP servers are becoming production dependencies. If agents rely on them, teams need a way to catch broken tools, unsafe schemas, schema drift, slow responses, and security footguns before those failures reach users.
+
+Observatory gives maintainers and teams:
+
+- **One-command CI setup** with `init-ci`
+- **GitHub PR comments** for compatibility, drift, and security findings
+- **Health score badges** for public trust signals
+- **Record/replay/verify** workflows for regression testing
+- **MCP server mode** so agents can inspect other MCP servers directly
+- **Production pilot path** for hosted history, private repo reporting, certification, support, and fleet visibility
+
+See [public proof](./docs/proof.md), the [MCP safety report](./docs/mcp-safety-report-latest.md), the [certification distribution loop](./docs/certification-distribution.md), and [commercial pilots](./COMMERCIAL.md).
 
 ## Production / Enterprise
 
@@ -44,6 +71,7 @@ Free for local OSS use. Paid pilots are available for hosted reporting, private 
 Run `npx @kryptosai/mcp-observatory cloud` or contact `william@banksey.com` for production MCP usage.
 
 See [commercial pilots](./COMMERCIAL.md), [privacy and telemetry](./PRIVACY.md), and [terms for production use](./TERMS.md).
+For a fuller narrative, see the [project case study](./docs/project-case-study.md).
 
 ## Quick Start
 
@@ -101,6 +129,7 @@ Or add it manually to your config:
 | `lock` | Snapshot MCP server schemas into a lock file |
 | `lock verify` | Verify live servers match the lock file |
 | `history` | Show health score trends for your MCP servers |
+| `init-ci` | Create a GitHub Action and badge snippet for MCP compatibility/security checks |
 | `ci-report` | Generate CI report for GitHub issue creation |
 | `enterprise-report` | Generate a static production/security report from run artifacts |
 | `score <cmd>` | Score an MCP server's health (0-100) |
@@ -171,6 +200,12 @@ When you run `scan`, it looks for MCP configs in:
 
 Add Observatory to your MCP server's CI pipeline:
 
+```bash
+npx @kryptosai/mcp-observatory init-ci --command "npx -y my-mcp-server" --badge
+```
+
+Or create the workflow manually:
+
 ```yaml
 # .github/workflows/observatory.yml
 name: MCP Server Check
@@ -205,6 +240,22 @@ Action inputs:
 The action runs checks on every PR, comments a markdown report, and blocks merge on regressions. See [`action/README.md`](./action/README.md) for all options.
 
 Production teams can add hosted CI history, private-repo reporting, security reports, production monitoring, support, and fleet visibility. Run `npx @kryptosai/mcp-observatory cloud` for pilot options.
+
+### Certified by MCP Observatory
+
+MCP server maintainers can add a public compatibility/security signal to their README:
+
+```md
+[![MCP Observatory](https://img.shields.io/badge/MCP%20Observatory-enabled-2563eb)](https://github.com/KryptosAI/mcp-observatory)
+```
+
+Or generate a score badge from a live check:
+
+```bash
+npx @kryptosai/mcp-observatory badge npx -y my-mcp-server --output docs/mcp-health.svg
+```
+
+See the [certification distribution loop](./docs/certification-distribution.md) for the GitHub Action template, maintainer PR body, and badge rollout playbook.
 
 Generate a pilot-ready production/security report from local run artifacts:
 

--- a/docs/certification-campaign-template.md
+++ b/docs/certification-campaign-template.md
@@ -1,0 +1,167 @@
+# MCP Observatory Certification Campaign
+
+Use this tracker for outbound PR waves against MCP server repositories.
+
+## Campaign Goal
+
+Open helpful PRs that add MCP Observatory CI checks and a public compatibility/security badge to popular MCP server projects.
+
+One-shot campaign target:
+
+- 50 researched repos
+- 25 PRs opened
+- 10 accepted checks or badges
+- 5 public proof points added to launch materials
+- 3 production/security pilot conversations started
+
+## Qualification Rules
+
+Prioritize:
+
+- active MCP server repos
+- clear install/run command
+- recent commit or release in the last 90 days
+- 100+ stars, meaningful npm downloads, directory popularity, or enterprise category
+- developer tools, security, CI/CD, database, browser automation, SaaS, cloud, or finance servers
+
+Skip:
+
+- servers that require private credentials to start
+- repos with destructive default tools
+- abandoned repos unless they have major download volume
+- projects that already have equivalent MCP compatibility/security CI
+
+## Tracker
+
+| Priority | Repo | Package/Command | Category | Stars/Downloads/Listing Signal | Activity Signal | Risk Notes | Status | PR URL | Accepted/Badge/Proof |
+| ---: | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | `owner/repo` | `npx -y package` | Security | | | | researched | | |
+| 2 | `owner/repo` | `npx -y package` | Developer Tools | | | | researched | | |
+| 3 | `owner/repo` | `uvx package` | Browser Automation | | | | researched | | |
+| 4 | `owner/repo` | `docker run image` | Database | | | | researched | | |
+| 5 | `owner/repo` | `npx -y package` | Cloud | | | | researched | | |
+| 6 | `owner/repo` | `npx -y package` | SaaS | | | | researched | | |
+| 7 | `owner/repo` | `uvx package` | Finance | | | | researched | | |
+| 8 | `owner/repo` | `npx -y package` | Developer Tools | | | | researched | | |
+| 9 | `owner/repo` | `npx -y package` | Security | | | | researched | | |
+| 10 | `owner/repo` | `docker run image` | Infrastructure | | | | researched | | |
+| 11 | `owner/repo` | `npx -y package` | Developer Tools | | | | researched | | |
+| 12 | `owner/repo` | `uvx package` | Data | | | | researched | | |
+| 13 | `owner/repo` | `npx -y package` | Search | | | | researched | | |
+| 14 | `owner/repo` | `npx -y package` | Filesystem | | | | researched | | |
+| 15 | `owner/repo` | `docker run image` | Browser Automation | | | | researched | | |
+| 16 | `owner/repo` | `npx -y package` | API | | | | researched | | |
+| 17 | `owner/repo` | `uvx package` | Security | | | | researched | | |
+| 18 | `owner/repo` | `npx -y package` | Database | | | | researched | | |
+| 19 | `owner/repo` | `npx -y package` | Developer Tools | | | | researched | | |
+| 20 | `owner/repo` | `docker run image` | Cloud | | | | researched | | |
+| 21 | `owner/repo` | `npx -y package` | SaaS | | | | researched | | |
+| 22 | `owner/repo` | `uvx package` | Data | | | | researched | | |
+| 23 | `owner/repo` | `npx -y package` | Security | | | | researched | | |
+| 24 | `owner/repo` | `npx -y package` | Developer Tools | | | | researched | | |
+| 25 | `owner/repo` | `docker run image` | Infrastructure | | | | researched | | |
+| 26 | `owner/repo` | `npx -y package` | Browser Automation | | | | researched | | |
+| 27 | `owner/repo` | `uvx package` | API | | | | researched | | |
+| 28 | `owner/repo` | `npx -y package` | Database | | | | researched | | |
+| 29 | `owner/repo` | `npx -y package` | Search | | | | researched | | |
+| 30 | `owner/repo` | `docker run image` | Cloud | | | | researched | | |
+| 31 | `owner/repo` | `npx -y package` | Developer Tools | | | | researched | | |
+| 32 | `owner/repo` | `uvx package` | Security | | | | researched | | |
+| 33 | `owner/repo` | `npx -y package` | SaaS | | | | researched | | |
+| 34 | `owner/repo` | `npx -y package` | Data | | | | researched | | |
+| 35 | `owner/repo` | `docker run image` | Infrastructure | | | | researched | | |
+| 36 | `owner/repo` | `npx -y package` | Finance | | | | researched | | |
+| 37 | `owner/repo` | `uvx package` | Browser Automation | | | | researched | | |
+| 38 | `owner/repo` | `npx -y package` | API | | | | researched | | |
+| 39 | `owner/repo` | `npx -y package` | Database | | | | researched | | |
+| 40 | `owner/repo` | `docker run image` | Security | | | | researched | | |
+| 41 | `owner/repo` | `npx -y package` | Developer Tools | | | | researched | | |
+| 42 | `owner/repo` | `uvx package` | Data | | | | researched | | |
+| 43 | `owner/repo` | `npx -y package` | Search | | | | researched | | |
+| 44 | `owner/repo` | `npx -y package` | SaaS | | | | researched | | |
+| 45 | `owner/repo` | `docker run image` | Cloud | | | | researched | | |
+| 46 | `owner/repo` | `npx -y package` | Filesystem | | | | researched | | |
+| 47 | `owner/repo` | `uvx package` | Security | | | | researched | | |
+| 48 | `owner/repo` | `npx -y package` | Developer Tools | | | | researched | | |
+| 49 | `owner/repo` | `npx -y package` | Infrastructure | | | | researched | | |
+| 50 | `owner/repo` | `docker run image` | Browser Automation | | | | researched | | |
+
+Statuses:
+
+- `researched`
+- `branch-ready`
+- `pr-opened`
+- `accepted`
+- `declined`
+- `needs-maintainer-input`
+- `proof-captured`
+- `pilot-lead`
+
+## PR Checklist
+
+- Add `.github/workflows/mcp-observatory.yml`
+- Use `deep: true` and `security: true`
+- Keep `fail-on-regression: true` unless the repo is noisy
+- Add README badge only when it fits the repo style
+- Include the maintainer PR body from `certification-distribution.md`
+- Do not include raw telemetry, private evidence, or sales pricing
+
+## PR Templates
+
+### Workflow-Only PR
+
+```md
+This adds a lightweight MCP Observatory check for this MCP server.
+
+Why it helps:
+
+- verifies MCP tools/prompts/resources still respond correctly
+- catches schema drift and common security footguns before release
+- posts a readable PR report for maintainers
+- gives users a compatibility signal when evaluating MCP servers
+
+It runs in GitHub Actions and does not require an account. If the check is too strict for this repo, `fail-on-regression: false` can be used while keeping the report visible.
+```
+
+### Workflow + Badge PR
+
+```md
+This adds MCP Observatory CI plus a small README badge so users can see this server is checked for MCP compatibility, schema drift, and common security issues.
+
+The workflow runs on PRs and pushes to `main`. The badge links back to MCP Observatory for context and can be removed if it does not fit the repo style.
+```
+
+### Issue-Only Fallback
+
+```md
+I tried preparing a small MCP Observatory CI check for this server, but did not want to open a PR without confirming the safest startup command.
+
+Would you accept a workflow that runs:
+
+```bash
+npx @kryptosai/mcp-observatory test <server command> --security --deep
+```
+
+The goal is to give users a visible compatibility/security signal and catch schema drift before releases.
+```
+
+## Proof Capture
+
+For accepted PRs, record:
+
+- repo
+- PR URL
+- category
+- accepted date
+- badge added: yes/no
+- CI status
+- quote or maintainer reaction if public
+- whether the repo appears in Glama, PulseMCP, Smithery, or awesome-MCP lists
+
+Use accepted PRs as proof for:
+
+- README traction section
+- launch posts
+- enterprise outreach
+- directory listing copy
+- weekly MCP safety report

--- a/docs/certification-distribution.md
+++ b/docs/certification-distribution.md
@@ -1,0 +1,125 @@
+# Certification Distribution Loop
+
+Use this when opening helpful PRs to MCP server projects. The motion is simple: run MCP Observatory, give the maintainer a useful security/compatibility check, and leave them with a badge/report they can keep.
+
+## Offer
+
+MCP Observatory gives MCP server maintainers:
+
+- CI coverage for tools, prompts, resources, schema quality, and security checks
+- A PR comment report on every change
+- A README badge they can show publicly
+- A local-first OSS path with no account required
+- A paid production path only if they need hosted history, private repo reporting, support, certification, or fleet visibility
+
+## Copy-Paste Badge
+
+For repos that add the GitHub Action, suggest this README badge:
+
+```md
+[![MCP Observatory](https://img.shields.io/badge/MCP%20Observatory-enabled-2563eb)](https://github.com/KryptosAI/mcp-observatory)
+```
+
+For repos that generate a score badge, suggest:
+
+```bash
+npx @kryptosai/mcp-observatory badge npx -y <server-package> --output docs/mcp-health.svg
+```
+
+```md
+[![MCP Health](./docs/mcp-health.svg)](https://github.com/KryptosAI/mcp-observatory)
+```
+
+## GitHub Action Template
+
+Fast path:
+
+```bash
+npx @kryptosai/mcp-observatory init-ci --command "npx -y <server-package>" --badge
+```
+
+That creates:
+
+- `.github/workflows/mcp-observatory.yml`
+- `docs/mcp-observatory-badge.md`
+
+Manual template:
+
+```yaml
+name: MCP Observatory
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  mcp-observatory:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: KryptosAI/mcp-observatory/action@main
+        with:
+          command: npx -y <server-package>
+          deep: true
+          security: true
+          comment-on-pr: true
+```
+
+For repos with a local target config:
+
+```yaml
+- uses: KryptosAI/mcp-observatory/action@main
+  with:
+    target: ./observatory-target.json
+    deep: true
+    security: true
+```
+
+## Maintainer PR Body
+
+```md
+This adds a lightweight MCP Observatory check for this server.
+
+Why it helps:
+
+- verifies MCP tools/prompts/resources still respond correctly
+- catches schema drift and common security footguns before release
+- posts a readable PR report for maintainers
+- creates a public compatibility signal for users evaluating MCP servers
+
+It runs locally/inside GitHub Actions and does not require an account. If the check is too strict for this repo, `fail-on-regression: false` can be used while keeping the PR report visible.
+```
+
+## Comment For Passing Repos
+
+```md
+Nice, this server passes MCP Observatory checks. If you want the signal in the README, you can add:
+
+```md
+[![MCP Observatory](https://img.shields.io/badge/MCP%20Observatory-enabled-2563eb)](https://github.com/KryptosAI/mcp-observatory)
+```
+
+That gives users a quick compatibility/security signal when they are choosing MCP servers.
+```
+
+## Targeting Order
+
+Prioritize repos with:
+
+- 100+ GitHub stars or visible npm downloads
+- active releases in the last 90 days
+- MCP servers used by developer tools, security, CI/CD, databases, browser automation, or enterprise SaaS
+- no existing MCP compatibility/security CI
+- clear package command that can run in GitHub Actions
+
+Avoid drive-by PRs where the server requires private credentials, paid services, or destructive default actions.
+
+## Directory Follow-Through
+
+After a repo accepts the check or badge:
+
+- ask the maintainer to mention “tested with MCP Observatory” in their MCP directory listing
+- update the MCP Observatory launch/story docs with the accepted repo
+- use accepted PRs as proof in enterprise outreach
+- invite production users to hosted reporting or certification pilots

--- a/docs/directory-listing-copy.md
+++ b/docs/directory-listing-copy.md
@@ -1,0 +1,78 @@
+# Directory And Marketplace Listing Copy
+
+## Standard Positioning
+
+MCP Observatory helps teams test, secure, and monitor MCP servers before agents depend on them.
+
+## Short Description
+
+CI, security checks, schema drift detection, reports, and badges for MCP servers.
+
+## Medium Description
+
+MCP Observatory is a CLI, GitHub Action, and MCP server for testing MCP servers before agents depend on them. It checks tools, prompts, resources, schema quality, security footguns, regressions, and drift, then generates reports and badges maintainers can share.
+
+## Long Description
+
+MCP Observatory gives MCP servers production safety rails: one-command CI setup, compatibility checks, security analysis, schema drift detection, record/replay/verify workflows, PR comments, health score badges, and static enterprise reports. It can run as a CLI, inside GitHub Actions, or as an MCP server that lets agents inspect other MCP servers.
+
+Free for local OSS use. Paid pilots are available for hosted reporting, private repo CI history, recurring security reports, certification, support, and fleet visibility.
+
+## Primary CTA
+
+Add MCP CI in one command:
+
+```bash
+npx @kryptosai/mcp-observatory init-ci --command "npx -y my-mcp-server" --badge
+```
+
+## Tags
+
+### GitHub Topics
+
+- `mcp`
+- `model-context-protocol`
+- `mcp-server`
+- `mcp-testing`
+- `mcp-security`
+- `mcp-ci`
+- `schema-drift`
+- `developer-tools`
+- `security`
+- `github-action`
+
+### Directory Tags
+
+- MCP
+- Model Context Protocol
+- Security
+- Developer Tools
+- Testing
+- CI/CD
+- Observability
+- Schema Drift
+- Regression Testing
+- AI Agents
+
+### npm Keywords
+
+- `mcp`
+- `mcp-server`
+- `model-context-protocol`
+- `mcp-testing`
+- `mcp-security`
+- `mcp-ci`
+- `schema-drift`
+- `github-action`
+- `developer-tools`
+- `security`
+- `production-monitoring`
+- `enterprise-report`
+
+## Links
+
+- README: `https://github.com/KryptosAI/mcp-observatory#readme`
+- GitHub Action: `https://github.com/KryptosAI/mcp-observatory/tree/main/action`
+- Certification guide: `https://github.com/KryptosAI/mcp-observatory/blob/main/docs/certification-distribution.md`
+- Proof: `https://github.com/KryptosAI/mcp-observatory/blob/main/docs/proof.md`
+- Commercial pilots: `https://github.com/KryptosAI/mcp-observatory/blob/main/COMMERCIAL.md`

--- a/docs/distribution-launch.md
+++ b/docs/distribution-launch.md
@@ -3,6 +3,8 @@
 Use this as the reversible launch motion for MCP Observatory commercialization.
 
 For the release gate and publication checklist, see [Publish And Distribution Readiness](./publish-readiness.md).
+For listing copy, use [Directory And Marketplace Listing Copy](./directory-listing-copy.md).
+For public proof, use [MCP Observatory Proof](./proof.md).
 
 ## Positioning
 
@@ -16,6 +18,7 @@ MCP Observatory helps teams test, secure, and monitor MCP servers before agents 
 - MCP directory listings updated with production/security language
 - Launch post published
 - Badge or certification language available for passing servers
+- Certification distribution loop published at [`docs/certification-distribution.md`](./certification-distribution.md)
 
 ## Launch Post Draft
 
@@ -40,6 +43,22 @@ We are running a small number of production pilots for hosted reports, private r
 Would it be useful to compare what your MCP servers look like today and where regressions or production risk could show up?
 
 William
+
+## Helpful Maintainer PR Motion
+
+For popular MCP server repositories, open small PRs that add:
+
+- `.github/workflows/mcp-observatory.yml`
+- optional README badge
+- a short PR body explaining the security/compatibility benefit
+
+Frame this as free OSS safety infrastructure:
+
+> I added a lightweight MCP Observatory check so users can see this server is tested for compatibility, schema drift, and common security issues. It runs in GitHub Actions, comments a readable report on PRs, and does not require an account.
+
+Use the full template in [`certification-distribution.md`](./certification-distribution.md).
+
+Track each outbound wave with [`certification-campaign-template.md`](./certification-campaign-template.md).
 
 ## Account Ranking Inputs
 

--- a/docs/enterprise-outreach-playbook.md
+++ b/docs/enterprise-outreach-playbook.md
@@ -6,6 +6,8 @@ Use this playbook after running:
 npm run telemetry:intelligence -- --input telemetry-exports/events-flat-full.json --out-dir reports
 ```
 
+Start from `reports/telemetry-usage-summary.html` to confirm external usage before reading account rankings. Do not treat first-party CI, release workflows, or internal/personal sessions as market traction.
+
 Do not include raw personal emails in public issues, posts, or docs. Use account domains, GitHub orgs, and aggregate telemetry evidence.
 
 ## Priority Accounts
@@ -68,12 +70,14 @@ npx @kryptosai/mcp-observatory enterprise-report \
 
 Include only aggregate facts:
 
+- company or GitHub organization domain
 - event count
 - unique sessions
 - first seen / last seen
 - commands used
 - targets seen
 - CI/private-network/security signals
+- confidence
 - recommended pilot tier
 
 Do not include raw hostnames, personal emails, tokens, or private URLs in external outreach.

--- a/docs/mcp-safety-report-latest.md
+++ b/docs/mcp-safety-report-latest.md
@@ -1,0 +1,85 @@
+# MCP Safety Report
+
+Latest generated baseline: June 19, 2026.
+
+MCP servers are becoming production dependencies. When agents depend on a server, that server needs repeatable compatibility checks, security review, schema drift detection, and visible trust signals.
+
+## What Observatory Checks
+
+MCP Observatory checks:
+
+- tools, prompts, and resources list/respond correctly
+- advertised capabilities match observed behavior
+- safe read-only tools can be invoked
+- schemas are usable by agents
+- security footguns are visible before production use
+- runs can be compared for regressions and schema drift
+- artifacts can be rendered as JSON, Markdown, HTML, JUnit, SARIF, or PR comments
+
+## Aggregate Usage Snapshot
+
+Safe aggregate telemetry from the latest local export:
+
+| Metric | Value |
+| --- | ---: |
+| Total telemetry events | 10,278 |
+| Unique sessions | 7,211 |
+| External sessions | 5,368 |
+| External CI sessions | 2,434 |
+| Attributed company/org sessions | 128 |
+
+Top external commands:
+
+1. `serve`
+2. `run`
+3. `diff`
+4. `test`
+5. `scan`
+6. `history`
+
+No raw emails, hostnames, private URLs, tokens, or response bodies are included in this report.
+
+## Common MCP Failure Classes
+
+From public sample artifacts and Observatory check categories, the most important failure classes are:
+
+- server startup failure
+- malformed or missing tools/list, prompts/list, or resources/list responses
+- schema quality issues that make tools harder for agents to call correctly
+- regressions between two runs
+- unexpected drift from a recorded baseline
+- broad filesystem/network/security-sensitive tool surfaces
+- slow or unreliable connection behavior
+
+## How Maintainers Add The Check
+
+```bash
+npx @kryptosai/mcp-observatory init-ci --command "npx -y my-mcp-server" --badge
+```
+
+That creates a GitHub Action and a README badge snippet. The action can comment on PRs and fail when MCP compatibility or security checks regress.
+
+## Production Path
+
+Production teams can use MCP Observatory for:
+
+- private repo CI history
+- hosted reporting
+- recurring security reports
+- MCP certification
+- support and rollout review
+- fleet visibility across teams and repos
+
+Contact `william@banksey.com` for pilots.
+
+## Launch Post
+
+MCP servers are becoming production dependencies.
+
+I built MCP Observatory so MCP maintainers can add CI, security checks, schema drift detection, PR reports, and trust badges in one command:
+
+```bash
+npx @kryptosai/mcp-observatory init-ci --command "npx -y my-mcp-server" --badge
+```
+
+Free for local OSS use. Paid pilots are available for hosted reporting, private repo CI, certification, support, and fleet visibility.

--- a/docs/project-case-study.md
+++ b/docs/project-case-study.md
@@ -1,0 +1,106 @@
+# MCP Observatory Case Study
+
+## One-Line Summary
+
+MCP Observatory is CI/security infrastructure for production MCP servers.
+
+## Problem
+
+MCP servers are becoming dependencies for AI agents. Teams need to know whether those servers still start, expose usable tools, keep schemas stable, avoid obvious security footguns, and behave consistently as agents depend on them.
+
+## Product
+
+MCP Observatory provides:
+
+- CLI checks for MCP servers
+- MCP server mode so agents can inspect other MCP servers
+- GitHub Action integration
+- PR comments and commit status checks
+- JSON, Markdown, HTML, JUnit, SARIF, and PR-comment reports
+- schema drift detection
+- record/replay/verify workflows
+- health score badges
+- static enterprise reports
+- telemetry intelligence for product and account-level learning
+
+## Architecture
+
+The project is a TypeScript/Node CLI with modular command handlers, MCP adapters, check runners, reporters, artifact schemas, and a GitHub Action wrapper. A Cloudflare Worker handles hosted artifact upload pilots, and a separate telemetry Worker stores private aggregate usage events in D1.
+
+## Technical Proof
+
+As of June 19, 2026:
+
+- 10k+ source lines in `src`
+- 40 test files
+- 321 passing tests
+- npm package published
+- GitHub Action available
+- MCP server mode available
+- telemetry export and company intelligence tooling available
+
+## Traction Snapshot
+
+Safe public and aggregate signals:
+
+- 10,278 telemetry events
+- 7,211 telemetry sessions
+- 5,368 external sessions after separating internal activity
+- 582 GitHub clones and 175 unique cloners in the visible June 2026 traffic window
+- 104 npm downloads during June 11-17, 2026
+
+These are early signals. Public social proof is still limited and should be improved through the certification campaign.
+
+## Security And Privacy Posture
+
+The project includes:
+
+- telemetry opt-out controls
+- privacy disclosure
+- security policy
+- token-based hosted artifact upload
+- private-network rejection for hosted scans
+- sanitized public reporting policy
+
+Public claims should use aggregate metrics and accepted public integrations, not raw telemetry.
+
+## Commercial Path
+
+The free OSS wedge is local testing and public repo CI. Paid value is production/private use:
+
+- hosted CI history
+- private repo reporting
+- recurring security reports
+- certification
+- support
+- fleet visibility
+- enterprise review
+
+Current pilot anchors:
+
+- Team: starts at `$299/month`
+- Business: starts at `$999/month`
+- Enterprise: starts at `$3k/month`
+- Strategic: `$250k+/year`
+
+## Job-Opportunity Value
+
+This project demonstrates ability across:
+
+- AI infrastructure
+- developer tooling
+- security tooling
+- MCP ecosystem work
+- CI/CD integrations
+- telemetry and product analytics
+- commercialization and enterprise packaging
+
+It is strongest as a portfolio asset when paired with public proof: accepted external PRs, badges in other repos, directory listings, and a short demo.
+
+## Next Milestones
+
+1. Publish latest package with `init-ci`.
+2. Open first certification PR wave.
+3. Capture accepted PRs as public proof.
+4. Publish recurring MCP safety reports.
+5. Convert serious users into paid pilots.

--- a/docs/proof.md
+++ b/docs/proof.md
@@ -1,0 +1,68 @@
+# MCP Observatory Proof
+
+MCP Observatory is early, but it is already a working MCP testing/security stack rather than a landing page.
+
+## Current Public Surface
+
+- npm package: `@kryptosai/mcp-observatory`
+- GitHub Action: `KryptosAI/mcp-observatory/action@main`
+- CLI command count: scan, test, record, replay, verify, diff, watch, suggest, serve, lock, history, init-ci, ci-report, enterprise-report, score, badge, cloud
+- Test suite: 321 passing tests across 40 test files as of June 19, 2026
+- GitHub traffic snapshot: 582 clones and 175 unique cloners in the visible June 2026 traffic window
+- npm downloads snapshot: 104 downloads for June 11-17, 2026
+
+## Safe Aggregate Telemetry Snapshot
+
+Internal telemetry is used for product analytics and account-level outreach. Public reporting uses only aggregate or sanitized data.
+
+As of the latest local export on June 19, 2026:
+
+- 10,278 telemetry events
+- 7,211 unique sessions
+- 5,368 external sessions after separating internal/personal activity
+- 2,434 external CI sessions
+- 128 attributed company/org sessions
+- top external commands: `serve`, `run`, `diff`, `test`, `scan`, `history`
+
+Raw emails, hostnames, private URLs, tokens, and response bodies are not published.
+
+## Product Proof
+
+MCP Observatory can:
+
+- install as an npm CLI
+- run as an MCP server
+- test local-process and HTTP MCP targets
+- run in GitHub Actions
+- post PR comments
+- generate JSON, Markdown, HTML, JUnit, SARIF, and PR-comment reports
+- generate health badges
+- record/replay/verify MCP sessions
+- detect schema drift
+- run lightweight MCP security checks
+- create static enterprise reports from artifacts
+
+## Certification Proof
+
+The certification campaign is designed to create public proof through accepted maintainer PRs.
+
+Accepted third-party integrations will be tracked here:
+
+| Repo | PR | Check Added | Badge Added | Status |
+| --- | --- | --- | --- | --- |
+| _pending_ | | | | |
+
+## Commercial Proof
+
+Current paid positioning is pilot-first:
+
+- Team Pilot: starts at `$299/month`
+- Business Pilot: starts at `$999/month`
+- Enterprise Pilot: starts at `$3k/month`
+- Strategic Accounts: custom, `$250k+/year`
+
+Paid value is production use: hosted reporting, private repo CI history, security reports, certification, support, fleet visibility, and enterprise review.
+
+## Claims Policy
+
+Use public proof for public claims. Company-domain telemetry signals are private and should only be used internally for outreach unless a customer gives permission or there is independent public evidence.

--- a/docs/publish-readiness.md
+++ b/docs/publish-readiness.md
@@ -31,6 +31,9 @@ Confirm:
 - Refresh MCP directory listings with: “MCP Observatory helps teams test, secure, and monitor MCP servers before agents depend on them.”
 - Include “free for local OSS use; paid for hosted reporting, private repo CI, security reports, production monitoring, certification, support, and fleet visibility.”
 - Link production users to `COMMERCIAL.md` and `william@banksey.com`.
+- Submit or refresh listings on Glama, PulseMCP, Smithery, and relevant awesome-MCP lists with the tags: security, developer tools, CI/CD, testing, observability, schema drift.
+- Use the certification distribution loop to open helpful PRs against popular MCP server repos and convert accepted PRs into proof points.
+- Link public proof, the safety report, and directory listing copy from launch/outreach materials.
 
 ## Sales Operating Loop
 

--- a/examples/integrations/README.md
+++ b/examples/integrations/README.md
@@ -5,4 +5,5 @@ These examples are intentionally lightweight. They exist to show where MCP Obser
 ## Included
 
 - `github-actions-artifact.md`: save JSON artifacts and Markdown reports in CI
+- `mcp-observatory-workflow.yml`: copy-paste GitHub Action for MCP compatibility/security checks
 - `pr-comment-snippet.md`: post a short diff summary into a pull request comment

--- a/examples/integrations/mcp-observatory-workflow.yml
+++ b/examples/integrations/mcp-observatory-workflow.yml
@@ -1,0 +1,18 @@
+name: MCP Observatory
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  mcp-observatory:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: KryptosAI/mcp-observatory/action@main
+        with:
+          command: npx -y <server-package>
+          deep: true
+          security: true
+          comment-on-pr: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kryptosai/mcp-observatory",
-  "version": "0.20.3",
+  "version": "0.21.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kryptosai/mcp-observatory",
-      "version": "0.20.3",
+      "version": "0.21.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kryptosai/mcp-observatory",
-  "version": "0.20.3",
+  "version": "0.21.0",
   "description": "Test, secure, and monitor MCP servers before agents depend on them.",
   "mcpName": "io.github.KryptosAI/mcp-observatory",
   "license": "MIT",

--- a/scripts/export-telemetry-d1.ts
+++ b/scripts/export-telemetry-d1.ts
@@ -49,6 +49,15 @@ interface TelemetryRow {
   detected_frameworks: string | null;
   org: string | null;
   contact: string | null;
+  github_repository: string | null;
+  github_workflow: string | null;
+  github_run_id: string | null;
+  github_run_number: string | null;
+  github_event_name: string | null;
+  github_ref: string | null;
+  github_actor: string | null;
+  is_first_party: number | null;
+  telemetry_source: string | null;
 }
 
 function argValue(name: string): string | undefined {
@@ -149,7 +158,9 @@ SELECT
   git_email, git_remote_url, hostname, health_score, health_grade, prompts_found,
   resources_found, security_finding_count, connect_ms, fatal_error,
   server_commands, check_statuses, suggested_servers, detected_languages,
-  detected_frameworks, org, contact
+  detected_frameworks, org, contact,
+  github_repository, github_workflow, github_run_id, github_run_number,
+  github_event_name, github_ref, github_actor, is_first_party, telemetry_source
 FROM events
 ${where}
 ORDER BY id ASC`;

--- a/scripts/telemetry-company-intelligence.ts
+++ b/scripts/telemetry-company-intelligence.ts
@@ -1,7 +1,8 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 
-interface TelemetryRow {
+export interface TelemetryRow {
   session_id?: string;
   sessionId?: string;
   org?: string | null;
@@ -26,6 +27,25 @@ interface TelemetryRow {
   securityFindingCount?: number | null;
   created_at?: string | null;
   timestamp?: string | null;
+  github_repository?: string | null;
+  githubRepository?: string | null;
+  github_workflow?: string | null;
+  githubWorkflow?: string | null;
+  github_run_id?: string | null;
+  githubRunId?: string | null;
+  github_run_number?: string | null;
+  githubRunNumber?: string | null;
+  github_event_name?: string | null;
+  githubEventName?: string | null;
+  github_ref?: string | null;
+  githubRef?: string | null;
+  github_actor?: string | null;
+  githubActor?: string | null;
+  is_first_party?: number | boolean | null;
+  isFirstParty?: boolean | null;
+  telemetry_source?: UsageCategory | null;
+  telemetrySource?: UsageCategory | null;
+  transport?: string | null;
 }
 
 interface Account {
@@ -42,7 +62,7 @@ interface Account {
   lastSeen?: string;
 }
 
-interface AccountOutput {
+export interface AccountOutput {
   company_domain: string;
   evidence: string;
   event_count: number;
@@ -56,6 +76,30 @@ interface AccountOutput {
   outreach_status: "not_contacted";
   first_seen: string;
   last_seen: string;
+}
+
+export type UsageCategory = "first_party_ci" | "external_ci" | "local" | "mcp" | "unknown";
+
+export interface UsageSummary {
+  generated_at: string;
+  total_events: number;
+  total_sessions: number;
+  external_events: number;
+  external_sessions: number;
+  first_party_ci_events: number;
+  first_party_ci_sessions: number;
+  external_ci_events: number;
+  external_ci_sessions: number;
+  attributed_company_events: number;
+  attributed_company_sessions: number;
+  unattributed_local_events: number;
+  unattributed_local_sessions: number;
+  internal_personal_events: number;
+  internal_personal_sessions: number;
+  attributed_domains_count: number;
+  latest_external_seen: string;
+  top_external_commands: Array<{ command: string; events: number; sessions: number }>;
+  top_attributed_accounts: Array<{ company_domain: string; event_count: number; unique_sessions: number }>;
 }
 
 const FREE_EMAIL_DOMAINS = new Set([
@@ -103,6 +147,8 @@ const INTERNAL_DOMAINS = new Set([
   "github:kryptosai",
   "kryptosai.com",
 ]);
+
+const FIRST_PARTY_GITHUB_REPOSITORY = "kryptosai/mcp-observatory";
 
 function argValue(name: string): string | undefined {
   const idx = process.argv.indexOf(name);
@@ -194,6 +240,55 @@ function orgDomain(org: string | null | undefined): string | undefined {
   return slug ? `org:${slug}` : undefined;
 }
 
+function sessionId(row: TelemetryRow): string | undefined {
+  return row.session_id ?? row.sessionId;
+}
+
+function seenAt(row: TelemetryRow): string {
+  return row.created_at ?? row.timestamp ?? "";
+}
+
+function githubRepository(row: TelemetryRow): string | undefined {
+  return (row.github_repository ?? row.githubRepository ?? undefined)?.trim().toLowerCase();
+}
+
+function rowIsFirstParty(row: TelemetryRow): boolean {
+  if (row.is_first_party === 1 || row.is_first_party === true || row.isFirstParty === true) return true;
+  if ((row.telemetry_source ?? row.telemetrySource) === "first_party_ci") return true;
+  return githubRepository(row) === FIRST_PARTY_GITHUB_REPOSITORY;
+}
+
+function rowIsCi(row: TelemetryRow): boolean {
+  const ciProvider = row.ci_provider ?? row.ciProvider;
+  return row.is_ci === 1 || row.is_ci === true || row.isCI === true || Boolean(ciProvider);
+}
+
+export function classifyUsageRow(row: TelemetryRow): UsageCategory {
+  const explicit = row.telemetry_source ?? row.telemetrySource;
+  if (explicit && ["first_party_ci", "external_ci", "local", "mcp", "unknown"].includes(explicit)) {
+    return explicit;
+  }
+  if (rowIsFirstParty(row)) return "first_party_ci";
+  if (rowIsCi(row)) return "external_ci";
+  if (row.transport === "mcp") return "mcp";
+  if (row.transport === "cli" || !row.transport) return "local";
+  return "unknown";
+}
+
+function rowDomains(row: TelemetryRow): Array<{ domain: string; evidence: string }> {
+  return [
+    { domain: emailDomain(row.git_email ?? row.gitEmail), evidence: "git_email_domain" },
+    { domain: orgDomain(row.org), evidence: "declared_org" },
+    { domain: emailDomain(row.contact), evidence: "declared_contact_domain" },
+    { domain: remoteOrgOrDomain(row.git_remote_url ?? row.gitRemoteUrl), evidence: "git_remote_url" },
+    { domain: hostnameDomain(row.hostname), evidence: "hostname_domain" },
+  ].filter((signal): signal is { domain: string; evidence: string } => Boolean(signal.domain));
+}
+
+function hasExternalAttribution(row: TelemetryRow): boolean {
+  return rowDomains(row).some((signal) => !INTERNAL_DOMAINS.has(signal.domain));
+}
+
 function parseRows(raw: string): TelemetryRow[] {
   const trimmed = raw.trim();
   if (!trimmed) return [];
@@ -282,6 +377,114 @@ function toOutput(account: Account): AccountOutput {
   };
 }
 
+function addSession(set: Set<string>, row: TelemetryRow): void {
+  const session = sessionId(row);
+  if (session) set.add(session);
+}
+
+function incrementCommand(
+  map: Map<string, { events: number; sessions: Set<string> }>,
+  row: TelemetryRow,
+): void {
+  const command = row.command ?? "unknown";
+  const bucket = map.get(command) ?? { events: 0, sessions: new Set<string>() };
+  bucket.events += 1;
+  addSession(bucket.sessions, row);
+  map.set(command, bucket);
+}
+
+export function buildUsageSummary(rows: TelemetryRow[], accounts: AccountOutput[]): UsageSummary {
+  const totalSessions = new Set<string>();
+  const externalSessions = new Set<string>();
+  const firstPartyCiSessions = new Set<string>();
+  const externalCiSessions = new Set<string>();
+  const attributedCompanySessions = new Set<string>();
+  const unattributedLocalSessions = new Set<string>();
+  const internalPersonalSessions = new Set<string>();
+  const topExternalCommands = new Map<string, { events: number; sessions: Set<string> }>();
+
+  let externalEvents = 0;
+  let firstPartyCiEvents = 0;
+  let externalCiEvents = 0;
+  let attributedCompanyEvents = 0;
+  let unattributedLocalEvents = 0;
+  let internalPersonalEvents = 0;
+  let latestExternalSeen = "";
+
+  for (const row of rows) {
+    addSession(totalSessions, row);
+    const category = classifyUsageRow(row);
+    const isFirstParty = rowIsFirstParty(row);
+    const isInternal = rowDomains(row).some((signal) => INTERNAL_DOMAINS.has(signal.domain));
+    const isAttributedCompany = hasExternalAttribution(row);
+    const isExternal = !isFirstParty && category !== "first_party_ci" && !isInternal;
+
+    if (category === "first_party_ci") {
+      firstPartyCiEvents += 1;
+      addSession(firstPartyCiSessions, row);
+    }
+
+    if (category === "external_ci") {
+      externalCiEvents += 1;
+      addSession(externalCiSessions, row);
+    }
+
+    if (isAttributedCompany && isExternal) {
+      attributedCompanyEvents += 1;
+      addSession(attributedCompanySessions, row);
+    }
+
+    if ((category === "local" || category === "mcp" || category === "unknown") && !isAttributedCompany && !isInternal) {
+      unattributedLocalEvents += 1;
+      addSession(unattributedLocalSessions, row);
+    }
+
+    if (isInternal) {
+      internalPersonalEvents += 1;
+      addSession(internalPersonalSessions, row);
+    }
+
+    if (isExternal) {
+      externalEvents += 1;
+      addSession(externalSessions, row);
+      incrementCommand(topExternalCommands, row);
+      const seen = seenAt(row);
+      if (seen && seen > latestExternalSeen) latestExternalSeen = seen;
+    }
+  }
+
+  return {
+    generated_at: new Date().toISOString(),
+    total_events: rows.length,
+    total_sessions: totalSessions.size,
+    external_events: externalEvents,
+    external_sessions: externalSessions.size,
+    first_party_ci_events: firstPartyCiEvents,
+    first_party_ci_sessions: firstPartyCiSessions.size,
+    external_ci_events: externalCiEvents,
+    external_ci_sessions: externalCiSessions.size,
+    attributed_company_events: attributedCompanyEvents,
+    attributed_company_sessions: attributedCompanySessions.size,
+    unattributed_local_events: unattributedLocalEvents,
+    unattributed_local_sessions: unattributedLocalSessions.size,
+    internal_personal_events: internalPersonalEvents,
+    internal_personal_sessions: internalPersonalSessions.size,
+    attributed_domains_count: accounts.length,
+    latest_external_seen: latestExternalSeen,
+    top_external_commands: [...topExternalCommands.entries()]
+      .map(([command, stats]) => ({ command, events: stats.events, sessions: stats.sessions.size }))
+      .sort((a, b) => b.events - a.events || a.command.localeCompare(b.command))
+      .slice(0, 20),
+    top_attributed_accounts: accounts
+      .slice(0, 20)
+      .map((account) => ({
+        company_domain: account.company_domain,
+        event_count: account.event_count,
+        unique_sessions: account.unique_sessions,
+      })),
+  };
+}
+
 function csvEscape(value: string | number): string {
   const s = String(value);
   if (!/[",\n]/.test(s)) return s;
@@ -318,11 +521,92 @@ function htmlEscape(value: string | number): string {
     .replaceAll("\"", "&quot;");
 }
 
-function renderHtml(rows: AccountOutput[]): string {
+function renderUsageSummaryHtml(summary: UsageSummary): string {
+  const generatedAt = summary.generated_at;
+  const metric = (label: string, value: string | number): string =>
+    `<div class="metric"><strong>${htmlEscape(value)}</strong><span>${htmlEscape(label)}</span></div>`;
+  const commandRows = summary.top_external_commands
+    .map((row) => `<tr><td>${htmlEscape(row.command)}</td><td>${row.events}</td><td>${row.sessions}</td></tr>`)
+    .join("\n          ");
+  const accountRows = summary.top_attributed_accounts
+    .map((row) => `<tr><td>${htmlEscape(row.company_domain)}</td><td>${row.event_count}</td><td>${row.unique_sessions}</td></tr>`)
+    .join("\n          ");
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>MCP Observatory Usage Summary</title>
+  <style>
+    :root { color-scheme: light; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    body { margin: 0; color: #17202a; background: #f7f8fb; }
+    main { max-width: 1180px; margin: 0 auto; padding: 32px 20px 48px; }
+    h1 { margin: 0 0 8px; font-size: 28px; letter-spacing: 0; }
+    h2 { margin: 28px 0 12px; font-size: 18px; letter-spacing: 0; }
+    .meta { color: #5a6675; margin-bottom: 24px; }
+    .summary { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 12px; margin-bottom: 24px; }
+    .metric { background: #fff; border: 1px solid #dfe5ee; border-radius: 8px; padding: 14px 16px; }
+    .metric strong { display: block; font-size: 24px; }
+    .metric span { color: #5a6675; font-size: 13px; }
+    .grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 16px; }
+    .table-wrap { overflow-x: auto; background: #fff; border: 1px solid #dfe5ee; border-radius: 8px; }
+    table { border-collapse: collapse; width: 100%; font-size: 13px; }
+    th, td { border-bottom: 1px solid #edf1f6; padding: 10px 12px; text-align: left; }
+    th { background: #eef3f8; font-size: 12px; text-transform: uppercase; color: #425166; }
+    tr:last-child td { border-bottom: 0; }
+    @media (max-width: 760px) { .summary, .grid { grid-template-columns: 1fr; } main { padding: 20px 12px 36px; } }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>MCP Observatory Usage Summary</h1>
+    <div class="meta">Generated ${htmlEscape(generatedAt)}. First-party CI is separated from external usage.</div>
+    <section class="summary" aria-label="Summary">
+      ${metric("total events", summary.total_events)}
+      ${metric("total sessions", summary.total_sessions)}
+      ${metric("external events", summary.external_events)}
+      ${metric("external sessions", summary.external_sessions)}
+      ${metric("first-party CI events", summary.first_party_ci_events)}
+      ${metric("first-party CI sessions", summary.first_party_ci_sessions)}
+      ${metric("external CI events", summary.external_ci_events)}
+      ${metric("external CI sessions", summary.external_ci_sessions)}
+      ${metric("attributed company events", summary.attributed_company_events)}
+      ${metric("attributed company sessions", summary.attributed_company_sessions)}
+      ${metric("unattributed local events", summary.unattributed_local_events)}
+      ${metric("latest external seen", summary.latest_external_seen || "n/a")}
+    </section>
+    <section class="grid">
+      <div>
+        <h2>Top External Commands</h2>
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th>Command</th><th>Events</th><th>Sessions</th></tr></thead>
+            <tbody>${commandRows || "<tr><td colspan=\"3\">No external commands found.</td></tr>"}</tbody>
+          </table>
+        </div>
+      </div>
+      <div>
+        <h2>Top Attributed Accounts</h2>
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th>Account</th><th>Events</th><th>Sessions</th></tr></thead>
+            <tbody>${accountRows || "<tr><td colspan=\"3\">No attributed accounts found.</td></tr>"}</tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+  </main>
+</body>
+</html>
+`;
+}
+
+function renderHtml(rows: AccountOutput[], summary: UsageSummary): string {
   const strategic = rows.filter((row) => row.tier_recommendation === "Strategic").length;
   const enterprise = rows.filter((row) => row.tier_recommendation === "Enterprise").length;
   const highConfidence = rows.filter((row) => row.confidence === "high").length;
-  const generatedAt = new Date().toISOString();
+  const generatedAt = summary.generated_at;
   const cells = (row: AccountOutput): string => [
     row.company_domain,
     row.tier_recommendation,
@@ -366,12 +650,16 @@ function renderHtml(rows: AccountOutput[]): string {
 <body>
   <main>
     <h1>MCP Observatory Telemetry Intelligence</h1>
-    <div class="meta">Generated ${htmlEscape(generatedAt)}. Raw emails are excluded from this report.</div>
+    <div class="meta">Generated ${htmlEscape(generatedAt)}. Raw emails are excluded from this report. First-party CI is excluded from external account rankings.</div>
     <section class="summary" aria-label="Summary">
       <div class="metric"><strong>${rows.length}</strong><span>company/org candidates</span></div>
       <div class="metric"><strong>${strategic}</strong><span>strategic accounts</span></div>
       <div class="metric"><strong>${enterprise}</strong><span>enterprise accounts</span></div>
       <div class="metric"><strong>${highConfidence}</strong><span>high-confidence accounts</span></div>
+      <div class="metric"><strong>${summary.external_events}</strong><span>external events</span></div>
+      <div class="metric"><strong>${summary.external_sessions}</strong><span>external sessions</span></div>
+      <div class="metric"><strong>${summary.first_party_ci_events}</strong><span>first-party CI events</span></div>
+      <div class="metric"><strong>${summary.unattributed_local_sessions}</strong><span>unattributed local sessions</span></div>
     </section>
     <div class="table-wrap">
       <table>
@@ -450,17 +738,11 @@ async function main(): Promise<void> {
   }
 
   for (const row of rows) {
-    const signals = [
-      { domain: emailDomain(row.git_email ?? row.gitEmail), evidence: "git_email_domain" },
-      { domain: orgDomain(row.org), evidence: "declared_org" },
-      { domain: emailDomain(row.contact), evidence: "declared_contact_domain" },
-      { domain: remoteOrgOrDomain(row.git_remote_url ?? row.gitRemoteUrl), evidence: "git_remote_url" },
-      { domain: hostnameDomain(row.hostname), evidence: "hostname_domain" },
-    ];
+    if (!includeInternal && classifyUsageRow(row) === "first_party_ci") continue;
+    const signals = rowDomains(row);
 
     const rowAccounts = new Map<string, string[]>();
     for (const signal of signals) {
-      if (!signal.domain) continue;
       const evidence = rowAccounts.get(signal.domain) ?? [];
       evidence.push(signal.evidence);
       rowAccounts.set(signal.domain, evidence);
@@ -482,23 +764,34 @@ async function main(): Promise<void> {
       a.company_domain.localeCompare(b.company_domain),
     );
 
+  const summary = buildUsageSummary(rows, outputs);
+
   await mkdir(outDir, { recursive: true });
   const jsonPath = path.join(outDir, "telemetry-company-intelligence.json");
   const csvPath = path.join(outDir, "telemetry-company-intelligence.csv");
   const htmlPath = path.join(outDir, "telemetry-company-intelligence.html");
+  const summaryJsonPath = path.join(outDir, "telemetry-usage-summary.json");
+  const summaryHtmlPath = path.join(outDir, "telemetry-usage-summary.html");
   await writeFile(jsonPath, JSON.stringify(outputs, null, 2) + "\n", "utf8");
   await writeFile(csvPath, renderCsv(outputs), "utf8");
-  await writeFile(htmlPath, renderHtml(outputs), "utf8");
+  await writeFile(htmlPath, renderHtml(outputs, summary), "utf8");
+  await writeFile(summaryJsonPath, JSON.stringify(summary, null, 2) + "\n", "utf8");
+  await writeFile(summaryHtmlPath, renderUsageSummaryHtml(summary), "utf8");
 
   process.stdout.write(`Analyzed ${rows.length} telemetry rows.\n`);
   process.stdout.write(`Identified ${outputs.length} company/org candidates.\n`);
+  process.stdout.write(`External sessions: ${summary.external_sessions}; first-party CI sessions: ${summary.first_party_ci_sessions}.\n`);
   process.stdout.write(`Wrote ${jsonPath}\n`);
   process.stdout.write(`Wrote ${csvPath}\n`);
   process.stdout.write(`Wrote ${htmlPath}\n`);
+  process.stdout.write(`Wrote ${summaryJsonPath}\n`);
+  process.stdout.write(`Wrote ${summaryHtmlPath}\n`);
 }
 
-void main().catch((error: unknown) => {
-  const message = error instanceof Error ? error.message : String(error);
-  process.stderr.write(`${message}\n`);
-  process.exitCode = 1;
-});
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  void main().catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,6 +18,7 @@ import { registerWatchCommands } from "./commands/watch.js";
 import { registerHistoryCommands } from "./commands/history.js";
 import { registerCiReportCommands } from "./commands/ci-report.js";
 import { registerEnterpriseReportCommands } from "./commands/enterprise-report.js";
+import { registerInitCiCommands } from "./commands/init-ci.js";
 import { registerLockCommands } from "./commands/lock.js";
 import { DEFAULT_CLOUD_UPLOAD_ENDPOINT, printCloudInfo } from "./commercial.js";
 import { runTarget } from "./index.js";
@@ -56,6 +57,7 @@ const MENU_GROUPS: MenuGroup[] = [
       { command: ["lock", "verify"], label: "lock verify",  outcome: "Verify servers match the lock file" },
       { command: ["diff"],           label: "diff",         outcome: "Compare two run artifacts for regressions" },
       { command: ["history"],        label: "history",      outcome: "Show health score trends over time" },
+      { command: ["init-ci"],        label: "init-ci",      outcome: "Create GitHub Action and badge snippets" },
       { command: ["enterprise-report"], label: "enterprise-report", outcome: "Generate a production/security report" },
     ],
   },
@@ -240,6 +242,7 @@ async function main(): Promise<void> {
         `  ${c(ANSI.dim, "$")} ${c(ANSI.cyan, `${bin} lock`)}               Snapshot server schemas (like package-lock)`,
         `  ${c(ANSI.dim, "$")} ${c(ANSI.cyan, `${bin} lock verify`)}        Verify no schema drift since last lock`,
         `  ${c(ANSI.dim, "$")} ${c(ANSI.cyan, `${bin} diff`)} ${c(ANSI.dim, "<a> <b>")}       Compare two runs for regressions`,
+        `  ${c(ANSI.dim, "$")} ${c(ANSI.cyan, `${bin} init-ci`)}            Add GitHub Action and badge snippets`,
         "",
         `  ${c(ANSI.dim, `Run ${bin} <command> --help for details on any command.`)}`,
         "",
@@ -261,6 +264,7 @@ async function main(): Promise<void> {
   registerHistoryCommands(program);
   registerCiReportCommands(program);
   registerEnterpriseReportCommands(program);
+  registerInitCiCommands(program);
   registerLockCommands(program);
 
   const cloudCmd = program

--- a/src/commands/init-ci.ts
+++ b/src/commands/init-ci.ts
@@ -1,0 +1,132 @@
+import { access, mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import type { Command } from "commander";
+import { buildEvent, recordEvent } from "../telemetry.js";
+
+export interface InitCiOptions {
+  command?: string;
+  target?: string;
+  workflow?: string;
+  badgeFile?: string;
+  badge?: boolean;
+  force?: boolean;
+}
+
+const DEFAULT_WORKFLOW_PATH = ".github/workflows/mcp-observatory.yml";
+const DEFAULT_BADGE_PATH = "docs/mcp-observatory-badge.md";
+
+async function exists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function workflowYaml(options: InitCiOptions): string {
+  const command = options.command?.trim();
+  const target = options.target?.trim();
+  const lines = [
+    "name: MCP Observatory",
+    "",
+    "on:",
+    "  pull_request:",
+    "  push:",
+    "    branches: [main]",
+    "",
+    "jobs:",
+    "  mcp-observatory:",
+    "    runs-on: ubuntu-latest",
+    "    steps:",
+    "      - uses: actions/checkout@v6",
+    "      - uses: KryptosAI/mcp-observatory/action@main",
+    "        with:",
+  ];
+
+  if (target) {
+    lines.push(`          target: ${target}`);
+  } else {
+    lines.push(`          command: ${command ?? "npx -y <server-package>"}`);
+  }
+
+  lines.push(
+    "          deep: true",
+    "          security: true",
+    "          comment-on-pr: true",
+    "",
+  );
+
+  return lines.join("\n");
+}
+
+function badgeMarkdown(): string {
+  return [
+    "[![MCP Observatory](https://img.shields.io/badge/MCP%20Observatory-enabled-2563eb)](https://github.com/KryptosAI/mcp-observatory)",
+    "",
+    "This project runs MCP Observatory in CI to check MCP compatibility, schema drift, and common security issues.",
+    "",
+  ].join("\n");
+}
+
+async function writeFileOnce(filePath: string, content: string, force: boolean): Promise<"created" | "overwritten" | "skipped"> {
+  const alreadyExists = await exists(filePath);
+  if (alreadyExists && !force) return "skipped";
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, content, "utf8");
+  return alreadyExists ? "overwritten" : "created";
+}
+
+export async function initCi(options: InitCiOptions): Promise<{ workflowStatus: string; badgeStatus?: string; workflowPath: string; badgePath?: string }> {
+  if (options.command && options.target) {
+    throw new Error("Use either --command or --target, not both.");
+  }
+
+  const workflowPath = options.workflow ?? DEFAULT_WORKFLOW_PATH;
+  const badgePath = options.badgeFile ?? DEFAULT_BADGE_PATH;
+  const workflowStatus = await writeFileOnce(workflowPath, workflowYaml(options), options.force === true);
+  const result: { workflowStatus: string; badgeStatus?: string; workflowPath: string; badgePath?: string } = {
+    workflowStatus,
+    workflowPath,
+  };
+
+  if (options.badge) {
+    result.badgeStatus = await writeFileOnce(badgePath, badgeMarkdown(), options.force === true);
+    result.badgePath = badgePath;
+  }
+
+  return result;
+}
+
+export function registerInitCiCommands(program: Command): void {
+  program
+    .command("init-ci")
+    .description("Create a GitHub Action and optional badge snippet for MCP Observatory checks.")
+    .option("--command <command>", "MCP server command to test, for example: 'npx -y my-mcp-server'")
+    .option("--target <file>", "Target config JSON path to use instead of a command.")
+    .option("--workflow <file>", "Workflow output path.", DEFAULT_WORKFLOW_PATH)
+    .option("--badge", "Also write a README badge snippet.", false)
+    .option("--badge-file <file>", "Badge snippet output path.", DEFAULT_BADGE_PATH)
+    .option("--force", "Overwrite existing files.", false)
+    .action(async (options: InitCiOptions) => {
+      const result = await initCi(options);
+      const skipped = result.workflowStatus === "skipped";
+      process.stdout.write(`${result.workflowStatus}: ${result.workflowPath}\n`);
+      if (result.badgePath && result.badgeStatus) {
+        process.stdout.write(`${result.badgeStatus}: ${result.badgePath}\n`);
+      }
+      if (skipped) {
+        process.stdout.write("Use --force to overwrite existing files.\n");
+      }
+      process.stdout.write("Next: commit the workflow, open a PR, and add the badge snippet to the README if desired.\n");
+
+      recordEvent(buildEvent("command_complete", "init-ci", "cli", {
+        ciProvider: "github-actions",
+        commitStatusSet: !skipped,
+      }));
+    });
+}
+
+export async function readGeneratedWorkflow(filePath: string): Promise<string> {
+  return readFile(filePath, "utf8");
+}

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -66,7 +66,19 @@ export interface TelemetryEnrichment {
   nightlyScan?: boolean;
   issueCreated?: boolean;
   issueNumber?: number;
+  // GitHub Actions attribution
+  githubRepository?: string;
+  githubWorkflow?: string;
+  githubRunId?: string;
+  githubRunNumber?: string;
+  githubEventName?: string;
+  githubRef?: string;
+  githubActor?: string;
+  isFirstParty?: boolean;
+  telemetrySource?: TelemetrySource;
 }
+
+export type TelemetrySource = "first_party_ci" | "external_ci" | "local" | "mcp" | "unknown";
 
 export interface TelemetryEvent extends TelemetryEnrichment {
   event: string;
@@ -85,6 +97,7 @@ export interface TelemetryEvent extends TelemetryEnrichment {
 const CONFIG_DIR = path.join(os.homedir(), ".mcp-observatory");
 const CONFIG_PATH = path.join(CONFIG_DIR, "config.json");
 const DEFAULT_ENDPOINT = "https://mcp-observatory-telemetry.kryptosai.workers.dev/v1/events";
+const FIRST_PARTY_GITHUB_REPOSITORY = "kryptosai/mcp-observatory";
 
 // ── Config cache ─────────────────────────────────────────────────────────────
 
@@ -219,6 +232,44 @@ export function detectCiProvider(): string | undefined {
   return undefined;
 }
 
+function envValue(name: string): string | undefined {
+  const value = process.env[name]?.trim();
+  return value || undefined;
+}
+
+export function collectGitHubActionsMetadata(): Pick<
+  TelemetryEnrichment,
+  "githubRepository" | "githubWorkflow" | "githubRunId" | "githubRunNumber" | "githubEventName" | "githubRef" | "githubActor"
+> {
+  return {
+    githubRepository: envValue("GITHUB_REPOSITORY"),
+    githubWorkflow: envValue("GITHUB_WORKFLOW"),
+    githubRunId: envValue("GITHUB_RUN_ID"),
+    githubRunNumber: envValue("GITHUB_RUN_NUMBER"),
+    githubEventName: envValue("GITHUB_EVENT_NAME"),
+    githubRef: envValue("GITHUB_REF"),
+    githubActor: envValue("GITHUB_ACTOR"),
+  };
+}
+
+export function isFirstPartyGitHubRepository(repository: string | undefined): boolean {
+  return repository?.trim().toLowerCase() === FIRST_PARTY_GITHUB_REPOSITORY;
+}
+
+export function classifyTelemetrySource(options: {
+  transport: "cli" | "mcp";
+  isCI: boolean;
+  ciProvider?: string;
+  githubRepository?: string;
+}): { isFirstParty: boolean; telemetrySource: TelemetrySource } {
+  const isFirstParty = options.ciProvider === "github-actions" && isFirstPartyGitHubRepository(options.githubRepository);
+  if (isFirstParty) return { isFirstParty, telemetrySource: "first_party_ci" };
+  if (options.isCI || options.ciProvider) return { isFirstParty, telemetrySource: "external_ci" };
+  if (options.transport === "mcp") return { isFirstParty, telemetrySource: "mcp" };
+  if (options.transport === "cli") return { isFirstParty, telemetrySource: "local" };
+  return { isFirstParty, telemetrySource: "unknown" };
+}
+
 // ── User identity collection ─────────────────────────────────────────────────
 
 interface UserIdentity {
@@ -276,6 +327,15 @@ export function buildEvent(
 ): TelemetryEvent {
   const ci = detectCI();
   const identity = _cachedIdentity;
+  const ciProvider = enrichment?.ciProvider ?? detectCiProvider();
+  const github = ciProvider === "github-actions" ? collectGitHubActionsMetadata() : {};
+  const githubRepository = enrichment?.githubRepository ?? github.githubRepository;
+  const classification = classifyTelemetrySource({
+    transport,
+    isCI: ci.isCI,
+    ciProvider,
+    githubRepository,
+  });
   return {
     event,
     version: TOOL_VERSION,
@@ -286,12 +346,16 @@ export function buildEvent(
     isCI: ci.isCI,
     ciName: ci.ciName,
     transport,
-    ciProvider: enrichment?.ciProvider ?? detectCiProvider(),
+    ciProvider,
     org: enrichment?.org ?? identity?.org,
     contact: enrichment?.contact ?? identity?.contact,
     gitEmail: identity?.gitEmail,
     gitRemoteUrl: identity?.gitRemoteUrl,
     hostname: identity?.hostname,
+    ...github,
+    githubRepository,
+    isFirstParty: enrichment?.isFirstParty ?? classification.isFirstParty,
+    telemetrySource: enrichment?.telemetrySource ?? classification.telemetrySource,
     ...enrichment,
   };
 }

--- a/tests/cli-entrypoint.test.ts
+++ b/tests/cli-entrypoint.test.ts
@@ -175,6 +175,12 @@ describe("CLI entrypoint", () => {
     expect(stdout).toContain("history");
   });
 
+  it("init-ci subcommand shows help", () => {
+    const { stdout, exitCode } = runCli(["init-ci", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("init-ci");
+  });
+
   it("history with no data shows empty message", () => {
     const tmpDir = path.join(os.tmpdir(), `obs-test-${Date.now()}`);
     fs.mkdirSync(tmpDir, { recursive: true });

--- a/tests/init-ci.test.ts
+++ b/tests/init-ci.test.ts
@@ -1,0 +1,72 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { initCi } from "../src/commands/init-ci.js";
+
+const tempDirs: string[] = [];
+
+async function tempDir(): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "mcp-observatory-init-ci-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("init-ci", () => {
+  it("creates a GitHub Action workflow and badge snippet", async () => {
+    const dir = await tempDir();
+    const workflow = path.join(dir, ".github/workflows/mcp-observatory.yml");
+    const badgeFile = path.join(dir, "docs/mcp-observatory-badge.md");
+
+    const result = await initCi({
+      command: "npx -y @example/mcp-server",
+      workflow,
+      badge: true,
+      badgeFile,
+    });
+
+    expect(result.workflowStatus).toBe("created");
+    expect(result.badgeStatus).toBe("created");
+
+    const workflowText = await readFile(workflow, "utf8");
+    expect(workflowText).toContain("uses: KryptosAI/mcp-observatory/action@main");
+    expect(workflowText).toContain("command: npx -y @example/mcp-server");
+    expect(workflowText).toContain("deep: true");
+    expect(workflowText).toContain("security: true");
+
+    const badgeText = await readFile(badgeFile, "utf8");
+    expect(badgeText).toContain("MCP Observatory");
+    expect(badgeText).toContain("github.com/KryptosAI/mcp-observatory");
+  });
+
+  it("uses a target config instead of a command when requested", async () => {
+    const dir = await tempDir();
+    const workflow = path.join(dir, ".github/workflows/mcp-observatory.yml");
+    await initCi({ target: "./observatory-target.json", workflow });
+
+    const workflowText = await readFile(workflow, "utf8");
+    expect(workflowText).toContain("target: ./observatory-target.json");
+    expect(workflowText).not.toContain("command:");
+  });
+
+  it("skips existing files unless force is set", async () => {
+    const dir = await tempDir();
+    const workflow = path.join(dir, ".github/workflows/mcp-observatory.yml");
+    await initCi({ command: "npx -y first-server", workflow });
+    const skipped = await initCi({ command: "npx -y second-server", workflow });
+    expect(skipped.workflowStatus).toBe("skipped");
+    expect(await readFile(workflow, "utf8")).toContain("first-server");
+
+    const overwritten = await initCi({ command: "npx -y second-server", workflow, force: true });
+    expect(overwritten.workflowStatus).toBe("overwritten");
+    expect(await readFile(workflow, "utf8")).toContain("second-server");
+  });
+
+  it("rejects command and target together", async () => {
+    await expect(initCi({ command: "npx -y server", target: "./target.json" })).rejects.toThrow("Use either --command or --target");
+  });
+});

--- a/tests/telemetry-intelligence.test.ts
+++ b/tests/telemetry-intelligence.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { buildUsageSummary, classifyUsageRow, type AccountOutput, type TelemetryRow } from "../scripts/telemetry-company-intelligence.js";
+
+function account(domain: string, events: number, sessions: number): AccountOutput {
+  return {
+    company_domain: domain,
+    evidence: "git_email_domain",
+    event_count: events,
+    unique_sessions: sessions,
+    commands_used: "run",
+    targets_seen: "internal-mcp",
+    ci_events: 0,
+    production_signals: "",
+    confidence: "medium",
+    tier_recommendation: "Business",
+    outreach_status: "not_contacted",
+    first_seen: "2026-06-18T00:00:00.000Z",
+    last_seen: "2026-06-18T00:00:00.000Z",
+  };
+}
+
+describe("telemetry intelligence usage classification", () => {
+  it("classifies explicit and legacy telemetry rows", () => {
+    expect(classifyUsageRow({
+      telemetry_source: "first_party_ci",
+      session_id: "s1",
+    })).toBe("first_party_ci");
+    expect(classifyUsageRow({
+      github_repository: "KryptosAI/mcp-observatory",
+      ci_provider: "github-actions",
+      session_id: "s2",
+    })).toBe("first_party_ci");
+    expect(classifyUsageRow({
+      githubRepository: "Acme/private-mcp",
+      ciProvider: "github-actions",
+      sessionId: "s3",
+    })).toBe("external_ci");
+    expect(classifyUsageRow({
+      transport: "mcp",
+      session_id: "s4",
+    })).toBe("mcp");
+    expect(classifyUsageRow({
+      transport: "cli",
+      session_id: "s5",
+    })).toBe("local");
+  });
+
+  it("separates first-party CI from external usage totals", () => {
+    const rows: TelemetryRow[] = [
+      {
+        session_id: "first-party-1",
+        command: "run",
+        ci_provider: "github-actions",
+        github_repository: "KryptosAI/mcp-observatory",
+        is_first_party: 1,
+        telemetry_source: "first_party_ci",
+        created_at: "2026-06-18T00:00:00.000Z",
+      },
+      {
+        session_id: "external-ci-1",
+        command: "ci-report",
+        ci_provider: "github-actions",
+        github_repository: "Acme/private-mcp",
+        git_email: "owner@acme.com",
+        telemetry_source: "external_ci",
+        created_at: "2026-06-18T01:00:00.000Z",
+      },
+      {
+        session_id: "company-local-1",
+        command: "scan",
+        git_email: "dev@examplecorp.com",
+        transport: "cli",
+        created_at: "2026-06-18T02:00:00.000Z",
+      },
+      {
+        session_id: "unattributed-1",
+        command: "serve",
+        transport: "cli",
+        created_at: "2026-06-18T03:00:00.000Z",
+      },
+      {
+        session_id: "internal-1",
+        command: "run",
+        git_email: "william@banksey.com",
+        transport: "cli",
+        created_at: "2026-06-18T04:00:00.000Z",
+      },
+    ];
+
+    const summary = buildUsageSummary(rows, [account("acme.com", 1, 1), account("examplecorp.com", 1, 1)]);
+    expect(summary.total_events).toBe(5);
+    expect(summary.total_sessions).toBe(5);
+    expect(summary.first_party_ci_events).toBe(1);
+    expect(summary.first_party_ci_sessions).toBe(1);
+    expect(summary.external_ci_events).toBe(1);
+    expect(summary.external_ci_sessions).toBe(1);
+    expect(summary.external_events).toBe(3);
+    expect(summary.external_sessions).toBe(3);
+    expect(summary.attributed_company_events).toBe(2);
+    expect(summary.attributed_company_sessions).toBe(2);
+    expect(summary.unattributed_local_events).toBe(1);
+    expect(summary.unattributed_local_sessions).toBe(1);
+    expect(summary.internal_personal_events).toBe(1);
+    expect(summary.latest_external_seen).toBe("2026-06-18T03:00:00.000Z");
+    expect(summary.top_external_commands.map((row) => row.command).sort()).toEqual(["ci-report", "scan", "serve"]);
+    expect(JSON.stringify(summary)).not.toContain("@");
+  });
+});

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -110,5 +110,44 @@ describe("telemetry", () => {
       expect(event.org).toBe("example.com");
       expect(event.contact).toBe("ops@example.com");
     });
+
+    it("classifies MCP Observatory GitHub Actions as first-party CI", async () => {
+      vi.stubEnv("GITHUB_ACTIONS", "true");
+      vi.stubEnv("GITHUB_REPOSITORY", "KryptosAI/mcp-observatory");
+      vi.stubEnv("GITHUB_WORKFLOW", "Release");
+      vi.stubEnv("GITHUB_RUN_ID", "123");
+      vi.stubEnv("GITHUB_RUN_NUMBER", "74");
+      vi.stubEnv("GITHUB_EVENT_NAME", "workflow_dispatch");
+      vi.stubEnv("GITHUB_REF", "refs/heads/main");
+      vi.stubEnv("GITHUB_ACTOR", "KryptosAI");
+      const { buildEvent } = await import("../src/telemetry.js");
+      const event = buildEvent("command_run", "run", "cli");
+      expect(event.githubRepository).toBe("KryptosAI/mcp-observatory");
+      expect(event.githubWorkflow).toBe("Release");
+      expect(event.githubRunId).toBe("123");
+      expect(event.githubRunNumber).toBe("74");
+      expect(event.githubEventName).toBe("workflow_dispatch");
+      expect(event.githubRef).toBe("refs/heads/main");
+      expect(event.githubActor).toBe("KryptosAI");
+      expect(event.isFirstParty).toBe(true);
+      expect(event.telemetrySource).toBe("first_party_ci");
+    });
+
+    it("classifies other GitHub Actions repositories as external CI", async () => {
+      vi.stubEnv("GITHUB_ACTIONS", "true");
+      vi.stubEnv("GITHUB_REPOSITORY", "Acme/private-mcp");
+      const { buildEvent } = await import("../src/telemetry.js");
+      const event = buildEvent("command_run", "ci-report", "cli");
+      expect(event.githubRepository).toBe("Acme/private-mcp");
+      expect(event.isFirstParty).toBe(false);
+      expect(event.telemetrySource).toBe("external_ci");
+    });
+
+    it("classifies local CLI and MCP transport usage separately", async () => {
+      vi.stubEnv("GITHUB_ACTIONS", "");
+      const { buildEvent } = await import("../src/telemetry.js");
+      expect(buildEvent("command_run", "scan", "cli").telemetrySource).toBe("local");
+      expect(buildEvent("command_run", "serve", "mcp").telemetrySource).toBe("mcp");
+    });
   });
 });

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -144,10 +144,9 @@ describe("telemetry", () => {
     });
 
     it("classifies local CLI and MCP transport usage separately", async () => {
-      vi.stubEnv("GITHUB_ACTIONS", "");
-      const { buildEvent } = await import("../src/telemetry.js");
-      expect(buildEvent("command_run", "scan", "cli").telemetrySource).toBe("local");
-      expect(buildEvent("command_run", "serve", "mcp").telemetrySource).toBe("mcp");
+      const { classifyTelemetrySource } = await import("../src/telemetry.js");
+      expect(classifyTelemetrySource({ transport: "cli", isCI: false }).telemetrySource).toBe("local");
+      expect(classifyTelemetrySource({ transport: "mcp", isCI: false }).telemetrySource).toBe("mcp");
     });
   });
 });


### PR DESCRIPTION
## Summary
- ship MCP Observatory 0.21.0 growth package with init-ci, certification docs, proof page, safety report, and directory listing copy
- add first-party/external telemetry attribution and usage summary reporting
- sharpen README around one-command MCP CI and production pilot path
- add campaign tracker, maintainer PR templates, and workflow example for certification PR waves

## Published
- npm latest verified: @kryptosai/mcp-observatory@0.21.0
- clean npm install verified init-ci generates workflow and badge snippet

## Validation
- npm run lint
- npm run typecheck
- npm run build
- npm test
- npm run smoke
- npm run validate:artifacts
- npm audit --json
- npm pack --dry-run
- clean tarball install smoke
- clean npm latest install smoke

## Notes
- rotated CLOUD_UPLOAD_TOKEN and removed local token artifact
- GitHub topics update was attempted but not approved from this session
