### PR TITLE
Add target registry contribution flywheel

### DIFF
--- a/.github/ISSUE_TEMPLATE/target-contribution.yml
+++ b/.github/ISSUE_TEMPLATE/target-contribution.yml
@@ -1,0 +1,68 @@
+name: MCP target contribution
+description: Propose one public MCP server for the Safety Index target registry.
+title: "[Target] Add "
+labels: ["good first issue", "target-registry", "mcp-server"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        The highest-leverage contribution is one safe MCP target that can run without private credentials.
+
+        Please do not paste secrets, private URLs, private schemas, customer data, or destructive commands.
+  - type: input
+    id: server
+    attributes:
+      label: MCP server
+      description: Link to the public repo, package, or docs.
+      placeholder: https://github.com/example/example-mcp
+    validations:
+      required: true
+  - type: input
+    id: command
+    attributes:
+      label: Safe startup command
+      description: Command Observatory can run in CI without secrets.
+      placeholder: npx -y example-mcp
+    validations:
+      required: true
+  - type: dropdown
+    id: secrets
+    attributes:
+      label: Requires secrets?
+      options:
+        - "No"
+        - "Optional"
+        - "Yes"
+    validations:
+      required: true
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      options:
+        - Browser Automation
+        - Developer Tools
+        - Documentation / Search
+        - Filesystem
+        - Memory
+        - Database
+        - Infrastructure
+        - Visualization
+        - Agent Runtime
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: Why agents care
+      description: What would an autonomous agent use this MCP server for?
+      placeholder: Agents may use this server to...
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: Safety notes
+      description: Mention fixtures, harmless test modes, risky tools, or commands to avoid.
+      placeholder: This can run with no secrets. Avoid invoking...

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@ MCP Observatory helps agents test other MCP tools before relying on them. Keep c
 ## High-Leverage Agent Tasks
 
 - Add a real MCP server target that can run in CI without secrets.
+- Follow `docs/target-contribution-guide.md` to add one Safety Index target and generated evidence.
 - Improve the Markdown or JSON report so autonomous agents can decide whether a tool is safe to use.
 - Make startup failure diagnosis clearer.
 - Improve `setup-ci --all` so maintainers can add read-only MCP checks with less friction.
@@ -41,6 +42,13 @@ npm run metrics:refresh
 npm run metrics:serve
 ```
 
+For target-registry contributions:
+
+```bash
+npm run safety-index
+npm test -- tests/safety-index.test.ts
+```
+
 ## Bot Maintainer Contribution Path
 
 If you maintain an autonomous agent, OpenClaw-style productivity system, MCP gateway, or coding-agent runtime, the best contribution is a safe target:
@@ -54,3 +62,18 @@ What should the agent know before trusting this tool?
 ```
 
 Use `docs/agent-runtime-quickstart.md` for the detailed path.
+
+## Target Registry Contribution Path
+
+The best bot-friendly contribution is one target:
+
+```text
+Public MCP server:
+Safe startup command:
+Requires secrets? yes/no
+Risk class:
+Failure class:
+Why agents care:
+```
+
+Use `docs/target-registry.md` and `docs/target-contribution-guide.md`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,8 @@ This repo is intentionally small. Good contributions make the evidence clearer. 
 
 ## Current Priorities
 
+- Add one safe MCP target to the [MCP Target Registry](./docs/target-registry.md)
+- Follow the [Target Contribution Guide](./docs/target-contribution-guide.md) for a small first PR with evidence
 - [#3 Improve artifact output readability in the Markdown report](https://github.com/KryptosAI/mcp-observatory/issues/3)
 - [#6 Improve CLI startup error messaging for connection and setup failures](https://github.com/KryptosAI/mcp-observatory/issues/6)
 - [#1](https://github.com/KryptosAI/mcp-observatory/issues/1) and [#2](https://github.com/KryptosAI/mcp-observatory/issues/2) once a concrete passing server is identified
@@ -52,9 +54,10 @@ npm run integration:real
 
 If this is your first contribution to the project, pick one of these paths:
 
-1. Docs path: improve one README or CONTRIBUTING section and keep the change tightly scoped.
-2. Reporting path: improve one Markdown report section and update the checked-in report examples.
-3. Fixture path: add or refine one deterministic target or artifact in `examples/` or `tests/fixtures/`.
+1. Target path: add one public no-secret MCP server to `docs/safety-index/targets.json` and include generated evidence.
+2. Docs path: improve one README or CONTRIBUTING section and keep the change tightly scoped.
+3. Reporting path: improve one Markdown report section and update the checked-in report examples.
+4. Fixture path: add or refine one deterministic target or artifact in `examples/` or `tests/fixtures/`.
 
 For each path:
 
@@ -81,3 +84,14 @@ When you add a fixture:
 - document what the fixture is proving and why it matters
 
 The `fixture contribution` issue template is the best starting point for proposing a new case.
+
+## Target Registry Contributions
+
+The fastest useful contribution is one safe MCP target. Start with the [MCP Target Registry](./docs/target-registry.md), then use the [Target Contribution Guide](./docs/target-contribution-guide.md).
+
+Minimal PR shape:
+
+- one new object in `docs/safety-index/targets.json`
+- generated JSON and Markdown evidence under `docs/safety-index/artifacts/`
+- updated `docs/mcp-server-safety-index.md`
+- validation commands in the PR body

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Agents should not depend on tools nobody tests. MCP Observatory gives MCP server
 
 Two fast paths:
 
-Cloned this repo? Start here: [`CLONED_THIS.md`](./CLONED_THIS.md).
+Cloned this repo? Start here: [`CLONED_THIS.md`](./CLONED_THIS.md). Want to contribute? Add one server to the [MCP Target Registry](./docs/target-registry.md).
 
 Add MCP CI in one command:
 
@@ -67,7 +67,7 @@ Observatory gives maintainers and teams:
 - **MCP server mode** so agents can inspect other MCP servers directly
 - **Production pilot path** for hosted history, private repo reporting, certification, support, and fleet visibility
 
-See the [clone-to-CI campaign](./docs/clone-to-ci-campaign.md), [`setup-ci --doctor`](./docs/setup-ci-doctor.md), [MCP server security field guide](./docs/mcp-security-field-guide.md), [Safety Methodology](./docs/methodology.md), [MCP Server Safety Index](./docs/mcp-server-safety-index.md), [June 2026 safety field report](./docs/mcp-safety-field-report-2026-06.md), [reference evaluations](./docs/reference-evaluations.md), [MCP lock files](./docs/mcp-lock-files.md), [public proof](./docs/proof.md), the [certification PR campaign](./docs/certification-pr-campaign.md), [ecosystem distribution kit](./docs/ecosystem-distribution-kit.md), [local metrics dashboard](./docs/metrics-dashboard.md), and [commercial pilots](./COMMERCIAL.md).
+See the [target registry](./docs/target-registry.md), [target contribution guide](./docs/target-contribution-guide.md), [clone-to-CI campaign](./docs/clone-to-ci-campaign.md), [`setup-ci --doctor`](./docs/setup-ci-doctor.md), [MCP server security field guide](./docs/mcp-security-field-guide.md), [Safety Methodology](./docs/methodology.md), [MCP Server Safety Index](./docs/mcp-server-safety-index.md), [June 2026 safety field report](./docs/mcp-safety-field-report-2026-06.md), [reference evaluations](./docs/reference-evaluations.md), [MCP lock files](./docs/mcp-lock-files.md), [public proof](./docs/proof.md), the [certification PR campaign](./docs/certification-pr-campaign.md), [ecosystem distribution kit](./docs/ecosystem-distribution-kit.md), [local metrics dashboard](./docs/metrics-dashboard.md), and [commercial pilots](./COMMERCIAL.md).
 
 ## For Security And Platform Teams
 

--- a/docs/target-contribution-guide.md
+++ b/docs/target-contribution-guide.md
@@ -1,0 +1,139 @@
+# Target Contribution Guide
+
+This guide turns MCP Observatory contribution into one small, repeatable action: add one safe MCP server target.
+
+## The Goal
+
+Add a target that another person or agent can reproduce later.
+
+Success means:
+
+- the command is public
+- the command is safe to run in CI
+- the target has a clear risk class
+- generated evidence is checked in
+- the PR is small enough to review quickly
+
+## Step 1: Pick A Candidate
+
+Look for MCP servers in:
+
+- GitHub repos with `mcp-server` or `model-context-protocol`
+- npm packages ending in `-mcp` or `mcp-server`
+- agent runtime docs that mention MCP tools
+- existing issues where maintainers ask for compatibility evidence
+
+Prefer targets with a simple command:
+
+```bash
+npx -y package-name
+```
+
+If a target needs a fixture, keep it harmless and checked in under `examples/`.
+
+## Step 2: Run A Quick Check
+
+From the repo root:
+
+```bash
+npx @kryptosai/mcp-observatory test npx -y package-name --security
+```
+
+If that works, add the target to:
+
+```text
+docs/safety-index/targets.json
+```
+
+## Step 3: Write Useful Metadata
+
+Use plain language. The metadata should help an agent decide whether this tool is worth trusting.
+
+- `riskClass`: what kind of power this server gives an agent
+- `failureClass`: what kind of breakage would matter most
+- `whyItMatters`: why agent users care
+- `reproductionNotes`: how to run it safely
+
+Examples:
+
+```text
+Browser control
+Browser/code execution boundary
+Agents may use this to navigate pages and inspect web state.
+Zero-config public package; security findings are policy-review prompts, not vulnerability claims.
+```
+
+## Step 4: Generate Evidence
+
+Run:
+
+```bash
+npm run safety-index
+```
+
+This updates:
+
+```text
+docs/mcp-server-safety-index.md
+docs/safety-index/artifacts/<target-id>.json
+docs/safety-index/artifacts/<target-id>.md
+```
+
+## Step 5: Validate
+
+Run the fast checks:
+
+```bash
+npm run lint
+npm run typecheck
+npm test -- tests/safety-index.test.ts
+```
+
+Use broader checks for larger changes:
+
+```bash
+npm test
+npm run smoke
+```
+
+## Step 6: Open A Tight PR
+
+Good PR title:
+
+```text
+Add Safety Index target for Example MCP
+```
+
+Good PR body:
+
+```md
+## Summary
+
+- add a no-secret Safety Index target for Example MCP
+- include generated JSON and Markdown evidence
+
+## Validation
+
+- npm run safety-index
+- npm run lint
+- npm run typecheck
+- npm test -- tests/safety-index.test.ts
+```
+
+## Maintainer Follow-Up
+
+After the PR lands, you can ask the upstream maintainer:
+
+```md
+I added a read-only MCP Observatory target for your MCP server so agent users can verify startup, schemas, and common safety footguns.
+
+The check is local-first and does not require secrets. If you want, the same target can become an advisory GitHub Action or README badge.
+```
+
+## What Not To Do
+
+- do not add broad scraping
+- do not include secrets or private URLs
+- do not run destructive tools
+- do not combine many targets in one first PR
+- do not frame warnings as vulnerabilities unless the evidence clearly supports that

--- a/docs/target-registry.md
+++ b/docs/target-registry.md
@@ -1,0 +1,112 @@
+# MCP Target Registry
+
+```
+  ███╗   ███╗ ██████╗██████╗
+  ████╗ ████║██╔════╝██╔══██╗
+  ██╔████╔██║██║     ██████╔╝
+  ██║╚██╔╝██║██║     ██╔═══╝
+  ██║ ╚═╝ ██║╚██████╗██║
+  ╚═╝     ╚═╝ ╚═════╝╚═╝
+     O B S E R V A T O R Y
+```
+
+The easiest way to help MCP Observatory grow is to add one safe MCP target.
+
+A target is a public MCP server that can be installed, started, and evaluated without private credentials or destructive side effects. Each target teaches agents and maintainers what healthy MCP behavior looks like.
+
+## Why This Can Compound
+
+Every accepted target creates several useful surfaces:
+
+- a reproducible startup command
+- a public safety-index row
+- JSON and Markdown evidence artifacts
+- a maintainer conversation starter
+- a badge or CI adoption path
+- a small contribution that another agent can copy
+
+That means one tiny PR can produce docs, evidence, search surface, backlinks, and future issues.
+
+## Registry Source
+
+Current Safety Index targets live in:
+
+```text
+docs/safety-index/targets.json
+```
+
+Generated evidence lives in:
+
+```text
+docs/safety-index/artifacts/
+docs/mcp-server-safety-index.md
+```
+
+## Best Targets
+
+Good first targets:
+
+- start with `npx -y package-name` or another public no-secret command
+- expose at least one real MCP tool, prompt, or resource
+- avoid production accounts, OAuth, private tokens, and paid services
+- use a harmless fixture directory when filesystem access is needed
+- represent something agents actually use: browser, files, memory, docs, databases, search, code, CI, or infrastructure
+
+Avoid targets that need:
+
+- private OAuth
+- live destructive actions
+- paid-only APIs
+- customer data
+- private repositories
+- long-running background services
+
+## Target Entry Shape
+
+Add one object to `docs/safety-index/targets.json`:
+
+```json
+{
+  "id": "example-server",
+  "name": "Example MCP Server",
+  "repo": "https://github.com/example/example-mcp",
+  "packageName": "example-mcp",
+  "category": "Developer Tools",
+  "command": "npx",
+  "args": ["-y", "example-mcp"],
+  "timeoutMs": 60000,
+  "riskClass": "Developer tool access",
+  "failureClass": "Startup/listing reproducibility",
+  "whyItMatters": "Agents may rely on this tool during coding workflows.",
+  "reproductionNotes": "Zero-config public package."
+}
+```
+
+## Contributor Loop
+
+1. Pick one public MCP server.
+2. Confirm it starts without secrets.
+3. Add one target entry.
+4. Run the Safety Index locally.
+5. Open a small PR with the target and generated evidence.
+6. Optionally ask the maintainer if they want an Observatory badge or CI check.
+
+Use the detailed walkthrough in [Target Contribution Guide](./target-contribution-guide.md).
+
+## Maintainer-Friendly Ask
+
+When contacting a maintainer, keep it concrete:
+
+```md
+I added a read-only MCP Observatory target for this server so agent users can verify startup, listed tools/prompts/resources, schema shape, and common safety footguns.
+
+It does not require an account, hosted service, or secrets. If you prefer a different safe startup command, I can adjust the target.
+```
+
+## Agent-Friendly Task
+
+For autonomous coding agents:
+
+```text
+Find one public MCP server with a no-secret startup command. Add a single Safety Index target entry, run npm run safety-index, and open a PR that includes the generated JSON/Markdown evidence.
+```

--- a/llms.txt
+++ b/llms.txt
@@ -47,6 +47,8 @@ Start here:
 
 - Agent runtime quickstart: `docs/agent-runtime-quickstart.md`
 - OpenClaw agent template: `docs/openclaw-agent-template/SOUL.md`
+- Target registry: `docs/target-registry.md`
+- Target contribution guide: `docs/target-contribution-guide.md`
 - Contribution guide: `CONTRIBUTING.md`
 - Certification distribution loop: `docs/certification-distribution.md`
 - GitHub issue tracker: https://github.com/KryptosAI/mcp-observatory/issues
@@ -56,3 +58,7 @@ Start here:
 Agents should not depend on tools nobody tests.
 
 MCP Observatory is complementary to official MCP SDKs and conformance tooling. It focuses on practical CI, security checks, drift detection, reports, and regression evidence for real MCP servers.
+
+## Best First Contribution
+
+Add one safe no-secret MCP server target to `docs/safety-index/targets.json`, run `npm run safety-index`, and open a PR with the generated evidence.


### PR DESCRIPTION
## Summary
- add a branded MCP Target Registry explainer that makes one-target PRs the main contribution loop
- add a Target Contribution Guide for humans and agents to submit safe no-secret MCP targets with evidence
- add a dedicated target contribution issue form and route it through the new target-registry label
- link the path from README, CONTRIBUTING, AGENTS.md, and llms.txt

## Validation
- npm test -- tests/safety-index.test.ts
- npm run typecheck -- --pretty false
- npm run lint