### PR TITLE
Add CodeQL code scanning workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,34 @@
+name: codeql
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+  schedule:
+    - cron: "23 9 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: analyze javascript-typescript
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: javascript-typescript
+          build-mode: none
+          queries: security-extended,security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:javascript-typescript"


### PR DESCRIPTION
## Summary
- add a dedicated CodeQL workflow for JavaScript/TypeScript analysis
- run on pull requests, pushes to main, weekly schedule, and manual dispatch
- grant only `contents: read` and `security-events: write`
- use `security-extended` and `security-and-quality` query suites

## Validation
- npm run lint
- workflow sanity check for CodeQL action + security-events permission

## Note
The first code scanning analysis is produced by the GitHub workflow after this PR runs/merges.
