### PR TITLE
fix: publish package version when semantic release skips

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,31 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npx -y --package semantic-release@25.0.5 --package @semantic-release/changelog@6.0.3 --package @semantic-release/git@10.0.1 semantic-release
 
+      - name: Check package version publication
+        id: package-version
+        run: |
+          package_name="$(node -p 'require("./package.json").name')"
+          package_version="$(node -p 'require("./package.json").version')"
+          if npm view "${package_name}@${package_version}" version >/tmp/npm-published-version.txt 2>/dev/null; then
+            echo "published=true" >> "$GITHUB_OUTPUT"
+            echo "Package ${package_name}@${package_version} is already published."
+          else
+            echo "published=false" >> "$GITHUB_OUTPUT"
+            echo "Package ${package_name}@${package_version} is not published yet."
+          fi
+          echo "name=${package_name}" >> "$GITHUB_OUTPUT"
+          echo "version=${package_version}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish package.json version with npm token
+        if: steps.package-version.outputs.published != 'true' && steps.npm-auth.outputs.valid == 'true'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public
+
+      - name: Publish package.json version with npm trusted publishing
+        if: steps.package-version.outputs.published != 'true' && steps.npm-auth.outputs.valid != 'true' && steps.npm-oidc.outputs.configured == 'true'
+        run: npm publish --provenance --access public
+
       - name: Skip release until npm trusted publishing is configured
         if: steps.npm-auth.outputs.valid != 'true' && steps.npm-oidc.outputs.configured != 'true'
         run: |


### PR DESCRIPTION
## Summary

Adds a guarded release workflow fallback that publishes the exact package.json version when semantic-release validates successfully but skips publishing because commit analysis finds no conventional release commit.

This is needed because v1.28.0 is merged and tagged on GitHub, but npm @latest is still v0.28.0.

## Safety

- Checks whether @kryptosai/mcp-observatory@<package.json version> already exists before publishing.
- Uses existing npm token path when available.
- Uses existing trusted publishing path when npm token auth is not available and OIDC is configured.
- Does not publish duplicate versions.

## Validation

- ruby YAML parse for .github/workflows/release.yml
- npm run lint