### PR TITLE
fix(cli): warn on unknown output format

### DIFF
--- a/src/commands/helpers.ts
+++ b/src/commands/helpers.ts
@@ -122,15 +122,20 @@ export async function resolveTarget(options: { target?: string }): Promise<Targe
 
 export function formatOutput(
   artifact: Parameters<typeof renderTerminal>[0],
-  format: "html" | "json" | "junit" | "markdown" | "pr-comment" | "sarif" | "terminal",
+  format: string,
   options: { artifactUri?: string } = {},
 ): string {
+  const knownFormats = new Set(["html", "json", "junit", "markdown", "pr-comment", "sarif", "terminal"]);
+
   if (format === "json") return JSON.stringify(artifact, null, 2);
   if (format === "markdown") return renderMarkdown(artifact);
   if (format === "pr-comment") return renderPrComment(artifact);
   if (format === "html") return renderHtml(artifact);
   if (format === "junit" && artifact.artifactType === "run") return renderJUnit(artifact);
   if (format === "sarif" && artifact.artifactType === "run") return renderSarif(artifact, options);
+  if (!knownFormats.has(format)) {
+    process.stderr.write(`Warning: unknown format '${format}'. Supported: terminal, markdown, html, sarif, junit. Falling back to terminal.\n`);
+  }
   return renderTerminal(artifact);
 }
 

--- a/tests/commands-helpers.test.ts
+++ b/tests/commands-helpers.test.ts
@@ -113,6 +113,16 @@ describe("command helper output", () => {
     expect(formatOutput(artifact, "terminal")).toContain("MCP Observatory Run");
   });
 
+  it("warns before falling back to terminal output for unknown formats", () => {
+    const artifact = makeArtifact();
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    expect(formatOutput(artifact, "unsupported")).toContain("MCP Observatory Run");
+    expect(stderr).toHaveBeenCalledWith(
+      "Warning: unknown format 'unsupported'. Supported: terminal, markdown, html, sarif, junit. Falling back to terminal.\n",
+    );
+  });
+
   it("writes formatted output to stdout or a file", async () => {
     const stdout = captureStdout();
 


### PR DESCRIPTION
## Summary

- add a stderr warning when an unknown output format is passed to the CLI output formatter
- users who pass an unsupported format now see a clear warning with the supported formats before it falls back to terminal output

## Validation

- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run smoke`

Focused validation run:

- [x] `npm test -- tests/commands-helpers.test.ts`

## Artifact Impact

- no artifact schema changes
- Markdown report output did not change; this only adds a warning for unknown output formats before falling back to terminal output

Fixes #179