### PR TITLE
docs: polish GitHub markdown rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,6 @@
-# MCP Observatory
-
-```
-  ███╗   ███╗ ██████╗██████╗
-  ████╗ ████║██╔════╝██╔══██╗
-  ██╔████╔██║██║     ██████╔╝
-  ██║╚██╔╝██║██║     ██╔═══╝
-  ██║ ╚═╝ ██║╚██████╗██║
-  ╚═╝     ╚═╝ ╚═════╝╚═╝
-     O B S E R V A T O R Y
-```
+<p align="center">
+  <img src="./docs/logo.svg" alt="MCP Observatory" width="820">
+</p>
 
 [![CI](https://github.com/KryptosAI/mcp-observatory/actions/workflows/ci.yml/badge.svg)](https://github.com/KryptosAI/mcp-observatory/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/@kryptosai/mcp-observatory)](https://www.npmjs.com/package/@kryptosai/mcp-observatory)
@@ -256,7 +248,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: KryptosAI/mcp-observatory/action@v0.26.1
+      - uses: KryptosAI/mcp-observatory/action@v0.27.0
         with:
           command: npx -y my-mcp-server
           deep: true
@@ -362,9 +354,7 @@ Your agent gets 10 tools:
 | `get_last_run` | Retrieve previous check results for a server |
 | `suggest_servers` | Discover MCP servers that match your project stack |
 
-An AI tool that checks other AI tools. It's a tool testing tools that serve tools.*
-
-<sub>* I'm a dude playing a dude disguised as another dude.</sub>
+An AI tool that checks other AI tools. It is a tool testing tools that serve tools.
 
 ### Security
 

--- a/action/README.md
+++ b/action/README.md
@@ -81,7 +81,7 @@ permissions:
 
 steps:
   - uses: actions/checkout@v6
-  - uses: KryptosAI/mcp-observatory/action@v0.26.1
+  - uses: KryptosAI/mcp-observatory/action@v0.27.0
     with:
       command: npx -y my-mcp-server
       security: true
@@ -94,10 +94,10 @@ steps:
 - uses: KryptosAI/mcp-observatory/action@main
   with:
     command: npx -y my-mcp-server
-    package-version: 0.26.1
+    package-version: 0.27.0
 ```
 
-For stricter reproducibility, pin both the Action ref and the npm package version, for example `uses: KryptosAI/mcp-observatory/action@v0.26.1` plus `package-version: 0.26.1`.
+For stricter reproducibility, pin both the Action ref and the npm package version, for example `uses: KryptosAI/mcp-observatory/action@v0.27.0` plus `package-version: 0.27.0`.
 
 ### Verify against baseline
 

--- a/docs/certification-distribution.md
+++ b/docs/certification-distribution.md
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: KryptosAI/mcp-observatory/action@v0.26.1
+      - uses: KryptosAI/mcp-observatory/action@v0.27.0
         with:
           command: npx -y <server-package>
           deep: true
@@ -78,10 +78,10 @@ jobs:
 For production CI, pin the package version:
 
 ```yaml
-- uses: KryptosAI/mcp-observatory/action@v0.26.1
+- uses: KryptosAI/mcp-observatory/action@v0.27.0
   with:
     command: npx -y <server-package>
-    package-version: 0.26.1
+    package-version: 0.27.0
     deep: true
     security: true
 ```
@@ -89,7 +89,7 @@ For production CI, pin the package version:
 For repos with a local target config:
 
 ```yaml
-- uses: KryptosAI/mcp-observatory/action@v0.26.1
+- uses: KryptosAI/mcp-observatory/action@v0.27.0
   with:
     target: ./observatory-target.json
     deep: true
@@ -113,7 +113,7 @@ It runs locally/inside GitHub Actions and does not require an account. If the ch
 
 ## Comment For Passing Repos
 
-```md
+~~~md
 Nice, this server passes MCP Observatory checks. If you want the signal in the README, you can add:
 
 ```md
@@ -121,7 +121,7 @@ Nice, this server passes MCP Observatory checks. If you want the signal in the R
 ```
 
 That gives users a quick compatibility/security signal when they are choosing MCP servers.
-```
+~~~
 
 ## Targeting Order
 

--- a/docs/ecosystem-distribution-kit.md
+++ b/docs/ecosystem-distribution-kit.md
@@ -63,7 +63,7 @@ Description:
 Snippet:
 
 ```yaml
-- uses: KryptosAI/mcp-observatory/action@v0.26.1
+- uses: KryptosAI/mcp-observatory/action@v0.27.0
   with:
     command: npx -y <server-package>
     deep: true

--- a/docs/feishu-lark-mcp.md
+++ b/docs/feishu-lark-mcp.md
@@ -45,7 +45,7 @@ jobs:
       MCP_OBSERVATORY_CONTACT: your-team-contact
     steps:
       - uses: actions/checkout@v4
-      - uses: KryptosAI/mcp-observatory/action@v0.26.1
+      - uses: KryptosAI/mcp-observatory/action@v0.27.0
         with:
           target: feishu-target.json
           security: true

--- a/docs/github-code-scanning-for-mcp.md
+++ b/docs/github-code-scanning-for-mcp.md
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: KryptosAI/mcp-observatory/action@v0.26.1
+      - uses: KryptosAI/mcp-observatory/action@v0.27.0
         with:
           command: npx -y my-mcp-server
           deep: true

--- a/docs/logo.svg
+++ b/docs/logo.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="240" viewBox="0 0 960 240" role="img" aria-labelledby="title desc">
+  <title id="title">MCP Observatory</title>
+  <desc id="desc">MCP Observatory wordmark with a constellation-style icon.</desc>
+  <defs>
+    <linearGradient id="mark" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#22d3ee"/>
+      <stop offset="0.52" stop-color="#8b5cf6"/>
+      <stop offset="1" stop-color="#f59e0b"/>
+    </linearGradient>
+    <linearGradient id="text" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#e5eefb"/>
+      <stop offset="1" stop-color="#a7b5cc"/>
+    </linearGradient>
+    <filter id="glow" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur stdDeviation="5" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  <rect width="960" height="240" rx="30" fill="#07111f"/>
+  <path d="M48 168V72c0-17.7 14.3-32 32-32h96c17.7 0 32 14.3 32 32v96c0 17.7-14.3 32-32 32H80c-17.7 0-32-14.3-32-32Z" fill="#0f1b2e" stroke="#263a58" stroke-width="2"/>
+  <path d="M78 154 98 91l29 42 30-62 22 83" fill="none" stroke="url(#mark)" stroke-width="9" stroke-linecap="round" stroke-linejoin="round" filter="url(#glow)"/>
+  <circle cx="98" cy="91" r="7" fill="#22d3ee"/>
+  <circle cx="127" cy="133" r="7" fill="#8b5cf6"/>
+  <circle cx="157" cy="71" r="7" fill="#f59e0b"/>
+  <circle cx="179" cy="154" r="7" fill="#22c55e"/>
+  <text x="248" y="111" fill="url(#text)" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="58" font-weight="760" letter-spacing="0">MCP Observatory</text>
+  <text x="252" y="154" fill="#8fa3bd" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="23" font-weight="500" letter-spacing="0">GitHub-native CI, SARIF, and security gates for MCP servers</text>
+</svg>

--- a/docs/project-case-study.md
+++ b/docs/project-case-study.md
@@ -77,7 +77,7 @@ Current public distribution proof includes:
 
 - latest release: `v0.26.1`
 - npm package: `@kryptosai/mcp-observatory`
-- GitHub Action: `KryptosAI/mcp-observatory/action@v0.26.1`
+- GitHub Action: `KryptosAI/mcp-observatory/action@v0.27.0`
 - npm downloads snapshot: 511 downloads for June 11-20, 2026
 - visible GitHub traffic window: 745 clones and 232 unique cloners
 - visible GitHub page-view window: 12 views and 9 unique visitors

--- a/docs/proof.md
+++ b/docs/proof.md
@@ -5,7 +5,7 @@ MCP Observatory is early, but it is already a working MCP testing/security stack
 ## Current Public Surface
 
 - npm package: `@kryptosai/mcp-observatory`
-- GitHub Action: `KryptosAI/mcp-observatory/action@v0.26.1`
+- GitHub Action: `KryptosAI/mcp-observatory/action@v0.27.0`
 - Latest release: `v0.26.1`
 - CLI command count: scan, test, record, replay, verify, diff, watch, suggest, serve, lock, history, setup-ci, init-ci, ci-report, enterprise-report, score, badge, cloud
 - Test suite: 348 passing tests across 45 test files as of July 1, 2026

--- a/docs/target-registry.md
+++ b/docs/target-registry.md
@@ -1,14 +1,8 @@
 # MCP Target Registry
 
-```
-  ███╗   ███╗ ██████╗██████╗
-  ████╗ ████║██╔════╝██╔══██╗
-  ██╔████╔██║██║     ██████╔╝
-  ██║╚██╔╝██║██║     ██╔═══╝
-  ██║ ╚═╝ ██║╚██████╗██║
-  ╚═╝     ╚═╝ ╚═════╝╚═╝
-     O B S E R V A T O R Y
-```
+<p align="center">
+  <img src="./logo.svg" alt="MCP Observatory" width="760">
+</p>
 
 The easiest way to help MCP Observatory grow is to add one safe MCP target.
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "docs/feishu-lark-mcp.md",
     "docs/github-code-scanning-for-mcp.md",
     "docs/known-issues.md",
+    "docs/logo.svg",
     "docs/mcp-lock-files.md",
     "docs/mcp-safety-field-report-2026-06.md",
     "docs/mcp-safety-report-latest.md",

--- a/tests/public-docs-privacy.test.ts
+++ b/tests/public-docs-privacy.test.ts
@@ -63,7 +63,7 @@ describe("public proof docs privacy guardrails", () => {
 
   it("keeps README action examples read-only and pinned", async () => {
     const content = await readFile(path.join(process.cwd(), "README.md"), "utf8");
-    expect(content).toContain("KryptosAI/mcp-observatory/action@v0.26.1");
+    expect(content).toContain("KryptosAI/mcp-observatory/action@v0.27.0");
     expect(content).not.toContain("KryptosAI/mcp-observatory/action@main");
     expect(content).not.toContain("pull-requests: write\n  statuses: write");
   });


### PR DESCRIPTION
## Summary

Fix GitHub-facing formatting issues found after the v0.27.0 launch.

## Changes

- Replace the README terminal block-art logo with a responsive SVG logo asset.
- Reuse the logo in the target registry instead of another Unicode code block.
- Fix a nested markdown fence in `docs/certification-distribution.md` that could break GitHub rendering.
- Remove an overly casual footer line from the README.
- Update stale Action examples from v0.26.1 to v0.27.0.
- Include `docs/logo.svg` in the npm package file list.

## Validation

- Checked all tracked Markdown files for balanced code fences.
- Render-smoked README through GitHub's Markdown API.
- `npm run lint`
- `npm run verify:packed-install`
