### PR TITLE
Accept npm trusted publishing 2xx responses

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
             -X POST \
             -H "Authorization: Bearer ${id_token}" \
             "https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/%40kryptosai%2Fmcp-observatory")"
-          if [ "$status" = "200" ]; then
+          if [[ "$status" =~ ^2 ]]; then
             echo "configured=true" >> "$GITHUB_OUTPUT"
           else
             message="$(node -e 'const fs = require("node:fs"); try { process.stdout.write(JSON.parse(fs.readFileSync("/tmp/npm-oidc-response.json", "utf8")).message || "unknown error") } catch { process.stdout.write("unknown error") }')"


### PR DESCRIPTION
## Summary
- treat any 2xx npm OIDC token exchange response as Trusted Publishing configured
- fixes false fallback when npm returns 201 Created for the exchange endpoint

## Evidence
The latest release workflow saw npm return , which means the Trusted Publisher connection is working, but the workflow only accepted .

## Validation
- npm run lint
- npm run typecheck
- npm audit --json
- npm --prefix api audit --json
- git diff --check