### PR TITLE
feat: add clone-to-ci growth campaign

### DIFF
--- a/CLONED_THIS.md
+++ b/CLONED_THIS.md
@@ -1,0 +1,38 @@
+# Cloned This?
+
+MCP Observatory is most useful when it becomes a CI gate for an MCP server, not just a repo someone checks out once.
+
+## Fast Path
+
+Run a local check:
+
+```bash
+npx @kryptosai/mcp-observatory test npx -y <server-package>
+```
+
+Then add the check to GitHub Actions:
+
+```bash
+npx @kryptosai/mcp-observatory setup-ci --all --command "npx -y <server-package>"
+```
+
+Check whether the repo is ready:
+
+```bash
+npx @kryptosai/mcp-observatory setup-ci --doctor
+```
+
+## What To Commit
+
+- `.github/workflows/mcp-observatory.yml`
+- `mcp-observatory.target.json` when the server needs args, cwd, or env placeholders
+- `docs/mcp-observatory-badge.md` if you want a README trust badge
+- `docs/mcp-observatory-pr-body.md` when opening a maintainer PR
+
+The generated workflow is read-only by default. Maintainers can opt into PR comments or commit statuses later.
+
+## Why This Matters
+
+MCP servers are becoming production dependencies for agents. CI should catch compatibility regressions, schema drift, and common security footguns before agents depend on a release.
+
+Production teams can request private readiness reviews, hosted CI history, recurring drift/security reports, certification, support, and fleet visibility through [COMMERCIAL.md](./COMMERCIAL.md).

--- a/COMMERCIAL.md
+++ b/COMMERCIAL.md
@@ -37,9 +37,10 @@ The OSS product should make adoption useful before a buyer talks to us:
 
 1. **Local proof**: run `test`, `scan`, `diff`, `lock`, or `serve` with no account.
 2. **CI proof**: run `setup-ci --all` to add a GitHub Action, badge snippets, and maintainer copy.
-3. **Public trust**: add an MCP Observatory badge or health score badge to a public MCP server.
-4. **Private readiness**: request a private MCP readiness review for internal servers, schemas, or agent environments.
-5. **Hosted production**: use hosted history, drift/security reports, certification, support, and fleet visibility.
+3. **Adoption proof**: run `setup-ci --doctor` to verify the workflow, target, badge, and maintainer assets are in place.
+4. **Public trust**: add an MCP Observatory badge or health score badge to a public MCP server.
+5. **Private readiness**: request a private MCP readiness review for internal servers, schemas, or agent environments.
+6. **Hosted production**: use hosted history, drift/security reports, certification, support, and fleet visibility.
 
 Good paid-fit signals include private repos, production MCP usage, repeated CI runs, security review needs, schema drift concerns, multiple teams/agents, and requests for historical reporting or certification.
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Agents should not depend on tools nobody tests. MCP Observatory gives MCP server
 
 Two fast paths:
 
+Cloned this repo? Start here: [`CLONED_THIS.md`](./CLONED_THIS.md).
+
 Add MCP CI in one command:
 
 ```bash
@@ -63,7 +65,7 @@ Observatory gives maintainers and teams:
 - **MCP server mode** so agents can inspect other MCP servers directly
 - **Production pilot path** for hosted history, private repo reporting, certification, support, and fleet visibility
 
-See the [MCP server security field guide](./docs/mcp-security-field-guide.md), [Safety Methodology](./docs/methodology.md), [MCP Server Safety Index](./docs/mcp-server-safety-index.md), [reference evaluations](./docs/reference-evaluations.md), [MCP lock files](./docs/mcp-lock-files.md), [public proof](./docs/proof.md), the [certification distribution loop](./docs/certification-distribution.md), [local metrics dashboard](./docs/metrics-dashboard.md), and [commercial pilots](./COMMERCIAL.md).
+See the [clone-to-CI campaign](./docs/clone-to-ci-campaign.md), [`setup-ci --doctor`](./docs/setup-ci-doctor.md), [MCP server security field guide](./docs/mcp-security-field-guide.md), [Safety Methodology](./docs/methodology.md), [MCP Server Safety Index](./docs/mcp-server-safety-index.md), [June 2026 safety field report](./docs/mcp-safety-field-report-2026-06.md), [reference evaluations](./docs/reference-evaluations.md), [MCP lock files](./docs/mcp-lock-files.md), [public proof](./docs/proof.md), the [certification PR campaign](./docs/certification-pr-campaign.md), [ecosystem distribution kit](./docs/ecosystem-distribution-kit.md), [local metrics dashboard](./docs/metrics-dashboard.md), and [commercial pilots](./COMMERCIAL.md).
 
 ## For Security And Platform Teams
 
@@ -144,6 +146,7 @@ Or add it manually to your config:
 | `lock verify` | Verify live servers match the lock file |
 | `history` | Show health score trends for your MCP servers |
 | `setup-ci` / `init-ci` | Create a GitHub Action and badge snippet for MCP compatibility/security checks |
+| `setup-ci --doctor` | Inspect whether the repository has a complete CI adoption kit |
 | `ci-report` | Generate CI report for GitHub issue creation |
 | `enterprise-report` | Generate a static production/security report from run artifacts |
 | `score <cmd>` | Score an MCP server's health (0-100) |
@@ -216,6 +219,12 @@ Add Observatory to your MCP server's CI pipeline:
 
 ```bash
 npx @kryptosai/mcp-observatory setup-ci --all --command "npx -y my-mcp-server"
