### PR TITLE
fix: sync v0.26.1 release metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: KryptosAI/mcp-observatory/action@v0.25.1
+      - uses: KryptosAI/mcp-observatory/action@v0.26.1
         with:
           command: npx -y my-mcp-server
           deep: true

--- a/action/README.md
+++ b/action/README.md
@@ -76,10 +76,10 @@ GitHub may downgrade `GITHUB_TOKEN` to read-only on forked pull requests. In tha
 - uses: KryptosAI/mcp-observatory/action@main
   with:
     command: npx -y my-mcp-server
-    package-version: 0.25.1
+    package-version: 0.26.1
 ```
 
-For stricter reproducibility, pin both the Action ref and the npm package version, for example `uses: KryptosAI/mcp-observatory/action@v0.25.1` plus `package-version: 0.25.1`.
+For stricter reproducibility, pin both the Action ref and the npm package version, for example `uses: KryptosAI/mcp-observatory/action@v0.26.1` plus `package-version: 0.26.1`.
 
 ### Verify against baseline
 

--- a/docs/certification-distribution.md
+++ b/docs/certification-distribution.md
@@ -81,7 +81,7 @@ For production CI, pin the package version:
 - uses: KryptosAI/mcp-observatory/action@main
   with:
     command: npx -y <server-package>
-    package-version: 0.25.1
+    package-version: 0.26.1
     deep: true
     security: true
 ```

--- a/docs/ecosystem-distribution-kit.md
+++ b/docs/ecosystem-distribution-kit.md
@@ -63,7 +63,7 @@ Description:
 Snippet:
 
 ```yaml
-- uses: KryptosAI/mcp-observatory/action@v0.25.1
+- uses: KryptosAI/mcp-observatory/action@v0.26.1
   with:
     command: npx -y <server-package>
     deep: true

--- a/docs/project-case-study.md
+++ b/docs/project-case-study.md
@@ -75,7 +75,7 @@ The distribution wedge is useful CI for other MCP repositories. The certificatio
 
 Current public distribution proof includes:
 
-- latest release: `v0.25.1`
+- latest release: `v0.26.1`
 - npm package: `@kryptosai/mcp-observatory`
 - GitHub Action: `KryptosAI/mcp-observatory/action@main`
 - npm downloads snapshot: 511 downloads for June 11-20, 2026

--- a/docs/proof.md
+++ b/docs/proof.md
@@ -5,8 +5,8 @@ MCP Observatory is early, but it is already a working MCP testing/security stack
 ## Current Public Surface
 
 - npm package: `@kryptosai/mcp-observatory`
-- GitHub Action: `KryptosAI/mcp-observatory/action@v0.25.1`
-- Latest release: `v0.25.1`
+- GitHub Action: `KryptosAI/mcp-observatory/action@v0.26.1`
+- Latest release: `v0.26.1`
 - CLI command count: scan, test, record, replay, verify, diff, watch, suggest, serve, lock, history, setup-ci, init-ci, ci-report, enterprise-report, score, badge, cloud
 - Test suite: 334 passing tests across 43 test files as of June 20, 2026
 - GitHub traffic snapshot: 745 clones and 232 unique cloners in the visible June 2026 traffic window

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kryptosai/mcp-observatory",
-  "version": "0.25.1",
+  "version": "0.26.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kryptosai/mcp-observatory",
-      "version": "0.25.1",
+      "version": "0.26.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kryptosai/mcp-observatory",
-  "version": "0.25.1",
+  "version": "0.26.1",
   "description": "The CI and security gate for MCP servers before agents depend on them.",
   "mcpName": "io.github.KryptosAI/mcp-observatory",
   "license": "MIT",

--- a/src/commands/enterprise-report.ts
+++ b/src/commands/enterprise-report.ts
@@ -144,7 +144,7 @@ function sampleArtifact(targetId: string, gate: RunArtifact["gate"], score: numb
     gate,
     runId: `sample-${targetId}`,
     createdAt: new Date().toISOString(),
-    toolVersion: "0.25.1",
+    toolVersion: "0.26.1",
     target: {
       targetId,
       adapter: "local-process",

--- a/src/commands/init-ci.ts
+++ b/src/commands/init-ci.ts
@@ -27,7 +27,7 @@ const DEFAULT_TARGET_CONFIG_PATH = "mcp-observatory.target.json";
 const DEFAULT_PR_BODY_PATH = "docs/mcp-observatory-pr-body.md";
 const DEFAULT_ISSUE_BODY_PATH = "docs/mcp-observatory-issue.md";
 const DEFAULT_SCORE_BADGE_PATH = "docs/mcp-observatory-score-badge.md";
-const DEFAULT_ACTION_REF = "v0.25.1";
+const DEFAULT_ACTION_REF = "v0.26.1";
 
 async function exists(filePath: string): Promise<boolean> {
   try {

--- a/tests/init-ci.test.ts
+++ b/tests/init-ci.test.ts
@@ -33,7 +33,7 @@ describe("init-ci", () => {
     expect(result.badgeStatus).toBe("created");
 
     const workflowText = await readFile(workflow, "utf8");
-    expect(workflowText).toContain("uses: KryptosAI/mcp-observatory/action@v0.25.1");
+    expect(workflowText).toContain("uses: KryptosAI/mcp-observatory/action@v0.26.1");
     expect(workflowText).not.toContain("pull-requests: write");
     expect(workflowText).not.toContain("statuses: write");
     expect(workflowText).toContain("command: npx -y @example/mcp-server");

--- a/tests/public-docs-privacy.test.ts
+++ b/tests/public-docs-privacy.test.ts
@@ -48,7 +48,7 @@ describe("public proof docs privacy guardrails", () => {
 
   it("keeps README action examples read-only and pinned", async () => {
     const content = await readFile(path.join(process.cwd(), "README.md"), "utf8");
-    expect(content).toContain("KryptosAI/mcp-observatory/action@v0.25.1");
+    expect(content).toContain("KryptosAI/mcp-observatory/action@v0.26.1");
     expect(content).not.toContain("KryptosAI/mcp-observatory/action@main");
     expect(content).not.toContain("pull-requests: write\n  statuses: write");
   });


### PR DESCRIPTION
## Summary
- bump package metadata to 0.26.1 after the v0.26.0 growth-campaign release
- update generated CI defaults, public docs, and tests to pin action/package examples at v0.26.1
- align the sample enterprise-report artifact toolVersion with the package version

## Validation
- npm run typecheck -- --pretty false
- npm run lint
- npm test
- npm run build
- npm run validate:artifacts
- npm run verify:packed-install