### PR TITLE
fix: guard npm publish race after semantic release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,25 +103,63 @@ jobs:
         run: |
           package_name="$(node -p 'require("./package.json").name')"
           package_version="$(node -p 'require("./package.json").version')"
-          if npm view "${package_name}@${package_version}" version >/tmp/npm-published-version.txt 2>/dev/null; then
-            echo "published=true" >> "$GITHUB_OUTPUT"
-            echo "Package ${package_name}@${package_version} is already published."
-          else
-            echo "published=false" >> "$GITHUB_OUTPUT"
-            echo "Package ${package_name}@${package_version} is not published yet."
-          fi
           echo "name=${package_name}" >> "$GITHUB_OUTPUT"
           echo "version=${package_version}" >> "$GITHUB_OUTPUT"
+          for attempt in 1 2 3 4 5 6; do
+            if npm view "${package_name}@${package_version}" version >/tmp/npm-published-version.txt 2>/dev/null; then
+              echo "published=true" >> "$GITHUB_OUTPUT"
+              echo "Package ${package_name}@${package_version} is already published."
+              exit 0
+            fi
+            latest_version="$(npm view "${package_name}" version 2>/dev/null || true)"
+            if node -e 'const semver = require("semver"); const latest = process.argv[1]; const current = process.argv[2]; process.exit(latest && semver.valid(latest) && semver.gte(latest, current) ? 0 : 1)' "$latest_version" "$package_version"; then
+              echo "published=true" >> "$GITHUB_OUTPUT"
+              echo "Package ${package_name}@${package_version} is covered by published latest ${latest_version}."
+              exit 0
+            fi
+            echo "Package ${package_name}@${package_version} not visible yet (attempt ${attempt}/6)."
+            sleep 10
+          done
+          echo "published=false" >> "$GITHUB_OUTPUT"
+          echo "Package ${package_name}@${package_version} is not published yet."
 
       - name: Publish package.json version with npm token
         if: steps.package-version.outputs.published != 'true' && steps.npm-auth.outputs.valid == 'true'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access public
+        run: |
+          package_name="${{ steps.package-version.outputs.name }}"
+          package_version="${{ steps.package-version.outputs.version }}"
+          if npm publish --access public; then
+            exit 0
+          fi
+          for attempt in 1 2 3 4 5 6; do
+            if npm view "${package_name}@${package_version}" version >/dev/null 2>&1; then
+              echo "Package ${package_name}@${package_version} is published; treating duplicate publish race as success."
+              exit 0
+            fi
+            echo "Package ${package_name}@${package_version} still not visible after publish failure (attempt ${attempt}/6)."
+            sleep 10
+          done
+          exit 1
 
       - name: Publish package.json version with npm trusted publishing
         if: steps.package-version.outputs.published != 'true' && steps.npm-auth.outputs.valid != 'true' && steps.npm-oidc.outputs.configured == 'true'
-        run: npm publish --provenance --access public
+        run: |
+          package_name="${{ steps.package-version.outputs.name }}"
+          package_version="${{ steps.package-version.outputs.version }}"
+          if npm publish --provenance --access public; then
+            exit 0
+          fi
+          for attempt in 1 2 3 4 5 6; do
+            if npm view "${package_name}@${package_version}" version >/dev/null 2>&1; then
+              echo "Package ${package_name}@${package_version} is published; treating duplicate publish race as success."
+              exit 0
+            fi
+            echo "Package ${package_name}@${package_version} still not visible after publish failure (attempt ${attempt}/6)."
+            sleep 10
+          done
+          exit 1
 
       - name: Skip release until npm trusted publishing is configured
         if: steps.npm-auth.outputs.valid != 'true' && steps.npm-oidc.outputs.configured != 'true'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kryptosai/mcp-observatory",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kryptosai/mcp-observatory",
-      "version": "1.28.0",
+      "version": "1.28.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kryptosai/mcp-observatory",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "description": "GitHub-native CI, SARIF, Code Scanning, and security gates for MCP servers before agents depend on them.",
   "mcpName": "io.github.KryptosAI/mcp-observatory",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Cleans up the release workflow after v1.28.1 published successfully but the fallback publish step raced npm registry visibility and tried to publish the same version again.

## Changes

- Sync package.json and package-lock.json to the published npm latest version, 1.28.1.
- Retry npm version visibility before declaring a package unpublished.
- Skip fallback publishing when npm latest already covers the package version.
- Treat duplicate publish races as success only after npm confirms the version exists.

## Validation

- ruby YAML parse for .github/workflows/release.yml
- npm run lint
- npm view @kryptosai/mcp-observatory confirms latest 1.28.1