### PR TITLE
chore: sync package metadata to v1.28.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kryptosai/mcp-observatory",
-  "version": "1.28.1",
+  "version": "1.28.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kryptosai/mcp-observatory",
-      "version": "1.28.1",
+      "version": "1.28.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kryptosai/mcp-observatory",
-  "version": "1.28.1",
+  "version": "1.28.2",
   "description": "GitHub-native CI, SARIF, Code Scanning, and security gates for MCP servers before agents depend on them.",
   "mcpName": "io.github.KryptosAI/mcp-observatory",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Sync package.json and package-lock.json to the npm/GitHub latest release version, v1.28.2.

This intentionally uses a chore commit so semantic-release should not create another patch release.

## Validation

- npm view @kryptosai/mcp-observatory confirms latest 1.28.2