### PR TITLE
Fix telemetry export retry and refresh metrics

### DIFF
--- a/docs/mcp-safety-report-latest.md
+++ b/docs/mcp-safety-report-latest.md
@@ -24,11 +24,13 @@ Safe aggregate telemetry from the latest local export:
 
 | Metric | Value |
 | --- | ---: |
-| Total telemetry events | 10,918 |
-| Total sessions | 7,380 |
-| External sessions | 5,379 |
+| Total telemetry events | 11,481 |
+| Total sessions | 7,571 |
+| External sessions | 5,389 |
 | External CI sessions | 2,446 |
-| Attributed company/org sessions | 138 |
+| Attributed company/org sessions | 148 |
+| Attributed company/org candidates | 12 |
+| Latest external activity | June 21, 2026 |
 | npm downloads snapshot | 511 downloads, June 11-20, 2026 |
 | GitHub clones in visible traffic window | 745 |
 | Unique cloners in visible traffic window | 232 |

--- a/docs/project-case-study.md
+++ b/docs/project-case-study.md
@@ -57,14 +57,15 @@ For deeper context, see the [MCP Server Security Field Guide](./mcp-security-fie
 
 Telemetry is used privately to understand product usage and identify account-level signals without publishing raw personal data.
 
-As of the latest local export on June 20, 2026:
+As of the latest local export on June 21, 2026:
 
-- 10,918 telemetry events
-- 7,380 total sessions
-- 5,379 external sessions after separating internal activity
+- 11,481 telemetry events
+- 7,571 total sessions
+- 5,389 external sessions after separating internal activity
 - 2,446 external CI sessions
-- 138 attributed company/org sessions
-- 11 attributed company/org candidates
+- 148 attributed company/org sessions
+- 12 attributed company/org candidates
+- latest external activity: June 21, 2026
 
 Public claims use aggregate or sanitized data only. Raw emails, hostnames, private URLs, tokens, and response bodies are not published.
 

--- a/docs/proof.md
+++ b/docs/proof.md
@@ -23,14 +23,15 @@ MCP Observatory is early, but it is already a working MCP testing/security stack
 
 Internal telemetry is used for product analytics and account-level outreach. Public reporting uses only aggregate or sanitized data.
 
-As of the latest local export on June 20, 2026:
+As of the latest local export on June 21, 2026:
 
-- 10,918 telemetry events
-- 7,380 total sessions
-- 5,379 external sessions after separating internal/personal activity
+- 11,481 telemetry events
+- 7,571 total sessions
+- 5,389 external sessions after separating internal/personal activity
 - 2,446 external CI sessions
-- 138 attributed company/org sessions
-- 11 attributed company/org candidates
+- 148 attributed company/org sessions
+- 12 attributed company/org candidates
+- latest external activity: June 21, 2026
 - top external commands: `serve`, `run`, `diff`, `test`, `scan`, `history`
 
 Raw emails, hostnames, private URLs, tokens, and response bodies are not published.

--- a/scripts/export-telemetry-d1.ts
+++ b/scripts/export-telemetry-d1.ts
@@ -1,6 +1,7 @@
 import { execFile } from "node:child_process";
 import { access, mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
@@ -58,6 +59,11 @@ interface TelemetryRow {
   github_actor: string | null;
   is_first_party: number | null;
   telemetry_source: string | null;
+}
+
+interface ExecFailure extends Error {
+  stdout?: string;
+  stderr?: string;
 }
 
 function argValue(name: string): string | undefined {
@@ -119,25 +125,43 @@ async function d1Query<T>(
   databaseName: string,
   sql: string,
 ): Promise<T[]> {
-  const { stdout } = await execFileAsync(
-    "npx",
-    [
-      "wrangler",
-      "d1",
-      "execute",
-      databaseName,
-      "--remote",
-      "--config",
-      wranglerConfig,
-      "--json",
-      "--command",
-      sql,
-    ],
-    {
-      maxBuffer: 1024 * 1024 * 64,
-    },
-  );
-  return parseWranglerJson<T>(stdout);
+  const args = [
+    "wrangler",
+    "d1",
+    "execute",
+    databaseName,
+    "--remote",
+    "--config",
+    wranglerConfig,
+    "--json",
+    "--command",
+    sql,
+  ];
+  const maxAttempts = 3;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      const { stdout } = await execFileAsync("npx", args, {
+        maxBuffer: 1024 * 1024 * 64,
+      });
+      return parseWranglerJson<T>(stdout);
+    } catch (error) {
+      if (attempt < maxAttempts) {
+        await sleep(1000 * attempt);
+        continue;
+      }
+
+      const failure = error as ExecFailure;
+      const details = [
+        failure.message,
+        failure.stderr ? `stderr:\n${failure.stderr.trim()}` : undefined,
+        failure.stdout ? `stdout:\n${failure.stdout.trim()}` : undefined,
+      ].filter(Boolean);
+      throw new Error(details.join("\n\n"), { cause: error });
+    }
+  }
+
+  throw new Error("Wrangler D1 query failed without returning a result.");
 }
 
 async function main(): Promise<void> {


### PR DESCRIPTION
## Summary
- add retry/backoff and better stderr/stdout details to the D1 telemetry export script
- regenerate telemetry intelligence from the live D1 export
- refresh public-safe aggregate metrics in proof, case study, and safety report docs

## Updated telemetry snapshot
- 11,481 telemetry events
- 7,571 total sessions
- 5,389 external sessions
- 337 first-party CI sessions
- 148 attributed company/org sessions
- 12 attributed company/org candidates
- latest external activity: 2026-06-21

## Validation
- npm run telemetry:export
- npm run telemetry:intelligence
- npm run lint
- npm run typecheck
- npm pack --dry-run
- git diff --check

## Notes
The original failure appears to have been a transient Wrangler/D1 execution failure: auth is valid, live schema includes the expected attribution columns, and rerunning succeeded. The script now retries transient failures and preserves command output in the final error.