### PR TITLE
Harden hosted scan and metrics responses

### DIFF
--- a/api/src/worker.ts
+++ b/api/src/worker.ts
@@ -313,12 +313,18 @@ const RATE_LIMIT_WINDOW_SECONDS = 60;
 const RATE_LIMIT_MAX_REQUESTS = 10;
 
 function generateRunId(): string {
-  const chars = "abcdefghijklmnopqrstuvwxyz0123456789";
-  let id = "";
-  for (let i = 0; i < 12; i++) {
-    id += chars[Math.floor(Math.random() * chars.length)];
-  }
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  const id = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
   return `run_${id}`;
+}
+
+function securityHeaders(): Record<string, string> {
+  return {
+    "X-Content-Type-Options": "nosniff",
+    "Referrer-Policy": "no-referrer",
+    "Content-Security-Policy": "default-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'",
+  };
 }
 
 function corsHeaders(): Record<string, string> {
@@ -335,6 +341,7 @@ function jsonResponse(body: unknown, status = 200): Response {
     status,
     headers: {
       "Content-Type": "application/json",
+      ...securityHeaders(),
       ...corsHeaders(),
     },
   });
@@ -912,6 +919,7 @@ async function handleGetBadge(
       headers: {
         "Content-Type": "image/svg+xml",
         "Cache-Control": "no-cache",
+        ...securityHeaders(),
         ...corsHeaders(),
       },
     });
@@ -926,6 +934,7 @@ async function handleGetBadge(
     headers: {
       "Content-Type": "image/svg+xml",
       "Cache-Control": "public, max-age=300",
+      ...securityHeaders(),
       ...corsHeaders(),
     },
   });

--- a/scripts/metrics-dashboard.ts
+++ b/scripts/metrics-dashboard.ts
@@ -1598,10 +1598,31 @@ async function openDashboard(paths: Paths): Promise<void> {
   await execFileAsync("open", [paths.dashboard]);
 }
 
+export function browserSecurityHeaders(contentType: string): Record<string, string> {
+  const headers: Record<string, string> = {
+    "X-Content-Type-Options": "nosniff",
+    "Referrer-Policy": "no-referrer",
+  };
+  if (contentType.startsWith("text/html")) {
+    headers["Content-Security-Policy"] = [
+      "default-src 'none'",
+      "script-src 'self' 'unsafe-inline'",
+      "style-src 'self' 'unsafe-inline'",
+      "connect-src 'self'",
+      "img-src 'self' data:",
+      "base-uri 'none'",
+      "form-action 'none'",
+      "frame-ancestors 'none'",
+    ].join("; ");
+  }
+  return headers;
+}
+
 function send(response: ServerResponse, status: number, body: string, contentType = "text/plain; charset=utf-8"): void {
   response.writeHead(status, {
     "content-type": contentType,
     "cache-control": "no-store",
+    ...browserSecurityHeaders(contentType),
   });
   response.end(body);
 }

--- a/tests/metrics-dashboard.test.ts
+++ b/tests/metrics-dashboard.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { ingestTelemetryRows, openDatabase, renderDashboardHtml } from "../scripts/metrics-dashboard.js";
+import { browserSecurityHeaders, ingestTelemetryRows, openDatabase, renderDashboardHtml } from "../scripts/metrics-dashboard.js";
 import type { TelemetryRow } from "../scripts/telemetry-company-intelligence.js";
 
 const tempDirs: string[] = [];
@@ -137,5 +137,15 @@ describe("local metrics dashboard", () => {
     expect(html).not.toContain("analyst@");
     expect(html).not.toContain("git_email");
     expect(html).not.toContain("serverCommands");
+  });
+
+  it("serves the local dashboard with defensive browser headers", () => {
+    expect(browserSecurityHeaders("text/html; charset=utf-8")).toMatchObject({
+      "X-Content-Type-Options": "nosniff",
+      "Referrer-Policy": "no-referrer",
+    });
+    expect(browserSecurityHeaders("text/html; charset=utf-8")["Content-Security-Policy"]).toContain("frame-ancestors 'none'");
+    expect(browserSecurityHeaders("text/html; charset=utf-8")["Content-Security-Policy"]).toContain("connect-src 'self'");
+    expect(browserSecurityHeaders("application/json; charset=utf-8")["Content-Security-Policy"]).toBeUndefined();
   });
 });

--- a/tests/worker-hardening.test.ts
+++ b/tests/worker-hardening.test.ts
@@ -22,4 +22,15 @@ describe("hosted Worker hardening", () => {
     expect(rateLimitIndex).toBeGreaterThan(authIndex);
     expect(scanIndex).toBeGreaterThan(rateLimitIndex);
   });
+
+  it("uses cryptographic run IDs and defensive response headers", async () => {
+    const source = await readFile(workerPath, "utf8");
+
+    expect(source).toContain("crypto.getRandomValues(bytes)");
+    expect(source).not.toContain("Math.random()");
+    expect(source).toContain('"X-Content-Type-Options": "nosniff"');
+    expect(source).toContain('"Referrer-Policy": "no-referrer"');
+    expect(source).toContain("frame-ancestors 'none'");
+    expect(source).toContain("...securityHeaders()");
+  });
 });


### PR DESCRIPTION
## Summary
- replace hosted Worker `Math.random()` run IDs with `crypto.getRandomValues` IDs
- add defensive response headers to hosted JSON/SVG responses
- add local metrics dashboard `nosniff`, `no-referrer`, and dashboard-scoped CSP headers
- add regression tests for the hardening choices

## Security checks
- no open GitHub issues with the `security` label
- `npm audit --json`: 0 vulnerabilities
- `npm --prefix api audit --json`: 0 vulnerabilities
- Dependabot alerts returned by API are fixed; secret scanning returned no alerts with current token access
- Code scanning API reports no analysis configured

## Validation
- npm run lint
- npm run typecheck -- --pretty false
- npm test
- npm run smoke
- npm run verify:packed-install
- npm audit --json
- npm --prefix api audit --json
