### PR TITLE
Add deprecation warnings for legacy CLI commands

### DIFF
--- a/src/commands/legacy.ts
+++ b/src/commands/legacy.ts
@@ -30,6 +30,7 @@ export function registerLegacyCommands(program: Command): void {
     .option("--force", "Overwrite existing generated CI adoption files.", false)
     .option("--no-color", "Disable colored output.")
     .action(async (options: { outDir: string; target?: string; watch: boolean; interval: string; invokeTools: boolean } & SetupCiConversionFlags) => {
+      console.error("run is deprecated. Use test instead.");
       if (options.campaign) options.campaign = normalizeCampaign(options.campaign);
       const target = await resolveTarget(options);
       if (options.watch) {
@@ -89,6 +90,7 @@ export function registerLegacyCommands(program: Command): void {
     .option("--target <config>", "Path to a target config JSON file.")
     .option("--no-color", "Disable colored output.")
     .action(async (capability: string, options: { target?: string }) => {
+      console.error("check is deprecated. Use test instead.");
       const validCapabilities = ["tools", "prompts", "resources", "tools-invoke"];
       if (!validCapabilities.includes(capability)) {
         throw new Error(`Invalid capability '${capability}'. Must be one of: ${validCapabilities.join(", ")}`);
@@ -128,6 +130,7 @@ export function registerLegacyCommands(program: Command): void {
         output?: string;
         run: string;
       }) => {
+        console.error("report is deprecated. Use --format on test, scan, or diff instead.");
         const artifact = await readArtifact(options.run);
         if (artifact.artifactType !== "run") {
           throw new Error("The report command only accepts run artifacts.");


### PR DESCRIPTION
## Summary

* Add deprecation warnings to the hidden legacy CLI commands:

  * `run` → `run is deprecated. Use test instead.`
  * `check` → `check is deprecated. Use test instead.`
  * `report` → `report is deprecated. Use --format on test, scan, or diff instead.`
* Print each warning to **stderr** using `console.error()` before continuing with the existing command logic.

## Code of Conduct

By submitting this pull request, I agree to follow the project's Contributor Covenant Code of Conduct.

## Validation

* [ ] `npm run lint` *(not run)*
* [x] `npm run build`
* [ ] `npm run typecheck` *(not run)*
* [ ] `npm test` *(repository has existing unrelated test failures in my environment)*

## Artifact Impact

* No artifact schema changes.
* No changes to Markdown report output.
