### PR TITLE
Add MCP receipt request intake loop

### DIFF
--- a/.github/ISSUE_TEMPLATE/tool-call-receipt-request.yml
+++ b/.github/ISSUE_TEMPLATE/tool-call-receipt-request.yml
@@ -1,12 +1,17 @@
-name: MCP tool-call receipt request
-description: Request a reproducible receipt for one MCP server your agent depends on.
-title: "[Receipt] "
+name: Drop an MCP server, get a receipt
+description: Request a safe, reproducible MCP Observatory receipt for one server your agent depends on.
+title: "[Receipt request] "
 labels: ["tool-call-receipt", "target-registry", "needs-triage"]
 body:
   - type: markdown
     attributes:
       value: |
-        Request one public MCP server receipt: safe startup command, run artifact, attack-sim evidence, SARIF when useful, and CI setup guidance.
+        Drop one public MCP server/package and MCP Observatory will try to turn it into a safe, reproducible receipt.
+
+        A normal receipt answers: what happened in this run?
+        A delta receipt answers: what changed since the last trusted run?
+
+        Good requests can become Safety Index entries, attack-sim evidence, SARIF artifacts, maintainer CI conversations, or starter PRs.
 
         Please do not paste secrets, private telemetry, private URLs, customer data, or destructive commands.
   - type: input
@@ -21,7 +26,7 @@ body:
     id: command
     attributes:
       label: Safe startup command
-      description: Command Observatory can run without secrets or destructive side effects.
+      description: Command Observatory can run without secrets, writes, destructive side effects, or production access.
       placeholder: npx -y example-mcp
     validations:
       required: true
@@ -67,5 +72,4 @@ body:
     attributes:
       label: Desired output
       description: What would be useful to receive?
-      placeholder: Safety Index entry, attack-sim report, SARIF artifact, setup-ci PR, private review, etc.
-
+      placeholder: Safety Index entry, attack-sim report, delta receipt, SARIF artifact, setup-ci PR, private review, etc.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ npx @kryptosai/mcp-observatory setup-ci --all --command "npx -y my-mcp-server" -
 
 See the [MCP Attack Simulator](./docs/mcp-attack-simulator.md), [Tool-call receipts](./docs/tool-call-receipts.md), [MCP Receipt Graph](./docs/receipt-graph.md), [launch page](./docs/launch.md), [GitHub Code Scanning demo](./docs/code-scanning-demo.md), [GitHub Code Scanning for MCP servers](./docs/github-code-scanning-for-mcp.md), [sample safety reports](./docs/mcp-server-safety-index.md), and [reference evaluations](./docs/reference-evaluations.md).
 