+```
+
+Check the adoption kit:
+
+```bash
+npx @kryptosai/mcp-observatory setup-ci --doctor
 ```
 
 Or create the workflow manually:

--- a/docs/certification-pr-campaign.md
+++ b/docs/certification-pr-campaign.md
@@ -1,0 +1,68 @@
+# Certification PR Campaign
+
+The certification campaign creates public proof by opening small, helpful PRs that add read-only MCP Observatory checks to public MCP servers.
+
+## Goal
+
+Create maintainer conversations and accepted public integrations around one clear offer:
+
+> Add MCP CI/security checks in 60 seconds.
+
+## PR Shape
+
+Each PR should be narrow:
+
+- add `.github/workflows/mcp-observatory.yml`
+- add `mcp-observatory.target.json` when needed
+- add optional badge snippet
+- keep permissions read-only by default
+- avoid changing server implementation code
+
+Generate the kit:
+
+```bash
+npx @kryptosai/mcp-observatory setup-ci --all --command "<safe startup command>"
+npx @kryptosai/mcp-observatory setup-ci --doctor
+```
+
+## Target Criteria
+
+Prioritize repos with:
+
+- active MCP server maintenance
+- clear package or local startup command
+- meaningful usage, stars, directory visibility, or enterprise category
+- safe CI startup without real credentials
+- maintainers likely to value compatibility/security proof
+
+Avoid repos where:
+
+- startup requires private credentials with no fixture mode
+- the server performs irreversible side effects during startup
+- maintainers have already rejected third-party CI without a new reason to revisit
+
+## Maintainer Message
+
+```markdown
+This PR adds a read-only MCP Observatory GitHub Action for MCP compatibility, schema drift, and common security checks.
+
+It does not require an account and does not change runtime code. The workflow is read-only by default; maintainers can opt into PR comments/statuses later.
+
+I used `setup-ci --doctor` to verify the adoption kit. If the startup command should use a repo-local build instead of the published package, I can adjust it.
+```
+
+## Weekly Quota
+
+- 5 researched targets
+- 3 opened PRs
+- 1 follow-up on existing open PRs
+- 1 accepted or meaningfully discussed PR converted into proof/docs
+
+## Success Signals
+
+- accepted workflows
+- maintainer replies
+- badge adoption
+- directory mentions
+- reference evaluations linked from maintainers
+- inbound certification or pilot requests

--- a/docs/clone-to-ci-campaign.md
+++ b/docs/clone-to-ci-campaign.md
@@ -1,0 +1,62 @@
+# Clone To CI Campaign
+
+This is the operating campaign for turning anonymous clone/download activity into durable MCP Observatory adoption.
+
+## Campaign Promise
+
+Add MCP CI/security checks in 60 seconds.
+
+```bash
+npx @kryptosai/mcp-observatory setup-ci --all --command "npx -y <server-package>"
+```
+
+## Strategy Map
+
+| Strategy | Move | Success Signal |
+| --- | --- | --- |
+| Passive credibility | Link `CLONED_THIS.md`, proof docs, badges, and sample reports from README/npm | higher repo views per clone |
+| Product-led conversion | Prompt `setup-ci` after `test`, `scan`, `diff`, `score`, and `lock verify`; expose `setup-ci --doctor` | more `setup-ci` sessions |
+| Ecosystem distribution | Submit directory/listing copy and Action examples to MCP/devtool/security indexes | more qualified clones/downloads |
+| Authority | Publish safety field reports and reference evaluations | backlinks, citations, inbound issues |
+| Certification | Open small read-only CI PRs against public MCP servers | merged PRs, maintainer replies, badge adoption |
+| Revenue | Offer private readiness reviews and hosted history to high-signal teams | pilot calls and paid reviews |
+
+## Weekly Loop
+
+1. Refresh the local metrics dashboard.
+2. Record clone/download/view and `setup-ci` conversion.
+3. Pick 5 public MCP repos for certification PRs.
+4. Submit or refresh 3 directory/listing entries.
+5. Publish one short public note from the safety findings.
+6. Draft private outreach to 3 high-signal accounts using sanitized evidence only.
+7. Generate a sanitized sample enterprise report for pilot conversations:
+   `npx @kryptosai/mcp-observatory enterprise-report --sample --format html --output reports/sample-enterprise-report.html`
+
+## Public Copy
+
+Short:
+
+> MCP Observatory adds CI, compatibility, drift, and security checks for MCP servers before agents depend on them.
+
+Clone conversion:
+
+> Cloned this? Add MCP CI in 60 seconds with `setup-ci --all`.
+
+Security-team angle:
+
+> Treat MCP servers like production dependencies: check startup, schema quality, tool safety, drift, and CI history before agents use them.
+
+## Metrics
+
+Track these in the local dashboard:
+
+- GitHub clones
+- npm downloads
+- GitHub views
+- local validation sessions
+- `setup-ci` sessions
+- clone/download to CI conversion
+- latest version adoption
+- external CI sessions
+
+The primary campaign goal is not raw clones. It is increasing `setup-ci` sessions and accepted CI/badge integrations.

--- a/docs/ecosystem-distribution-kit.md
+++ b/docs/ecosystem-distribution-kit.md
@@ -1,0 +1,79 @@
+# Ecosystem Distribution Kit
+
+Use this kit when submitting MCP Observatory to directories, marketplaces, newsletters, and awesome lists.
+
+## One-Line Description
+
+MCP Observatory is the CI and security gate for MCP servers before agents depend on them.
+
+## Short Listing
+
+MCP Observatory tests MCP servers for startup health, capability discovery, schema drift, common security footguns, health scoring, badges, and GitHub Action CI. It can run locally, in CI, or as an MCP server for agent-accessible diagnostics.
+
+## Tags
+
+- MCP
+- MCP security
+- AI security
+- agent security
+- developer tools
+- CI/CD
+- schema drift
+- supply chain security
+- testing
+- GitHub Actions
+
+## Primary CTA
+
+```bash
+npx @kryptosai/mcp-observatory setup-ci --all --command "npx -y <server-package>"
+```
+
+## Directory Targets
+
+Prioritize surfaces where users already look for MCP infrastructure:
+
+- MCP server directories
+- MCP developer-tool lists
+- AI security lists
+- GitHub Action Marketplace
+- awesome-MCP repositories
+- agent framework docs and community lists
+- npm package discovery through keywords and README copy
+
+## Submission Checklist
+
+- Link to the README.
+- Link to `CLONED_THIS.md` for immediate adoption.
+- Include the `setup-ci` command.
+- Mention free local OSS use.
+- Mention paid pilots only as production support: hosted history, private readiness review, drift/security reports, certification, support, and fleet visibility.
+- Do not include private telemetry, account names, hostnames, emails, or customer claims.
+
+## Marketplace Copy
+
+Title:
+
+> MCP Observatory CI
+
+Description:
+
+> Add MCP compatibility, schema drift, and security checks to GitHub Actions before agents depend on your server.
+
+Snippet:
+
+```yaml
+- uses: KryptosAI/mcp-observatory/action@v0.25.1
+  with:
+    command: npx -y <server-package>
+    deep: true
+    security: true
+```
+
+## Paid Pilot Demo
+
+Use a sanitized sample report when someone asks what the private review produces:
+
+```bash
+npx @kryptosai/mcp-observatory enterprise-report --sample --format html --output reports/sample-enterprise-report.html
+```

--- a/docs/mcp-safety-field-report-2026-06.md
+++ b/docs/mcp-safety-field-report-2026-06.md
@@ -1,0 +1,55 @@
+# MCP Safety Field Report: June 2026
+
+This field report summarizes recurring MCP readiness patterns observed while building and testing MCP Observatory against public examples, reference servers, and generated safety-index artifacts. It is not a leaderboard and does not rank maintainers.
+
+## What Is Working
+
+- MCP maintainers increasingly expose package-level startup commands that can be checked in CI.
+- Read-only GitHub Actions are a low-friction way to introduce compatibility and security checks.
+- Health badges and PR reports make MCP readiness understandable to users who are not deep in MCP internals.
+- Lock files are a natural fit for schema/tool drift because MCP servers behave like production dependencies.
+
+## Common Readiness Gaps
+
+1. **No CI proof for MCP startup**
+   Repos may publish a server without a pull-request check that verifies the server starts and responds to MCP capability discovery.
+
+2. **Schema descriptions are thin**
+   Tool and property descriptions are often good enough for demos but weak for production agents deciding when and how to call tools.
+
+3. **Filesystem and network boundaries need clearer evidence**
+   Path, URL, shell, and token-adjacent inputs need explicit review because agents can amplify small schema ambiguities into risky behavior.
+
+4. **Drift is not reviewed like dependency drift**
+   MCP tool surfaces can change between releases without a lock-file-style review step.
+
+5. **Badges exist for build status, not agent readiness**
+   Users need visible signals that a server was checked for MCP compatibility, drift, and common security issues.
+
+## Recommended Baseline
+
+Every production-facing MCP server should have:
+
+- startup check in CI
+- `deep: true` capability exercise where safe
+- lightweight security/schema checks
+- artifact output for review
+- optional score badge
+- lock-file verification for stable server surfaces
+- a documented safe startup command for CI
+
+## One-Command Adoption
+
+```bash
+npx @kryptosai/mcp-observatory setup-ci --all --command "npx -y <server-package>"
+```
+
+Then verify the adoption kit:
+
+```bash
+npx @kryptosai/mcp-observatory setup-ci --doctor
+```
+
+## Buyer-Safe Claim
+
+MCP Observatory is an evidence standard for MCP readiness. Public claims should use public artifacts, public PRs, and aggregate/sanitized metrics only. Private telemetry, hostnames, emails, target URLs, and account names stay private.

--- a/docs/metrics-dashboard.md
+++ b/docs/metrics-dashboard.md
@@ -13,7 +13,7 @@ The layout follows an App Store Connect-style breakdown:
 - Usage
 - Reliability
 
-The Strategy section turns raw telemetry into operator decisions: command funnel, version adoption, account/domain drilldown, CI/local source mix, and release-spike context.
+The Strategy section turns raw telemetry into operator decisions: command funnel, clone/download-to-CI conversion, version adoption, account/domain drilldown, CI/local source mix, and release-spike context.
 
 Daily rows are shown newest to oldest so the most recent project activity is always at the top.
 

--- a/docs/setup-ci-doctor.md
+++ b/docs/setup-ci-doctor.md
@@ -1,0 +1,31 @@
+# setup-ci Doctor
+
+`setup-ci --doctor` inspects whether a repository has a usable MCP Observatory CI adoption kit.
+
+```bash
+npx @kryptosai/mcp-observatory setup-ci --doctor
+```
+
+It checks:
+
+- the GitHub Action workflow exists
+- the action is pinned to a release or commit instead of `main`
+- the workflow has a command or target config
+- deep and security checks are enabled
+- write permissions are intentional
+- badge, target config, maintainer PR body, issue fallback, and score badge notes exist
+
+Use it after generating a kit:
+
+```bash
+npx @kryptosai/mcp-observatory setup-ci --all --command "npx -y <server-package>"
+npx @kryptosai/mcp-observatory setup-ci --doctor
+```
+
+Use it during maintainer PRs to make review easier:
+
+```bash
+npx @kryptosai/mcp-observatory setup-ci --doctor --workflow .github/workflows/mcp-observatory.yml
+```
+
+The doctor is intentionally advisory. Missing optional assets are warnings. A missing workflow, missing action reference, or missing MCP target is a blocking failure.

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "files": [
     "dist/src",
     "README.md",
+    "CLONED_THIS.md",
     "COMMERCIAL.md",
     "PRIVACY.md",
     "TERMS.md",

--- a/scripts/metrics-dashboard.ts
+++ b/scripts/metrics-dashboard.ts
@@ -1084,6 +1084,13 @@ function percent(part: number, whole: number): string {
   return `${Math.round((part / whole) * 100)}%`;
 }
 
+function conversionPercent(part: number, whole: number): string {
+  if (whole === 0) return "n/a";
+  const value = (part / whole) * 100;
+  if (value > 0 && value < 0.01) return "<0.01%";
+  return `${Math.round(value * 100) / 100}%`;
+}
+
 function strategyCards(model: DashboardModel): string {
   const externalCi = model.telemetry.sourceCounts.find((row) => row.source === "external_ci");
   const serve = model.telemetry.commandFunnel.find((row) => row.stage === "Agent install");
@@ -1091,6 +1098,8 @@ function strategyCards(model: DashboardModel): string {
   const latestVersion = model.telemetry.versionAdoption.find((row) => row.isLatest);
   const dominantVersion = [...model.telemetry.versionAdoption].sort((a, b) => b.sessions - a.sessions)[0];
   const cloneViewGap = model.github.clones14 > 0 ? `${formatNumber(model.github.clones14)} clones / ${formatNumber(model.github.views14)} views` : "no clone data yet";
+  const cloneDownloadSignals = model.github.clones14 + model.npm.downloads14;
+  const setupConversion = conversionPercent(ciSetup?.sessions ?? 0, cloneDownloadSignals);
   const cards = [
     {
       label: "Scale CI",
@@ -1116,8 +1125,8 @@ function strategyCards(model: DashboardModel): string {
     },
     {
       label: "Fix OSS Conversion",
-      signal: cloneViewGap,
-      action: "Downloads/clones are ahead of stars and repo views; add a quiet badge/star prompt after wins.",
+      signal: `${setupConversion} clone/download to CI`,
+      action: `Downloads/clones are ahead of stars and repo views (${cloneViewGap}); make setup-ci the next step after every win.`,
     },
   ];
   return cards.map((card) => `<article class="insight"><span>${escapeHtml(card.label)}</span><strong>${escapeHtml(card.signal)}</strong><p>${escapeHtml(card.action)}</p></article>`).join("");
@@ -1137,6 +1146,8 @@ export function renderDashboardHtml(model: DashboardModel): string {
   const latestVersion = model.telemetry.versionAdoption.find((row) => row.isLatest);
   const ciSource = model.telemetry.sourceCounts.find((row) => row.source === "external_ci");
   const serveStage = model.telemetry.commandFunnel.find((row) => row.stage === "Agent install");
+  const ciSetupStage = model.telemetry.commandFunnel.find((row) => row.stage === "CI setup");
+  const cloneDownloadSignals = model.github.clones14 + model.npm.downloads14;
   const releaseDay = model.github.latestReleasePublishedAt.slice(0, 10);
   const releaseTelemetry = model.telemetry.dailyEvents.find((row) => row.day === releaseDay);
   const releaseNpm = model.npm.daily.find((row) => row.day === releaseDay);
@@ -1230,6 +1241,7 @@ export function renderDashboardHtml(model: DashboardModel): string {
     <section class="metrics" aria-label="Strategy metrics">
       ${metric("external CI share", `${percent(ciSource?.sessions ?? 0, model.telemetry.totalSessions)}`, `${formatNumber(ciSource?.sessions ?? 0)} sessions`)}
       ${metric("agent install share", `${percent(serveStage?.sessions ?? 0, model.telemetry.totalSessions)}`, `${formatNumber(serveStage?.sessions ?? 0)} serve sessions`)}
+      ${metric("clone/download to CI", conversionPercent(ciSetupStage?.sessions ?? 0, cloneDownloadSignals), `${formatNumber(ciSetupStage?.sessions ?? 0)} setup sessions / ${formatNumber(cloneDownloadSignals)} clone+download signals`)}
       ${metric("latest version adoption", latestVersion ? `${latestVersion.sessionShare}%` : "n/a", latestVersion ? `${latestVersion.version}, ${formatNumber(latestVersion.sessions)} sessions` : "")}
       ${metric("clone-to-view gap", model.github.views14 === 0 ? "n/a" : `${Math.round(model.github.clones14 / Math.max(model.github.views14, 1))}:1`, `${formatNumber(model.github.clones14)} clones / ${formatNumber(model.github.views14)} views`)}
     </section>

--- a/src/commands/diff.ts
+++ b/src/commands/diff.ts
@@ -5,7 +5,7 @@ import {
   readArtifact,
 } from "../index.js";
 import { buildEvent, recordEvent } from "../telemetry.js";
-import { formatOutput, writeOutput } from "./helpers.js";
+import { formatOutput, printCiConversionCta, writeOutput } from "./helpers.js";
 
 export function registerDiffCommands(program: Command): void {
   program
@@ -34,6 +34,11 @@ export function registerDiffCommands(program: Command): void {
         const artifact = diffArtifacts(baseArtifact, headArtifact);
         const output = formatOutput(artifact, options.format);
         await writeOutput(output, options.format, options.output);
+        if (options.format === "terminal" && artifact.gate !== "fail") {
+          printCiConversionCta({
+            context: "keep this diff check running on every PR:",
+          });
+        }
 
         recordEvent(buildEvent("command_complete", "diff", "cli", {
           gateResult: artifact.gate,

--- a/src/commands/enterprise-report.ts
+++ b/src/commands/enterprise-report.ts
@@ -126,6 +126,73 @@ export function buildEnterpriseReport(artifacts: RunArtifact[], account = "MCP t
   ].join("\n");
 }
 
+function sampleCheck(id: CheckResult["id"], status: CheckResult["status"], itemCount = 0, message = `${id} ${status}`): CheckResult {
+  return {
+    id,
+    capability: id,
+    status,
+    durationMs: 40,
+    message,
+    evidence: [{ endpoint: id, advertised: true, responded: status !== "fail", minimalShapePresent: status !== "fail", itemCount }],
+  };
+}
+
+function sampleArtifact(targetId: string, gate: RunArtifact["gate"], score: number, grade: NonNullable<RunArtifact["healthScore"]>["grade"], checks: CheckResult[]): RunArtifact {
+  return {
+    artifactType: "run",
+    schemaVersion: "1.0.0",
+    gate,
+    runId: `sample-${targetId}`,
+    createdAt: new Date().toISOString(),
+    toolVersion: "0.25.1",
+    target: {
+      targetId,
+      adapter: "local-process",
+      command: "npx",
+      args: ["-y", targetId],
+    },
+    environment: { platform: "sample", nodeVersion: "sample" },
+    summary: {
+      gate,
+      total: checks.length,
+      pass: checks.filter((check) => check.status === "pass").length,
+      fail: checks.filter((check) => check.status === "fail").length,
+      partial: checks.filter((check) => check.status === "partial").length,
+      unsupported: 0,
+      flaky: 0,
+      skipped: 0,
+    },
+    checks,
+    healthScore: {
+      overall: score,
+      grade,
+      dimensions: [],
+    },
+  };
+}
+
+export function buildSampleEnterpriseArtifacts(): RunArtifact[] {
+  return [
+    sampleArtifact("payments-mcp", "pass", 91, "A", [
+      sampleCheck("tools", "pass", 18),
+      sampleCheck("prompts", "pass", 2),
+      sampleCheck("resources", "pass", 1),
+      sampleCheck("security-lite", "pass", 0),
+    ]),
+    sampleArtifact("internal-docs-mcp", "pass", 74, "C", [
+      sampleCheck("tools", "pass", 9),
+      sampleCheck("prompts", "pass", 0),
+      sampleCheck("resources", "pass", 3),
+      sampleCheck("schema-quality", "partial", 0, "Two tool input properties are missing descriptions."),
+      sampleCheck("security-lite", "partial", 0, "Review URL and token-adjacent inputs before production use."),
+    ]),
+    sampleArtifact("customer-support-mcp", "fail", 58, "D", [
+      sampleCheck("tools", "fail", 0, "Server did not respond to tools/list during startup window."),
+      sampleCheck("security", "partial", 0, "Authentication metadata was not explicit in the target config."),
+    ]),
+  ];
+}
+
 export function renderEnterpriseReportHtml(markdown: string): string {
   const body = markdown
     .split("\n")
@@ -162,8 +229,9 @@ export function registerEnterpriseReportCommands(program: Command): void {
     .option("--account <name>", "Account, team, or company name for the report.", "MCP team")
     .option("--format <format>", "Output format: markdown or html.", "markdown")
     .option("--output <path>", "Write report to file instead of stdout.")
-    .action(async (options: { artifactsDir: string; account: string; format: string; output?: string }) => {
-      const artifacts = await loadArtifactsFromDir(options.artifactsDir);
+    .option("--sample", "Use sanitized sample artifacts to demonstrate the paid pilot report.", false)
+    .action(async (options: { artifactsDir: string; account: string; format: string; output?: string; sample?: boolean }) => {
+      const artifacts = options.sample ? buildSampleEnterpriseArtifacts() : await loadArtifactsFromDir(options.artifactsDir);
       const markdown = buildEnterpriseReport(artifacts, options.account);
       const output = options.format === "html" ? renderEnterpriseReportHtml(markdown) : markdown;
 
@@ -179,6 +247,7 @@ export function registerEnterpriseReportCommands(program: Command): void {
         matrixPassCount: artifacts.filter((artifact) => artifact.gate === "pass").length,
         matrixFailCount: artifacts.filter((artifact) => artifact.gate === "fail").length,
         securityFindingCount: artifacts.reduce((sum, artifact) => sum + securityFindings(artifact), 0),
+        sampleReport: options.sample === true,
       }));
       if (options.output) {
         maybePrintCloudCta("ci");

--- a/src/commands/helpers.ts
+++ b/src/commands/helpers.ts
@@ -153,3 +153,37 @@ export function getBinName(): string {
   }
   return "mcp-observatory";
 }
+
+export function quoteShell(value: string): string {
+  if (/^[A-Za-z0-9_./:@=-]+$/.test(value)) return value;
+  return `"${value.replaceAll("\\", "\\\\").replaceAll("\"", "\\\"")}"`;
+}
+
+export function setupCiHint(target?: TargetConfig, targetPath?: string, bin = "npx @kryptosai/mcp-observatory"): string {
+  if (targetPath) {
+    return `${bin} setup-ci --all --target ${quoteShell(targetPath)}`;
+  }
+  if (target?.adapter === "local-process") {
+    const command = [target.command, ...target.args].map(quoteShell).join(" ");
+    return `${bin} setup-ci --all --command ${quoteShell(command)}`;
+  }
+  return `${bin} setup-ci --all --target mcp-observatory.target.json`;
+}
+
+export function shouldPrintConversionCta(): boolean {
+  return process.stdout.isTTY && process.env["CI"] !== "true";
+}
+
+export function printCiConversionCta(options: {
+  bin?: string;
+  context?: string;
+  target?: TargetConfig;
+  targetPath?: string;
+}): void {
+  if (!shouldPrintConversionCta()) return;
+  const bin = options.bin ?? "npx @kryptosai/mcp-observatory";
+  process.stdout.write(`  ${c(ANSI.bold, "Next:")} ${options.context ?? "keep this passing in CI"}\n`);
+  process.stdout.write(`  ${c(ANSI.dim, "$")} ${c(ANSI.cyan, setupCiHint(options.target, options.targetPath, bin))}\n`);
+  process.stdout.write(`  ${c(ANSI.dim, `Check adoption: ${bin} setup-ci --doctor`)}\n`);
+  process.stdout.write(`  ${c(ANSI.dim, "Public trust: add the badge, and star https://github.com/KryptosAI/mcp-observatory if it saved time.")}\n\n`);
+}

