### PR TITLE
Link target registry contribution queue

### DIFF
--- a/docs/target-registry.md
+++ b/docs/target-registry.md
@@ -93,6 +93,20 @@ Add one object to `docs/safety-index/targets.json`:
 
 Use the detailed walkthrough in [Target Contribution Guide](./target-contribution-guide.md).
 
+## Contribution Queue
+
+Ready-made target tasks live under the [`target-registry` label](https://github.com/KryptosAI/mcp-observatory/issues?q=is%3Aissue%20is%3Aopen%20label%3Atarget-registry).
+
+Good first target issues:
+
+- [Chrome DevTools MCP](https://github.com/KryptosAI/mcp-observatory/issues/128)
+- [Git MCP server](https://github.com/KryptosAI/mcp-observatory/issues/129)
+- [UI5 MCP safe startup mode](https://github.com/KryptosAI/mcp-observatory/issues/130)
+- [n8n MCP no-secret target](https://github.com/KryptosAI/mcp-observatory/issues/131)
+- [Kubernetes MCP safe-mode target](https://github.com/KryptosAI/mcp-observatory/issues/132)
+
+Pick one issue, make one small PR, and include generated evidence.
+
 ## Maintainer-Friendly Ask
 
 When contacting a maintainer, keep it concrete:


### PR DESCRIPTION
## Summary
- link the target registry docs to the live target-registry issue queue
- list the first five good-first target issues for contributors and coding agents

## Validation
- npm run lint
- npm run typecheck -- --pretty false
- npm test -- tests/safety-index.test.ts