+Want a receipt for a server your agent depends on? Comment on [Drop an MCP server, get a receipt #146](https://github.com/KryptosAI/mcp-observatory/issues/146) or use the [structured receipt request form](https://github.com/KryptosAI/mcp-observatory/issues/new?template=tool-call-receipt-request.yml). Public requests can become Safety Index entries, delta receipts, SARIF evidence, and maintainer CI conversations.
+
 ## Evidence You Can Inspect
 
 | Evidence | Where |
@@ -73,7 +75,7 @@ Two more fast paths:
 
 Cloned this repo? Start here: [`CLONED_THIS.md`](./CLONED_THIS.md). Want to contribute? Add one server to the [MCP Target Registry](./docs/target-registry.md), use the [Agent Task Pack](./docs/agent-tasks.md), and get public credit through [MCP Observatory Contributors](./docs/contributor-recognition.md).
 
-AI coding agents, agentic workflows, and rough PRs are welcome. Use the [10x Agentic Growth Sprint](./docs/10x-agentic-growth-sprint.md), [Agentic Contributor Outreach](./docs/agentic-contributor-outreach.md), or open a `Contributor quest`, `Agentic contribution idea`, or `MCP tool-call receipt request` issue to suggest a target, prompt, docs fix, receipt, or `setup-ci --sarif` integration.
+AI coding agents, agentic workflows, and rough PRs are welcome. Use the [10x Agentic Growth Sprint](./docs/10x-agentic-growth-sprint.md), [Agentic Contributor Outreach](./docs/agentic-contributor-outreach.md), or open a `Contributor quest`, `Agentic contribution idea`, or [`Drop an MCP server, get a receipt`](./docs/drop-server-get-receipt.md) issue to suggest a target, prompt, docs fix, receipt, or `setup-ci --sarif` integration.
 
 Add MCP CI and Code Scanning in one command:
 

--- a/docs/drop-server-get-receipt.md
+++ b/docs/drop-server-get-receipt.md
@@ -1,0 +1,54 @@
+# Drop An MCP Server, Get A Receipt
+
+This is the public intake loop for agent-native MCP trust.
+
+Open a receipt request with one MCP server or package. MCP Observatory will try to turn it into safe, reproducible evidence that another agent, maintainer, or security reviewer can inspect.
+
+Use the live intake thread when you want to comment quickly: [Drop an MCP server, get a receipt #146](https://github.com/KryptosAI/mcp-observatory/issues/146).
+
+## What To Drop
+
+Use the [receipt request form](https://github.com/KryptosAI/mcp-observatory/issues/new?template=tool-call-receipt-request.yml) for a structured request, or comment on [the live intake thread](https://github.com/KryptosAI/mcp-observatory/issues/146) when you want to drop a target quickly.
+
+Good requests have:
+
+- a public MCP server repo, npm package, docs page, or directory listing
+- a safe startup command such as `npx -y example-mcp`
+- an agent workflow that depends on the server
+- a risk you want checked, such as schema drift, broad filesystem access, tool poisoning, browser/network boundaries, or canary exposure
+
+Do not paste secrets, customer data, private URLs, production tokens, or destructive commands.
+
+## What A Receipt Can Include
+
+| Evidence | Why it matters |
+| --- | --- |
+| Tool surface | Shows what tools the server exposes to agents. |
+| Attack simulation | Flags safe-mode tool poisoning, broad boundary, canary, and drift risks. |
+| SARIF | Lets maintainers review MCP risk in GitHub Code Scanning. |
+| CI setup | Gives maintainers an exact `setup-ci --sarif` path. |
+| Delta receipt | Shows what changed since a previous trusted run. |
+| Safety Index entry | Turns the result into public, rerunnable evidence. |
+
+## Agent-Native Prompt
+
+```text
+Drop one MCP server/package your agent depends on.
+
+I want a receipt that proves:
+- what tools exist
+- what the schema allows
+- what the safe attack simulator found
+- what changed since the last trusted run
+- what CI gate a maintainer could adopt
+```
+
+## Maintainer Path
+
+If the server is yours, the best next step after a receipt is:
+
+```bash
+npx @kryptosai/mcp-observatory setup-ci --all --command "npx -y your-mcp-server" --sarif
+```
+
+That creates a GitHub Actions path for repeatable MCP safety checks and Code Scanning results.

--- a/docs/receipt-graph.md
+++ b/docs/receipt-graph.md
@@ -32,7 +32,7 @@ Use this page as the first public map from MCP servers to reproducible evidence.
 
 ## How To Add A Node
 
-1. Open a [tool-call receipt request](https://github.com/KryptosAI/mcp-observatory/issues/new?template=tool-call-receipt-request.yml).
+1. Open a [Drop an MCP server, get a receipt request](https://github.com/KryptosAI/mcp-observatory/issues/new?template=tool-call-receipt-request.yml).
 2. Provide a public MCP server and safe startup command.
 3. Run:
 
@@ -49,3 +49,5 @@ npx @kryptosai/mcp-observatory setup-ci --all --command "<safe startup command>"
 ```text
 Name one MCP server your agent depends on. I will help turn it into a reproducible receipt: safe startup command, run artifact, attack-sim evidence, SARIF, and a CI gate maintainers can review.
 ```
+
+For the public intake loop, see [Drop an MCP server, get a receipt](./drop-server-get-receipt.md) or comment on [the live GitHub thread](https://github.com/KryptosAI/mcp-observatory/issues/146).


### PR DESCRIPTION
## Summary\n- reframe the receipt request issue form as "Drop an MCP server, get a receipt"\n- add a public intake doc for server receipt requests and delta receipts\n- link the live GitHub intake issue #146 from README and receipt graph docs\n\n## Validation\n- ruby YAML parse for issue templates\n- git diff --check\n\nLive intake issue: #146