### PR TITLE
feat: promote attack simulator homepage demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ Agents should not depend on tools nobody tests. MCP Observatory turns a local MC
 
 ## Try It
 
-Safely simulate MCP attack-readiness for one server:
+Start with the homepage demo: safely simulate MCP attack-readiness for one server and emit SARIF evidence that maintainers can inspect in GitHub Code Scanning.
 
 ```bash
 npx @kryptosai/mcp-observatory attack-sim npx -y my-mcp-server --sarif attack-results.sarif
 ```
 
-Then convert the evidence into CI with Code Scanning:
+Then make the evidence repeatable in CI:
 
 ```bash
 npx @kryptosai/mcp-observatory setup-ci --all --command "npx -y my-mcp-server" --sarif


### PR DESCRIPTION
## Summary
- make attack-sim the first README demo
- point the next step directly at setup-ci --sarif
- use a conventional feat commit so semantic-release publishes the already-prepared 0.28.0 package

## Validation
- npm run release:prep
- npm run validate:artifacts

## Why now
Current npm latest is 0.27.0 while local/package artifacts are 0.28.0. The release workflow is green and npm trusted publishing works, but semantic-release skipped recent non-conventional commits as non-release-triggering.