### PR TITLE
Add opt-out setup-ci conversion flow

### DIFF
--- a/src/commands/init-ci.ts
+++ b/src/commands/init-ci.ts
@@ -2,6 +2,9 @@ import { access, mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { Command } from "commander";
 import { buildEvent, recordEvent } from "../telemetry.js";
+import { defaultRunsDirectory, findLatestSuccessfulRunArtifact, readArtifact } from "../storage.js";
+import type { RunArtifact } from "../types.js";
+import { quoteShell } from "./helpers.js";
 
 export interface InitCiOptions {
   command?: string;
@@ -19,6 +22,7 @@ export interface InitCiOptions {
   all?: boolean;
   force?: boolean;
   doctor?: boolean;
+  fromLastRun?: boolean;
 }
 
 const DEFAULT_WORKFLOW_PATH = ".github/workflows/mcp-observatory.yml";
@@ -277,6 +281,12 @@ function setupCommand(options: InitCiOptions): string {
   return "npx @kryptosai/mcp-observatory setup-ci --all --command \"npx -y <server-package>\"";
 }
 
+function initCiOptionsFromLastRunArtifact(artifact: RunArtifact, force: boolean | undefined): InitCiOptions | undefined {
+  if (artifact.target.adapter !== "local-process") return undefined;
+  const command = [artifact.target.command, ...artifact.target.args].map(quoteShell).join(" ");
+  return { all: true, command, force };
+}
+
 export async function doctorSetupCi(options: InitCiOptions = {}): Promise<SetupCiDoctorResult> {
   const workflowPath = options.workflow ?? DEFAULT_WORKFLOW_PATH;
   const badgePath = options.badgeFile ?? DEFAULT_BADGE_PATH;
@@ -433,7 +443,8 @@ function addInitCiOptions(command: Command): Command {
     .option("--action-ref <ref>", "Git ref for KryptosAI/mcp-observatory/action. Use a full commit SHA for strict third-party action pinning.", DEFAULT_ACTION_REF)
     .option("--all", "Write the full adoption kit: workflow, badge, target config, PR body, issue body, and score badge instructions.", false)
     .option("--force", "Overwrite existing files.", false)
-    .option("--doctor", "Inspect the current repository's MCP Observatory CI adoption state.", false);
+    .option("--doctor", "Inspect the current repository's MCP Observatory CI adoption state.", false)
+    .option("--from-last-run", "Generate the adoption kit from the latest successful local run artifact.", false);
 }
 
 function initCiAction(commandName: "init-ci" | "setup-ci"): (options: InitCiOptions) => Promise<void> {
@@ -456,6 +467,30 @@ function initCiAction(commandName: "init-ci" | "setup-ci"): (options: InitCiOpti
         setupCiWarnCount: result.checks.filter((check) => check.status === "warn").length,
       }));
       return;
+    }
+
+    if (options.fromLastRun) {
+      if (options.command || options.target) {
+        throw new Error("Use --from-last-run by itself, without --command or --target.");
+      }
+      const latestPath = await findLatestSuccessfulRunArtifact(defaultRunsDirectory(process.cwd()));
+      if (!latestPath) {
+        throw new Error("No successful run artifact found. Run a passing MCP check first.");
+      }
+      const artifact = await readArtifact(latestPath);
+      if (artifact.artifactType !== "run") {
+        throw new Error(`Latest artifact is not a run artifact: ${latestPath}`);
+      }
+      const fromRunOptions = initCiOptionsFromLastRunArtifact(artifact, options.force);
+      if (!fromRunOptions) {
+        throw new Error(`Latest successful run does not contain enough target information for setup-ci: ${latestPath}`);
+      }
+      options = {
+        ...options,
+        ...fromRunOptions,
+        all: true,
+      };
+      process.stdout.write(`Using latest successful run: ${latestPath}\n`);
     }
 
     const result = await initCi(options);

--- a/src/commands/legacy.ts
+++ b/src/commands/legacy.ts
@@ -10,6 +10,7 @@ import { appendHistory, buildHistoryEntry } from "../history.js";
 import { defaultRunsDirectory } from "../storage.js";
 import { buildEvent, recordEvent } from "../telemetry.js";
 import { ANSI, c, colorStatus, formatOutput, resolveTarget, writeOutput } from "./helpers.js";
+import { maybeConvertPassingCheckToCi, type SetupCiConversionFlags } from "./setup-ci-conversion.js";
 import { runWatchMode } from "./watch.js";
 
 export function registerLegacyCommands(program: Command): void {
@@ -21,8 +22,12 @@ export function registerLegacyCommands(program: Command): void {
     .option("--watch", "Re-run checks on an interval.", false)
     .option("--interval <seconds>", "Interval in seconds for watch mode.", "30")
     .option("--invoke-tools", "Actually call safe tools to verify they execute.", false)
+    .option("--setup-ci", "Offer CI conversion after a successful check; use with --yes in non-interactive runs to write files.", false)
+    .option("--yes", "Confirm CI conversion without prompting. Only writes when used with --setup-ci.", false)
+    .option("--no-setup-ci", "Suppress the post-success CI conversion prompt and hint.")
+    .option("--force", "Overwrite existing generated CI adoption files.", false)
     .option("--no-color", "Disable colored output.")
-    .action(async (options: { outDir: string; target?: string; watch: boolean; interval: string; invokeTools: boolean }) => {
+    .action(async (options: { outDir: string; target?: string; watch: boolean; interval: string; invokeTools: boolean } & SetupCiConversionFlags) => {
       const target = await resolveTarget(options);
       if (options.watch) {
         await runWatchMode(target, options.outDir, parseInt(options.interval, 10) || 30);
@@ -58,6 +63,16 @@ export function registerLegacyCommands(program: Command): void {
 
       if (artifact.gate === "fail") {
         process.exitCode = 1;
+      } else {
+        await maybeConvertPassingCheckToCi({
+          artifact,
+          target,
+          targetPath: options.target,
+          setupCi: options.setupCi,
+          yes: options.yes,
+          noSetupCi: options.noSetupCi,
+          force: options.force,
+        });
       }
     });
 

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -10,11 +10,19 @@ import { buildEvent, recordEvent } from "../telemetry.js";
 import type { RunArtifact } from "../types.js";
 import { TOOL_VERSION } from "../version.js";
 import { maybePrintCloudCta } from "../commercial.js";
-import { ANSI, LOGO, c, printCiConversionCta, useColor } from "./helpers.js";
+import { ANSI, LOGO, c, setupCiHint, useColor } from "./helpers.js";
+import { maybeConvertPassingCheckToCi, type SetupCiConversionFlags } from "./setup-ci-conversion.js";
 
 // ── Scan implementation ─────────────────────────────────────────────────────
 
-async function runScan(bin: string, configPath: string | undefined, invokeTools: boolean, securityCheck?: boolean, format?: string): Promise<void> {
+async function runScan(
+  bin: string,
+  configPath: string | undefined,
+  invokeTools: boolean,
+  securityCheck?: boolean,
+  format?: string,
+  conversionFlags: SetupCiConversionFlags = {},
+): Promise<void> {
   const t0 = Date.now();
   process.stdout.write(useColor() ? c(ANSI.cyan, LOGO) + `  ${c(ANSI.dim, `v${TOOL_VERSION}`)}\n\n` : LOGO + `  v${TOOL_VERSION}\n\n`);
 
@@ -169,11 +177,22 @@ async function runScan(bin: string, configPath: string | undefined, invokeTools:
   process.stdout.write("\n");
 
   if (failCount === 0) {
-    printCiConversionCta({
-      bin,
-      context: "turn this scan into a CI gate:",
-      target: targets.length === 1 ? targets[0]?.config : undefined,
-    });
+    if (artifacts.length === 1 && targets[0]) {
+      await maybeConvertPassingCheckToCi({
+        artifact: artifacts[0]!,
+        bin,
+        target: targets[0].config,
+        setupCi: conversionFlags.setupCi,
+        yes: conversionFlags.yes,
+        noSetupCi: conversionFlags.noSetupCi,
+        force: conversionFlags.force,
+      });
+    } else if (conversionFlags.noSetupCi !== true) {
+      process.stdout.write(`CI conversion available for a specific target:\n  ${setupCiHint(undefined, undefined, bin)}\n`);
+      if (conversionFlags.setupCi === true) {
+        process.stdout.write("Non-interactive mode will only write files when --setup-ci --yes is present, and multi-target scans need a single target config.\n");
+      }
+    }
   }
 
   if (format === "pr-comment-matrix" && artifacts.length > 0) {
@@ -219,11 +238,15 @@ export function registerScanCommands(program: Command, bin: string): void {
     .option("--config <path>", "Path to a specific MCP config file.")
     .option("--security", "Run deep security scan (credential patterns, response analysis). Lightweight security is always included.")
     .option("--format <format>", "Output format: terminal or pr-comment-matrix.", "terminal")
+    .option("--setup-ci", "Offer CI conversion after a successful one-target scan; use with --yes in non-interactive runs to write files.", false)
+    .option("--yes", "Confirm CI conversion without prompting. Only writes when used with --setup-ci.", false)
+    .option("--no-setup-ci", "Suppress the post-success CI conversion prompt and hint.")
+    .option("--force", "Overwrite existing generated CI adoption files.", false)
     .option("--no-color", "Disable colored output.");
 
   // `scan` with no subcommand — basic scan
-  scanCmd.action(async (options: { config?: string; security?: boolean; format: string }) => {
-    await runScan(bin, options.config, false, options.security, options.format);
+  scanCmd.action(async (options: { config?: string; security?: boolean; format: string } & SetupCiConversionFlags) => {
+    await runScan(bin, options.config, false, options.security, options.format, options);
   });
 
   // `scan deep` — scan + invoke tools
@@ -233,11 +256,15 @@ export function registerScanCommands(program: Command, bin: string): void {
     .option("--config <path>", "Path to a specific MCP config file.")
     .option("--security", "Run deep security scan (credential patterns, response analysis). Lightweight security is always included.")
     .option("--format <format>", "Output format: terminal or pr-comment-matrix.", "terminal")
-    .action(async (options: { config?: string; security?: boolean; format: string }) => {
+    .option("--setup-ci", "Offer CI conversion after a successful one-target scan; use with --yes in non-interactive runs to write files.", false)
+    .option("--yes", "Confirm CI conversion without prompting. Only writes when used with --setup-ci.", false)
+    .option("--no-setup-ci", "Suppress the post-success CI conversion prompt and hint.")
+    .option("--force", "Overwrite existing generated CI adoption files.", false)
+    .action(async (options: { config?: string; security?: boolean; format: string } & SetupCiConversionFlags) => {
       // Inherit parent config option if set
       const parentConfig = scanCmd.opts().config as string | undefined;
       const parentSecurity = scanCmd.opts().security as boolean | undefined;
       const parentFormat = scanCmd.opts().format as string;
-      await runScan(bin, options.config ?? parentConfig, true, options.security ?? parentSecurity ?? true, options.format ?? parentFormat);
+      await runScan(bin, options.config ?? parentConfig, true, options.security ?? parentSecurity ?? true, options.format ?? parentFormat, options);
     });
 }

--- a/src/commands/setup-ci-conversion.ts
+++ b/src/commands/setup-ci-conversion.ts
@@ -1,0 +1,146 @@
+import readline from "node:readline/promises";
+import type { Readable, Writable } from "node:stream";
+
+import type { RunArtifact, TargetConfig } from "../types.js";
+import { buildEvent, recordEvent } from "../telemetry.js";
+import { initCi, type InitCiOptions, type InitCiResult } from "./init-ci.js";
+import { ANSI, c, quoteShell, setupCiHint } from "./helpers.js";
+
+export interface SetupCiConversionFlags {
+  setupCi?: boolean;
+  yes?: boolean;
+  noSetupCi?: boolean;
+  force?: boolean;
+}
+
+export interface SetupCiConversionOptions extends SetupCiConversionFlags {
+  artifact: RunArtifact;
+  bin?: string;
+  target?: TargetConfig;
+  targetPath?: string;
+  input?: NodeJS.ReadStream | Readable;
+  output?: NodeJS.WriteStream | Writable;
+  isInteractive?: boolean;
+}
+
+export interface SetupCiConversionResult {
+  status: "not-eligible" | "suppressed" | "hinted" | "skipped" | "written";
+  command?: string;
+  initResult?: InitCiResult;
+}
+
+function artifactTargetCommand(artifact: RunArtifact): string | undefined {
+  if (artifact.target.adapter !== "local-process") return undefined;
+  return [artifact.target.command, ...artifact.target.args].map(quoteShell).join(" ");
+}
+
+function targetCommand(target: TargetConfig | undefined): string | undefined {
+  if (target?.adapter !== "local-process") return undefined;
+  return [target.command, ...target.args].map(quoteShell).join(" ");
+}
+
+function conversionCommand(options: SetupCiConversionOptions): string | undefined {
+  const bin = options.bin ?? "npx @kryptosai/mcp-observatory";
+  if (options.targetPath) return setupCiHint(undefined, options.targetPath, bin);
+  const command = targetCommand(options.target) ?? artifactTargetCommand(options.artifact);
+  if (command) return `${bin} setup-ci --all --command ${quoteShell(command)}`;
+  return undefined;
+}
+
+export function initCiOptionsFromRunArtifact(
+  artifact: RunArtifact,
+  options: Pick<SetupCiConversionOptions, "force" | "target" | "targetPath"> = {},
+): InitCiOptions | undefined {
+  if (options.targetPath) {
+    return { all: true, target: options.targetPath, force: options.force };
+  }
+  const command = targetCommand(options.target) ?? artifactTargetCommand(artifact);
+  if (!command) return undefined;
+  return { all: true, command, force: options.force };
+}
+
+function shouldPrompt(options: SetupCiConversionOptions): boolean {
+  if (options.isInteractive !== undefined) return options.isInteractive;
+  return process.stdin.isTTY === true && process.stdout.isTTY === true && process.env["CI"] !== "true";
+}
+
+async function promptForConversion(options: SetupCiConversionOptions): Promise<boolean> {
+  const input = options.input ?? process.stdin;
+  const output = options.output ?? process.stdout;
+  const rl = readline.createInterface({ input, output });
+  try {
+    const answer = (await rl.question("Convert this passing MCP check into CI? [Y/n] ")).trim().toLowerCase();
+    return answer === "" || answer === "y" || answer === "yes";
+  } finally {
+    rl.close();
+  }
+}
+
+function printInitCiResult(result: InitCiResult, output: NodeJS.WriteStream | Writable): void {
+  output.write(`${result.workflowStatus}: ${result.workflowPath}\n`);
+  if (result.badgePath && result.badgeStatus) output.write(`${result.badgeStatus}: ${result.badgePath}\n`);
+  if (result.targetConfigPath && result.targetConfigStatus) output.write(`${result.targetConfigStatus}: ${result.targetConfigPath}\n`);
+  if (result.prBodyPath && result.prBodyStatus) output.write(`${result.prBodyStatus}: ${result.prBodyPath}\n`);
+  if (result.issueBodyPath && result.issueBodyStatus) output.write(`${result.issueBodyStatus}: ${result.issueBodyPath}\n`);
+  if (result.scoreBadgePath && result.scoreBadgeStatus) output.write(`${result.scoreBadgeStatus}: ${result.scoreBadgePath}\n`);
+  if (result.workflowStatus === "skipped") output.write("Use --force to overwrite existing files.\n");
+  output.write("Next: commit the workflow, open a PR, and paste the generated PR body if present.\n");
+  output.write("Verify: npx @kryptosai/mcp-observatory setup-ci --doctor\n");
+}
+
+function recordConversion(status: SetupCiConversionResult["status"], options: SetupCiConversionOptions): void {
+  if (status === "not-eligible" || status === "suppressed") return;
+  recordEvent(buildEvent("command_complete", "setup-ci", "cli", {
+    ciProvider: "github-actions",
+    commitStatusSet: status === "written",
+    setupCiConversionStatus: status,
+    setupCiPromptShown: shouldPrompt(options),
+    setupCiAutoRequested: options.setupCi === true && options.yes === true,
+    targetIds: [options.target?.targetId ?? options.artifact.target.targetId],
+  }));
+}
+
+export async function maybeConvertPassingCheckToCi(options: SetupCiConversionOptions): Promise<SetupCiConversionResult> {
+  const output = options.output ?? process.stdout;
+  if (options.artifact.gate !== "pass" || options.artifact.fatalError) {
+    return { status: "not-eligible" };
+  }
+  if (options.noSetupCi === true) {
+    return { status: "suppressed" };
+  }
+
+  const initOptions = initCiOptionsFromRunArtifact(options.artifact, options);
+  const command = conversionCommand(options);
+  if (!initOptions || !command) {
+    return { status: "not-eligible" };
+  }
+
+  if (options.setupCi === true && options.yes === true) {
+    const initResult = await initCi(initOptions);
+    output.write("\n");
+    printInitCiResult(initResult, output);
+    recordConversion("written", options);
+    return { status: "written", command, initResult };
+  }
+
+  if (shouldPrompt(options)) {
+    output.write("\n");
+    const accepted = await promptForConversion(options);
+    if (accepted) {
+      const initResult = await initCi(initOptions);
+      printInitCiResult(initResult, output);
+      recordConversion("written", options);
+      return { status: "written", command, initResult };
+    }
+    output.write(`Skipped. Convert later with:\n  ${c(ANSI.cyan, command)}\n`);
+    recordConversion("skipped", options);
+    return { status: "skipped", command };
+  }
+
+  output.write(`\nCI conversion available:\n  ${command}\n`);
+  if (options.setupCi === true) {
+    output.write("Non-interactive mode will only write files when --setup-ci --yes is present.\n");
+  }
+  recordConversion("hinted", options);
+  return { status: "hinted", command };
+}

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -8,7 +8,30 @@ import { defaultRunsDirectory } from "../storage.js";
 import { appendHistory, buildHistoryEntry, getTrend, readHistory } from "../history.js";
 import { buildEvent, recordEvent } from "../telemetry.js";
 import { maybePrintCloudCta } from "../commercial.js";
-import { ANSI, c, printCiConversionCta, resolveTarget, targetFromCommand } from "./helpers.js";
+import { ANSI, c, resolveTarget, targetFromCommand } from "./helpers.js";
+import { maybeConvertPassingCheckToCi, type SetupCiConversionFlags } from "./setup-ci-conversion.js";
+
+function extractTrailingConversionFlags(
+  commandArgs: string[],
+  options: SetupCiConversionFlags,
+): { commandArgs: string[]; flags: SetupCiConversionFlags } {
+  const flags: SetupCiConversionFlags = { ...options };
+  const targetArgs: string[] = [];
+  for (const arg of commandArgs) {
+    if (arg === "--setup-ci") {
+      flags.setupCi = true;
+    } else if (arg === "--yes") {
+      flags.yes = true;
+    } else if (arg === "--no-setup-ci") {
+      flags.noSetupCi = true;
+    } else if (arg === "--force") {
+      flags.force = true;
+    } else {
+      targetArgs.push(arg);
+    }
+  }
+  return { commandArgs: targetArgs, flags };
+}
 
 export function registerTestCommands(program: Command): void {
   program
@@ -20,8 +43,15 @@ export function registerTestCommands(program: Command): void {
     .option("--deep", "Also invoke safe tools to verify they execute.")
     .option("--invoke-tools", "Alias for --deep.")
     .option("--security", "Run deep security scan (credential patterns, response analysis). Lightweight security is always included.")
+    .option("--setup-ci", "Offer CI conversion after a successful check; use with --yes in non-interactive runs to write files.", false)
+    .option("--yes", "Confirm CI conversion without prompting. Only writes when used with --setup-ci.", false)
+    .option("--no-setup-ci", "Suppress the post-success CI conversion prompt and hint.")
+    .option("--force", "Overwrite existing generated CI adoption files.", false)
     .option("--no-color", "Disable colored output.")
-    .action(async (commandArgs: string[], options: { deep?: boolean; invokeTools?: boolean; security?: boolean; target?: string }) => {
+    .action(async (commandArgs: string[], options: { deep?: boolean; invokeTools?: boolean; security?: boolean; target?: string } & SetupCiConversionFlags) => {
+      const extracted = extractTrailingConversionFlags(commandArgs, options);
+      commandArgs = extracted.commandArgs;
+      const conversionFlags = extracted.flags;
       const t0 = Date.now();
       const target = options.target ? await resolveTarget({ target: options.target }) : targetFromCommand(commandArgs);
       process.stdout.write(`  ${c(ANSI.dim, "⟳")} Checking ${c(ANSI.bold, target.targetId)}...`);
@@ -79,10 +109,14 @@ export function registerTestCommands(program: Command): void {
       if (artifact.gate === "fail") {
         process.exitCode = 1;
       } else {
-        printCiConversionCta({
-          context: "keep this passing in CI:",
+        await maybeConvertPassingCheckToCi({
+          artifact,
           target,
           targetPath: options.target,
+          setupCi: conversionFlags.setupCi,
+          yes: conversionFlags.yes,
+          noSetupCi: conversionFlags.noSetupCi,
+          force: conversionFlags.force,
         });
       }
       maybePrintCloudCta(options.security ? "security" : "general");

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -46,6 +46,31 @@ export async function findLatestArtifact(outDir: string, targetId: string, exclu
   }
 }
 
+export async function findLatestSuccessfulRunArtifact(outDir: string): Promise<string | null> {
+  try {
+    const entries = await readdir(outDir);
+    const candidates = entries
+      .filter((entry) => entry.endsWith(".json"))
+      .sort()
+      .reverse()
+      .map((entry) => path.join(outDir, entry));
+
+    for (const candidate of candidates) {
+      try {
+        const artifact = await readArtifact(candidate);
+        if (artifact.artifactType === "run" && artifact.gate === "pass" && !artifact.fatalError) {
+          return candidate;
+        }
+      } catch {
+        // Ignore malformed or stale files while looking for a usable last run.
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
 export async function readArtifact(filePath: string): Promise<Artifact> {
   const content = await readFile(filePath, "utf8");
   const data: unknown = JSON.parse(content);

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -67,6 +67,9 @@ export interface TelemetryEnrichment {
   setupCiReady?: boolean;
   setupCiFailCount?: number;
   setupCiWarnCount?: number;
+  setupCiConversionStatus?: string;
+  setupCiPromptShown?: boolean;
+  setupCiAutoRequested?: boolean;
   sampleReport?: boolean;
   // Nightly scans
   nightlyScan?: boolean;

--- a/tests/cli-entrypoint.test.ts
+++ b/tests/cli-entrypoint.test.ts
@@ -42,12 +42,15 @@ describe("CLI entrypoint", () => {
     const { stdout, exitCode } = runCli(["scan", "--help"]);
     expect(exitCode).toBe(0);
     expect(stdout).toContain("scan");
+    expect(stdout).toContain("--setup-ci");
   });
 
   it("test subcommand shows help", () => {
     const { stdout, exitCode } = runCli(["test", "--help"]);
     expect(exitCode).toBe(0);
     expect(stdout).toContain("test");
+    expect(stdout).toContain("--setup-ci");
+    expect(stdout).toContain("--no-setup-ci");
   });
 
   it("diff subcommand shows help", () => {
@@ -60,6 +63,7 @@ describe("CLI entrypoint", () => {
     const { stdout, exitCode } = runCli(["run", "--help"]);
     expect(exitCode).toBe(0);
     expect(stdout).toContain("run");
+    expect(stdout).toContain("--setup-ci");
   });
 
   it("serve subcommand shows help", () => {
@@ -131,6 +135,19 @@ describe("CLI entrypoint", () => {
     expect(stdout).toContain("fixture-server");
   });
 
+  it("test --setup-ci --yes writes adoption kit when flags trail the server command", () => {
+    const tmpDir = path.join(os.tmpdir(), `obs-test-${Date.now()}`);
+    fs.mkdirSync(tmpDir, { recursive: true });
+    const fixture = path.resolve("tests/fixtures/fixture-server.mjs");
+
+    const { stdout, exitCode } = runCli(["test", "node", fixture, "--setup-ci", "--yes"], { cwd: tmpDir });
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("created: .github/workflows/mcp-observatory.yml");
+    expect(fs.existsSync(path.join(tmpDir, ".github/workflows/mcp-observatory.yml"))).toBe(true);
+    expect(fs.readFileSync(path.join(tmpDir, "mcp-observatory.target.json"), "utf8")).toContain("fixture-server.mjs");
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
   it("diff --format json outputs valid JSON", () => {
     const { stdout, exitCode } = runCli([
       "diff",
@@ -186,6 +203,21 @@ describe("CLI entrypoint", () => {
     expect(exitCode).toBe(0);
     expect(stdout).toContain("setup-ci");
     expect(stdout).toContain("--doctor");
+    expect(stdout).toContain("--from-last-run");
+  });
+
+  it("setup-ci --from-last-run uses the latest successful run artifact", () => {
+    const tmpDir = path.join(os.tmpdir(), `obs-test-${Date.now()}`);
+    const runsDir = path.join(tmpDir, ".mcp-observatory", "runs");
+    fs.mkdirSync(runsDir, { recursive: true });
+    const fixture = fs.readFileSync(path.resolve("tests/fixtures/sample-run-a.json"), "utf8");
+    fs.writeFileSync(path.join(runsDir, "2026-07-01T00-00-00.000Z--fixture-server.json"), fixture);
+
+    const { stdout, exitCode } = runCli(["setup-ci", "--from-last-run"], { cwd: tmpDir });
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Using latest successful run:");
+    expect(fs.readFileSync(path.join(tmpDir, "mcp-observatory.target.json"), "utf8")).toContain("fixture-server.mjs");
+    fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
   it("history with no data shows empty message", () => {

--- a/tests/setup-ci-conversion.test.ts
+++ b/tests/setup-ci-conversion.test.ts
@@ -1,0 +1,202 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { Readable, Writable } from "node:stream";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { maybeConvertPassingCheckToCi } from "../src/commands/setup-ci-conversion.js";
+import type { RunArtifact } from "../src/types.js";
+
+const tempDirs: string[] = [];
+let originalCwd = process.cwd();
+
+async function tempDir(): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "mcp-observatory-setup-ci-conversion-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function outputSink(): { output: Writable; text: () => string } {
+  const chunks: string[] = [];
+  return {
+    output: new Writable({
+      write(chunk, _encoding, callback) {
+        chunks.push(String(chunk));
+        callback();
+      },
+    }),
+    text: () => chunks.join(""),
+  };
+}
+
+function passingArtifact(overrides: Partial<RunArtifact> = {}): RunArtifact {
+  return {
+    artifactType: "run",
+    schemaVersion: "1.0.0",
+    gate: "pass",
+    runId: "run_test",
+    createdAt: "2026-07-01T00:00:00.000Z",
+    toolVersion: "0.26.1",
+    target: {
+      targetId: "example-server",
+      adapter: "local-process",
+      command: "npx",
+      args: ["-y", "example-mcp"],
+    },
+    environment: {
+      platform: "test",
+      nodeVersion: "v26.0.0",
+    },
+    summary: {
+      total: 1,
+      pass: 1,
+      fail: 0,
+      partial: 0,
+      unsupported: 0,
+      flaky: 0,
+      skipped: 0,
+      gate: "pass",
+    },
+    checks: [],
+    ...overrides,
+  };
+}
+
+afterEach(async () => {
+  process.chdir(originalCwd);
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  originalCwd = process.cwd();
+});
+
+describe("post-check setup-ci conversion", () => {
+  it("prompts in interactive mode and defaults Enter to Yes", async () => {
+    const dir = await tempDir();
+    process.chdir(dir);
+    const sink = outputSink();
+
+    const result = await maybeConvertPassingCheckToCi({
+      artifact: passingArtifact(),
+      input: Readable.from(["\n"]),
+      output: sink.output,
+      isInteractive: true,
+    });
+
+    expect(result.status).toBe("written");
+    expect(await readFile(path.join(dir, ".github/workflows/mcp-observatory.yml"), "utf8")).toContain("target: mcp-observatory.target.json");
+    expect(await readFile(path.join(dir, "mcp-observatory.target.json"), "utf8")).toContain("example-mcp");
+    expect(sink.text()).toContain("Convert this passing MCP check into CI? [Y/n]");
+    expect(sink.text()).toContain("Verify: npx @kryptosai/mcp-observatory setup-ci --doctor");
+  });
+
+  it("lets interactive users answer n without writing files", async () => {
+    const dir = await tempDir();
+    process.chdir(dir);
+    const sink = outputSink();
+
+    const result = await maybeConvertPassingCheckToCi({
+      artifact: passingArtifact(),
+      input: Readable.from(["n\n"]),
+      output: sink.output,
+      isInteractive: true,
+    });
+
+    expect(result.status).toBe("skipped");
+    await expect(readFile(path.join(dir, ".github/workflows/mcp-observatory.yml"), "utf8")).rejects.toThrow();
+    expect(sink.text()).toContain("Skipped. Convert later with:");
+  });
+
+  it("does not write in non-interactive mode unless --setup-ci --yes is present", async () => {
+    const dir = await tempDir();
+    process.chdir(dir);
+    const sink = outputSink();
+
+    const result = await maybeConvertPassingCheckToCi({
+      artifact: passingArtifact(),
+      output: sink.output,
+      isInteractive: false,
+    });
+
+    expect(result.status).toBe("hinted");
+    await expect(readFile(path.join(dir, ".github/workflows/mcp-observatory.yml"), "utf8")).rejects.toThrow();
+    expect(sink.text()).toContain("CI conversion available:");
+    expect(sink.text()).toContain("setup-ci --all --command");
+  });
+
+  it("writes automatically with --setup-ci --yes", async () => {
+    const dir = await tempDir();
+    process.chdir(dir);
+    const sink = outputSink();
+
+    const result = await maybeConvertPassingCheckToCi({
+      artifact: passingArtifact(),
+      output: sink.output,
+      isInteractive: false,
+      setupCi: true,
+      yes: true,
+    });
+
+    expect(result.status).toBe("written");
+    expect(await readFile(path.join(dir, ".github/workflows/mcp-observatory.yml"), "utf8")).toContain("MCP Observatory");
+  });
+
+  it("never writes for failed or fatal artifacts", async () => {
+    const dir = await tempDir();
+    process.chdir(dir);
+
+    const result = await maybeConvertPassingCheckToCi({
+      artifact: passingArtifact({ gate: "fail" }),
+      isInteractive: true,
+      setupCi: true,
+      yes: true,
+    });
+
+    expect(result.status).toBe("not-eligible");
+    await expect(readFile(path.join(dir, ".github/workflows/mcp-observatory.yml"), "utf8")).rejects.toThrow();
+  });
+
+  it("skips existing generated files unless force is set", async () => {
+    const dir = await tempDir();
+    process.chdir(dir);
+
+    await maybeConvertPassingCheckToCi({
+      artifact: passingArtifact(),
+      isInteractive: false,
+      setupCi: true,
+      yes: true,
+    });
+    const skipped = await maybeConvertPassingCheckToCi({
+      artifact: passingArtifact({
+        target: {
+          targetId: "second-server",
+          adapter: "local-process",
+          command: "npx",
+          args: ["-y", "second-mcp"],
+        },
+      }),
+      isInteractive: false,
+      setupCi: true,
+      yes: true,
+    });
+
+    expect(skipped.initResult?.workflowStatus).toBe("skipped");
+    expect(await readFile(path.join(dir, "mcp-observatory.target.json"), "utf8")).toContain("example-mcp");
+
+    const overwritten = await maybeConvertPassingCheckToCi({
+      artifact: passingArtifact({
+        target: {
+          targetId: "second-server",
+          adapter: "local-process",
+          command: "npx",
+          args: ["-y", "second-mcp"],
+        },
+      }),
+      isInteractive: false,
+      setupCi: true,
+      yes: true,
+      force: true,
+    });
+
+    expect(overwritten.initResult?.workflowStatus).toBe("overwritten");
+    expect(await readFile(path.join(dir, "mcp-observatory.target.json"), "utf8")).toContain("second-mcp");
+  });
+});


### PR DESCRIPTION
## Summary
- prompt interactive users to convert successful `test`, `scan`, and `run` checks into CI with default Yes
- require `--setup-ci --yes` for non-interactive file writes and print exact conversion commands otherwise
- add `setup-ci --from-last-run` and conversion telemetry so the funnel is visible

## Tests
- npm run lint
- npm run typecheck -- --pretty false
- npm test
- npm run smoke
- npm run verify:packed-install
- temp-dir CLI check: `test node <fixture> --setup-ci --yes` writes workflow and target config