--- a/src/commands/init-ci.ts
+++ b/src/commands/init-ci.ts
@@ -18,6 +18,7 @@ export interface InitCiOptions {
   actionRef?: string;
   all?: boolean;
   force?: boolean;
+  doctor?: boolean;
 }
 
 const DEFAULT_WORKFLOW_PATH = ".github/workflows/mcp-observatory.yml";
@@ -221,6 +222,157 @@ export interface InitCiResult {
   scoreBadgePath?: string;
 }
 
+export interface SetupCiDoctorCheck {
+  id: string;
+  label: string;
+  status: "pass" | "warn" | "fail";
+  message: string;
+  fix?: string;
+}
+
+export interface SetupCiDoctorResult {
+  ready: boolean;
+  checks: SetupCiDoctorCheck[];
+  nextCommand: string;
+}
+
+async function readOptional(filePath: string): Promise<string | undefined> {
+  try {
+    return await readFile(filePath, "utf8");
+  } catch {
+    return undefined;
+  }
+}
+
+function checkFile(id: string, label: string, filePath: string, content: string | undefined, expectedText?: string): SetupCiDoctorCheck {
+  if (content === undefined) {
+    return {
+      id,
+      label,
+      status: "warn",
+      message: `${filePath} is missing.`,
+      fix: `Run setup-ci --all to generate ${filePath}.`,
+    };
+  }
+  if (expectedText && !content.includes(expectedText)) {
+    return {
+      id,
+      label,
+      status: "warn",
+      message: `${filePath} exists but does not look like a generated MCP Observatory asset.`,
+      fix: `Regenerate with setup-ci --all --force if this file should be managed by Observatory.`,
+    };
+  }
+  return {
+    id,
+    label,
+    status: "pass",
+    message: `${filePath} exists.`,
+  };
+}
+
+function setupCommand(options: InitCiOptions): string {
+  if (options.target) return `npx @kryptosai/mcp-observatory setup-ci --all --target ${options.target}`;
+  if (options.command) return `npx @kryptosai/mcp-observatory setup-ci --all --command "${options.command.replaceAll("\"", "\\\"")}"`;
+  return "npx @kryptosai/mcp-observatory setup-ci --all --command \"npx -y <server-package>\"";
+}
+
+export async function doctorSetupCi(options: InitCiOptions = {}): Promise<SetupCiDoctorResult> {
+  const workflowPath = options.workflow ?? DEFAULT_WORKFLOW_PATH;
+  const badgePath = options.badgeFile ?? DEFAULT_BADGE_PATH;
+  const targetConfigPath = optionPath(options.targetConfig, DEFAULT_TARGET_CONFIG_PATH);
+  const prBodyPath = optionPath(options.prBody, DEFAULT_PR_BODY_PATH);
+  const issueBodyPath = optionPath(options.issueBody, DEFAULT_ISSUE_BODY_PATH);
+  const scoreBadgePath = optionPath(options.scoreBadge, DEFAULT_SCORE_BADGE_PATH);
+
+  const workflow = await readOptional(workflowPath);
+  const checks: SetupCiDoctorCheck[] = [];
+  if (workflow === undefined) {
+    checks.push({
+      id: "workflow",
+      label: "GitHub Action",
+      status: "fail",
+      message: `${workflowPath} is missing.`,
+      fix: setupCommand(options),
+    });
+  } else {
+    checks.push({
+      id: "workflow",
+      label: "GitHub Action",
+      status: "pass",
+      message: `${workflowPath} exists.`,
+    });
+
+    const actionRef = workflow.match(/KryptosAI\/mcp-observatory\/action@([^\s]+)/)?.[1];
+    if (!actionRef) {
+      checks.push({
+        id: "action-ref",
+        label: "Pinned Action",
+        status: "fail",
+        message: "Workflow does not use KryptosAI/mcp-observatory/action.",
+        fix: setupCommand(options),
+      });
+    } else if (actionRef === "main") {
+      checks.push({
+        id: "action-ref",
+        label: "Pinned Action",
+        status: "warn",
+        message: "Workflow uses action@main.",
+        fix: "Pin the action to a release tag or full commit SHA.",
+      });
+    } else {
+      checks.push({
+        id: "action-ref",
+        label: "Pinned Action",
+        status: "pass",
+        message: `Workflow uses action@${actionRef}.`,
+      });
+    }
+
+    const hasTarget = /(^|\n)\s+target:\s+\S+/.test(workflow);
+    const hasCommand = /(^|\n)\s+command:\s+\S+/.test(workflow);
+    checks.push({
+      id: "target",
+      label: "Target",
+      status: hasTarget || hasCommand ? "pass" : "fail",
+      message: hasTarget || hasCommand ? "Workflow has an MCP target." : "Workflow does not define command or target.",
+      fix: hasTarget || hasCommand ? undefined : setupCommand(options),
+    });
+
+    const hasDeep = /(^|\n)\s+deep:\s+true/.test(workflow);
+    const hasSecurity = /(^|\n)\s+security:\s+true/.test(workflow);
+    checks.push({
+      id: "coverage",
+      label: "Coverage",
+      status: hasDeep && hasSecurity ? "pass" : "warn",
+      message: hasDeep && hasSecurity ? "Workflow enables deep and security checks." : "Workflow should enable deep and security checks.",
+      fix: hasDeep && hasSecurity ? undefined : "Set deep: true and security: true in the action inputs.",
+    });
+
+    const writesPr = /(^|\n)\s+pull-requests:\s+write/.test(workflow);
+    const writesStatus = /(^|\n)\s+statuses:\s+write/.test(workflow);
+    checks.push({
+      id: "permissions",
+      label: "Permissions",
+      status: writesPr || writesStatus ? "warn" : "pass",
+      message: writesPr || writesStatus ? "Workflow can write PR comments or statuses." : "Workflow is read-only by default.",
+      fix: writesPr || writesStatus ? "Keep write permissions only when maintainers intentionally want PR comments or commit statuses." : undefined,
+    });
+  }
+
+  checks.push(checkFile("badge", "README Badge", badgePath, await readOptional(badgePath), "MCP Observatory"));
+  checks.push(checkFile("target-config", "Target Config", targetConfigPath, await readOptional(targetConfigPath), "targetId"));
+  checks.push(checkFile("pr-body", "Maintainer PR Body", prBodyPath, await readOptional(prBodyPath), "Add MCP Observatory CI"));
+  checks.push(checkFile("issue-body", "Issue Fallback", issueBodyPath, await readOptional(issueBodyPath), "compatibility/security"));
+  checks.push(checkFile("score-badge", "Score Badge Notes", scoreBadgePath, await readOptional(scoreBadgePath), "mcp-observatory badge"));
+
+  return {
+    ready: checks.every((check) => check.status !== "fail"),
+    checks,
+    nextCommand: setupCommand(options),
+  };
+}
+
 export async function initCi(options: InitCiOptions): Promise<InitCiResult> {
   if (options.command && options.target) {
     throw new Error("Use either --command or --target, not both.");
@@ -280,11 +432,32 @@ function addInitCiOptions(command: Command): Command {
     .option("--set-status", "Allow the generated workflow to set commit statuses. This adds statuses: write permission.", false)
     .option("--action-ref <ref>", "Git ref for KryptosAI/mcp-observatory/action. Use a full commit SHA for strict third-party action pinning.", DEFAULT_ACTION_REF)
     .option("--all", "Write the full adoption kit: workflow, badge, target config, PR body, issue body, and score badge instructions.", false)
-    .option("--force", "Overwrite existing files.", false);
+    .option("--force", "Overwrite existing files.", false)
+    .option("--doctor", "Inspect the current repository's MCP Observatory CI adoption state.", false);
 }
 
 function initCiAction(commandName: "init-ci" | "setup-ci"): (options: InitCiOptions) => Promise<void> {
   return async (options: InitCiOptions) => {
+    if (options.doctor) {
+      const result = await doctorSetupCi(options);
+      process.stdout.write("MCP Observatory CI doctor\n\n");
+      for (const check of result.checks) {
+        const marker = check.status === "pass" ? "✓" : check.status === "warn" ? "!" : "✗";
+        process.stdout.write(`${marker} ${check.label}: ${check.message}\n`);
+        if (check.fix) process.stdout.write(`  fix: ${check.fix}\n`);
+      }
+      process.stdout.write(`\nNext best action:\n  ${result.nextCommand}\n`);
+      if (!result.ready) process.exitCode = 1;
+      recordEvent(buildEvent("command_complete", commandName, "cli", {
+        ciProvider: "github-actions",
+        setupCiDoctor: true,
+        setupCiReady: result.ready,
+        setupCiFailCount: result.checks.filter((check) => check.status === "fail").length,
+        setupCiWarnCount: result.checks.filter((check) => check.status === "warn").length,
+      }));
+      return;
+    }
+
     const result = await initCi(options);
     const skipped = result.workflowStatus === "skipped";
     process.stdout.write(`${result.workflowStatus}: ${result.workflowPath}\n`);

--- a/src/commands/lock.ts
+++ b/src/commands/lock.ts
@@ -11,7 +11,7 @@ import {
 } from "../lockfile.js";
 import type { LockFileServerEntry } from "../lockfile.js";
 import { runTarget } from "../runner.js";
-import { ANSI, c, getBinName } from "./helpers.js";
+import { ANSI, c, getBinName, printCiConversionCta } from "./helpers.js";
 
 // ── Register ────────────────────────────────────────────────────────────────
 
@@ -162,6 +162,11 @@ export function registerLockCommands(program: Command): void {
 
       if (anyFailed) {
         process.exitCode = 1;
+      } else {
+        printCiConversionCta({
+          bin: getBinName(),
+          context: "enforce this lock file on every PR:",
+        });
       }
     });
 }

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -10,7 +10,7 @@ import { buildEvent, recordEvent } from "../telemetry.js";
 import type { RunArtifact } from "../types.js";
 import { TOOL_VERSION } from "../version.js";
 import { maybePrintCloudCta } from "../commercial.js";
-import { ANSI, LOGO, c, useColor } from "./helpers.js";
+import { ANSI, LOGO, c, printCiConversionCta, useColor } from "./helpers.js";
 
 // ── Scan implementation ─────────────────────────────────────────────────────
 
@@ -167,6 +167,14 @@ async function runScan(bin: string, configPath: string | undefined, invokeTools:
     process.stdout.write(c(ANSI.dim, `  Run ${c(ANSI.cyan, `${bin} --help`)} for more commands\n`));
   }
   process.stdout.write("\n");
+
+  if (failCount === 0) {
+    printCiConversionCta({
+      bin,
+      context: "turn this scan into a CI gate:",
+      target: targets.length === 1 ? targets[0]?.config : undefined,
+    });
+  }
 
   if (format === "pr-comment-matrix" && artifacts.length > 0) {
     const { renderMatrixComment } = await import("../reporters/pr-comment-matrix.js");

--- a/src/commands/score.ts
+++ b/src/commands/score.ts
@@ -10,7 +10,7 @@ import {
 import { defaultRunsDirectory } from "../storage.js";
 import { buildEvent, recordEvent } from "../telemetry.js";
 import { maybePrintCloudCta } from "../commercial.js";
-import { ANSI, c, formatOutput, targetFromCommand, writeOutput } from "./helpers.js";
+import { ANSI, c, formatOutput, printCiConversionCta, targetFromCommand, writeOutput } from "./helpers.js";
 
 export function registerScoreCommands(program: Command): void {
   // ── score ────────────────────────────────────────────────────────────
@@ -100,6 +100,12 @@ export function registerScoreCommands(program: Command): void {
         }
       }
       process.stdout.write("\n");
+      if (artifact.gate !== "fail") {
+        printCiConversionCta({
+          context: "turn this score into a public trust signal:",
+          target,
+        });
+      }
       maybePrintCloudCta("security");
 
       if (artifact.gate === "fail") {

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -8,23 +8,7 @@ import { defaultRunsDirectory } from "../storage.js";
 import { appendHistory, buildHistoryEntry, getTrend, readHistory } from "../history.js";
 import { buildEvent, recordEvent } from "../telemetry.js";
 import { maybePrintCloudCta } from "../commercial.js";
-import { ANSI, c, resolveTarget, targetFromCommand } from "./helpers.js";
-
-function quoteShell(value: string): string {
-  if (/^[A-Za-z0-9_./:@=-]+$/.test(value)) return value;
-  return `"${value.replaceAll("\\", "\\\\").replaceAll("\"", "\\\"")}"`;
-}
-
-function setupCiHint(target: Awaited<ReturnType<typeof resolveTarget>>, targetPath?: string): string {
-  if (targetPath) {
-    return `npx @kryptosai/mcp-observatory setup-ci --all --target ${quoteShell(targetPath)}`;
-  }
-  if (target.adapter === "local-process") {
-    const command = [target.command, ...target.args].map(quoteShell).join(" ");
-    return `npx @kryptosai/mcp-observatory setup-ci --all --command ${quoteShell(command)}`;
-  }
-  return "npx @kryptosai/mcp-observatory setup-ci --all --target mcp-observatory.target.json";
-}
+import { ANSI, c, printCiConversionCta, resolveTarget, targetFromCommand } from "./helpers.js";
 
 export function registerTestCommands(program: Command): void {
   program
@@ -94,10 +78,12 @@ export function registerTestCommands(program: Command): void {
 
       if (artifact.gate === "fail") {
         process.exitCode = 1;
-      } else if (process.stdout.isTTY && process.env["CI"] !== "true") {
-        process.stdout.write(`  ${c(ANSI.bold, "Next:")} keep this passing in CI:\n`);
-        process.stdout.write(`  ${c(ANSI.dim, "$")} ${c(ANSI.cyan, setupCiHint(target, options.target))}\n`);
-        process.stdout.write(`  ${c(ANSI.dim, "Public trust: add the badge, and star https://github.com/KryptosAI/mcp-observatory if it saved time.")}\n\n`);
+      } else {
+        printCiConversionCta({
+          context: "keep this passing in CI:",
+          target,
+          targetPath: options.target,
+        });
       }
       maybePrintCloudCta(options.security ? "security" : "general");
     });

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -62,6 +62,12 @@ export interface TelemetryEnrichment {
   // Commit status
   commitStatusSet?: boolean;
   commitStatusState?: string;
+  // CI adoption
+  setupCiDoctor?: boolean;
+  setupCiReady?: boolean;
+  setupCiFailCount?: number;
+  setupCiWarnCount?: number;
+  sampleReport?: boolean;
   // Nightly scans
   nightlyScan?: boolean;
   issueCreated?: boolean;

--- a/tests/cli-entrypoint.test.ts
+++ b/tests/cli-entrypoint.test.ts
@@ -185,6 +185,7 @@ describe("CLI entrypoint", () => {
     const { stdout, exitCode } = runCli(["setup-ci", "--help"]);
     expect(exitCode).toBe(0);
     expect(stdout).toContain("setup-ci");
+    expect(stdout).toContain("--doctor");
   });
 
   it("history with no data shows empty message", () => {

--- a/tests/enterprise-report.test.ts
+++ b/tests/enterprise-report.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { buildEnterpriseReport, renderEnterpriseReportHtml } from "../src/commands/enterprise-report.js";
+import { buildEnterpriseReport, buildSampleEnterpriseArtifacts, renderEnterpriseReportHtml } from "../src/commands/enterprise-report.js";
 import type { CheckResult, RunArtifact } from "../src/types.js";
 
 function makeCheck(id: CheckResult["id"], status: CheckResult["status"], itemCount = 0, message = `${id} ${status}`): CheckResult {
@@ -74,5 +74,14 @@ describe("enterprise report", () => {
     expect(html).toContain("<!doctype html>");
     expect(html).toContain("<h1>Title</h1>");
     expect(html).toContain("<p>Body</p>");
+  });
+
+  it("builds a sanitized sample enterprise report", () => {
+    const report = buildEnterpriseReport(buildSampleEnterpriseArtifacts(), "Sample pilot");
+    expect(report).toContain("Account: Sample pilot");
+    expect(report).toContain("payments-mcp");
+    expect(report).toContain("internal-docs-mcp");
+    expect(report).toContain("customer-support-mcp");
+    expect(report).toContain("Security findings");
   });
 });

--- a/tests/init-ci.test.ts
+++ b/tests/init-ci.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, readFile, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { initCi } from "../src/commands/init-ci.js";
+import { doctorSetupCi, initCi } from "../src/commands/init-ci.js";
 
 const tempDirs: string[] = [];
 
@@ -128,6 +128,53 @@ describe("init-ci", () => {
     expect(await readFile(issueBody, "utf8")).toContain("compatibility/security checks");
     expect(await readFile(issueBody, "utf8")).toContain("validates the pull request code");
     expect(await readFile(scoreBadge, "utf8")).toContain("mcp-observatory badge");
+  });
+
+  it("reports a ready setup-ci adoption kit", async () => {
+    const dir = await tempDir();
+    const workflow = path.join(dir, ".github/workflows/mcp-observatory.yml");
+    const badgeFile = path.join(dir, "docs/mcp-observatory-badge.md");
+    const targetConfig = path.join(dir, "mcp-observatory.target.json");
+    const prBody = path.join(dir, "docs/mcp-observatory-pr-body.md");
+    const issueBody = path.join(dir, "docs/mcp-observatory-issue.md");
+    const scoreBadge = path.join(dir, "docs/mcp-observatory-score-badge.md");
+
+    await initCi({
+      command: "npx -y @example/mcp-server",
+      workflow,
+      badgeFile,
+      targetConfig,
+      prBody,
+      issueBody,
+      scoreBadge,
+      all: true,
+    });
+
+    const result = await doctorSetupCi({
+      workflow,
+      badgeFile,
+      targetConfig,
+      prBody,
+      issueBody,
+      scoreBadge,
+    });
+
+    expect(result.ready).toBe(true);
+    expect(result.checks.find((check) => check.id === "workflow")).toMatchObject({ status: "pass" });
+    expect(result.checks.find((check) => check.id === "action-ref")).toMatchObject({ status: "pass" });
+    expect(result.checks.find((check) => check.id === "permissions")).toMatchObject({ status: "pass" });
+  });
+
+  it("reports missing setup-ci workflow as the blocking doctor failure", async () => {
+    const dir = await tempDir();
+    const workflow = path.join(dir, ".github/workflows/mcp-observatory.yml");
+    const result = await doctorSetupCi({ command: "npx -y @example/mcp-server", workflow });
+
+    expect(result.ready).toBe(false);
+    expect(result.checks.find((check) => check.id === "workflow")).toMatchObject({
+      status: "fail",
+      fix: "npx @kryptosai/mcp-observatory setup-ci --all --command \"npx -y @example/mcp-server\"",
+    });
   });
 
   it("preserves quoted command arguments in generated target config", async () => {

--- a/tests/metrics-dashboard.test.ts
+++ b/tests/metrics-dashboard.test.ts
@@ -108,6 +108,7 @@ describe("local metrics dashboard", () => {
     expect(html).toContain("Strategy");
     expect(html).toContain("Command Funnel");
     expect(html).toContain("Version Adoption");
+    expect(html).toContain("clone/download to CI");
     expect(html).toContain("Account Drilldown");
     expect(html).toContain("Source Mix By Day");
     expect(html).toContain("Downloads");

--- a/tests/public-docs-privacy.test.ts
+++ b/tests/public-docs-privacy.test.ts
@@ -3,7 +3,13 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 const publicProofDocs = [
+  "CLONED_THIS.md",
   "docs/proof.md",
+  "docs/clone-to-ci-campaign.md",
+  "docs/ecosystem-distribution-kit.md",
+  "docs/certification-pr-campaign.md",
+  "docs/mcp-safety-field-report-2026-06.md",
+  "docs/setup-ci-doctor.md",
   "docs/mcp-safety-report-latest.md",
   "docs/project-case-study.md",
   "docs/enterprise-outreach-playbook.md",


### PR DESCRIPTION
## Summary
- add `setup-ci --doctor` to inspect CI adoption readiness
- broaden product-led conversion prompts across successful CLI workflows
- add clone/download-to-CI conversion metrics to the local dashboard
- add clone-to-CI, distribution, certification, and safety field report docs
- add sanitized `enterprise-report --sample` support for paid pilot demos
- include `CLONED_THIS.md` in the published package file set

## Six-strategy coverage
- Passive credibility: `CLONED_THIS.md`, README links, setup doctor docs
- Product-led conversion: CLI CTAs, `setup-ci --doctor`, dashboard conversion metric
- Ecosystem distribution: distribution kit and package surface updates
- Authority: June 2026 MCP safety field report
- Certification: PR campaign kit
- Revenue: sample enterprise report support; private outreach pack kept ignored under `reports/`

## Validation
- npm run typecheck -- --pretty false
- npm run lint
- npm test
- npm run build
- npm run validate:artifacts
- npm run verify:packed-install
- npm run metrics:refresh
- `setup-ci --doctor` missing-workflow smoke test
- `enterprise-report --sample` smoke test
- staged public-doc privacy grep for named telemetry accounts

## Privacy
Raw telemetry and account-specific pilot outreach stay local under ignored `reports/`. Public docs avoid named telemetry-derived accounts.