### PR TITLE
docs: Professional READMEs — comparison table, architecture diagram, seatbelt cross-ref, all-contributors fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,18 @@
 
 [![CI](https://github.com/KryptosAI/mcp-observatory/actions/workflows/ci.yml/badge.svg)](https://github.com/KryptosAI/mcp-observatory/actions/workflows/ci.yml)
 [![CodeQL](https://github.com/KryptosAI/mcp-observatory/actions/workflows/codeql.yml/badge.svg)](https://github.com/KryptosAI/mcp-observatory/actions/workflows/codeql.yml)
-[![Coverage](https://github.com/KryptosAI/mcp-observatory/actions/workflows/coverage.yml/badge.svg)](https://github.com/KryptosAI/mcp-observatory/actions/workflows/coverage.yml)
+[![Coverage Workflow](https://github.com/KryptosAI/mcp-observatory/actions/workflows/coverage.yml/badge.svg)](https://github.com/KryptosAI/mcp-observatory/actions/workflows/coverage.yml)
+[![npm](https://img.shields.io/npm/v/@kryptosai/mcp-observatory)](https://www.npmjs.com/package/@kryptosai/mcp-observatory)
+[![GitHub stars](https://img.shields.io/github/stars/KryptosAI/mcp-observatory?style=flat)](https://github.com/KryptosAI/mcp-observatory/stargazers)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
+
+<details>
+<summary>More badges</summary>
+
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/KryptosAI/mcp-observatory/badge)](https://securityscorecards.dev/viewer/?uri=github.com/KryptosAI/mcp-observatory)
 [![Dependabot](https://img.shields.io/badge/dependabot-enabled-025e8c?logo=dependabot)](./.github/dependabot.yml)
 [![npm provenance workflow](https://img.shields.io/badge/npm%20provenance-workflow-blue)](./.github/workflows/release.yml)
-[![npm](https://img.shields.io/npm/v/@kryptosai/mcp-observatory)](https://www.npmjs.com/package/@kryptosai/mcp-observatory)
 [![npm weekly downloads](https://img.shields.io/npm/dw/@kryptosai/mcp-observatory)](https://www.npmjs.com/package/@kryptosai/mcp-observatory)
-[![GitHub stars](https://img.shields.io/github/stars/KryptosAI/mcp-observatory?style=flat)](https://github.com/KryptosAI/mcp-observatory/stargazers)
-[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 [![Node >= 20](https://img.shields.io/badge/node-%3E%3D20-339933)](./package.json)
 [![Smithery](https://smithery.ai/badge/@kryptosai/mcp-observatory)](https://smithery.ai/server/@kryptosai/mcp-observatory)
 [![mcp-observatory MCP server](https://glama.ai/mcp/servers/KryptosAI/mcp-observatory/badges/score.svg)](https://glama.ai/mcp/servers/KryptosAI/mcp-observatory)
@@ -33,6 +37,8 @@
 [![MCP Hub China](https://img.shields.io/badge/MCP_Hub_China-listed-red)](https://mcp-hub.cn)
 [![OpenTools](https://img.shields.io/badge/OpenTools-listed-green)](https://opentools.ai)
 [![Gitee](https://img.shields.io/badge/Gitee-镜像-orange)](https://gitee.com/williamweishuhn/mcp-observatory)
+
+</details>
 
 **MCP Observatory maps the risk graph of agent toolchains before agents depend on them.** It helps teams validate MCP servers before deployment into sensitive, regulated, or mission-critical agentic AI environments.
 
@@ -209,6 +215,20 @@ The open source repo is the public evidence engine. Private telemetry intelligen
 
 Run `npx @kryptosai/mcp-observatory cloud`, open a pilot request from the issue chooser, or see [COMMERCIAL.md](./COMMERCIAL.md). Also see [privacy and telemetry](./PRIVACY.md), [campaign attribution](./docs/campaign-attribution.md), and [terms for production use](./TERMS.md).
 
+## How It Compares
+
+| Feature | mcp-observatory | Snyk agent-scan | Cisco mcp-scanner | agent-shield |
+|---|---|---|---|---|
+| MCP-native | ✓ | ✓ | ✓ | ✓ |
+| Attack simulation | ✓ | ✗ | ✗ | ✗ |
+| Schema drift detection | ✓ | ✗ | ✗ | ✗ |
+| Record/replay/verify | ✓ | ✗ | ✗ | ✗ |
+| Health scoring (0-100) | ✓ | ✗ | ✗ | ✗ |
+| SARIF output | ✓ | ✓ | ✓ | ✓ |
+| CI/CD native (setup-ci) | ✓ | ✓ | ✓ | ✓ |
+| Safety index (17+ servers) | ✓ | ✗ | ✗ | ✗ |
+| Runtime enforcement via mcp-seatbelt | ✓ | ✗ | ✗ | ✗ |
+
 ## Quick Start
 
 Scan every MCP server in your Claude config:
@@ -335,6 +355,42 @@ When you run `scan`, it looks for MCP configs in:
 - `~/Library/Application Support/Claude/claude_desktop_config.json` (Claude Desktop, macOS)
 - `%APPDATA%/Claude/claude_desktop_config.json` (Claude Desktop, Windows)
 - `.claude.json` and `.mcp.json` (current directory)
+
+## Architecture
+
+```
+                    ┌─────────────────────────┐
+                    │   MCP Observatory CLI    │
+                    │  npx @kryptosai/mcp-     │
+                    │     observatory scan     │
+                    └───────────┬─────────────┘
+                                │
+                    ┌───────────▼─────────────┐
+                    │   Config Discovery       │
+                    │  (Claude, Cursor, etc.)  │
+                    └───────────┬─────────────┘
+                                │
+              ┌─────────────────┼─────────────────┐
+              ▼                 ▼                  ▼
+    ┌─────────────────┐ ┌──────────────┐ ┌──────────────────┐
+    │   Security Scan  │ │  Attack Sim  │ │  Schema Drift    │
+    │  (shell, creds)  │ │ (tool poison)│ │  (version diff)  │
+    └────────┬────────┘ └──────┬───────┘ └────────┬─────────┘
+             │                 │                   │
+             └─────────────────┼───────────────────┘
+                               ▼
+                    ┌─────────────────────┐
+                    │   Health Score       │
+                    │  (0-100 + verdict)   │
+                    └──────────┬──────────┘
+                               │
+              ┌────────────────┼────────────────┐
+              ▼                ▼                 ▼
+    ┌──────────────┐  ┌──────────────┐  ┌──────────────┐
+    │  SARIF       │  │  Markdown    │  │  CI Gateway  │
+    │  (Code Scan) │  │  Report      │  │  (setup-ci)  │
+    └──────────────┘  └──────────────┘  └──────────────┘
+```
 
 ## CI / GitHub Action
 
@@ -556,7 +612,6 @@ Target configs support `${VAR}`, `$VAR`, and `env:VAR` references in `authToken`
 | Response snapshot diffs | ✅ | — | — | — |
 | Benchmarking / latency | — | — | ✅ | — |
 | Jest integration | — | — | — | ✅ |
-| MCP proxy mode | — | ✅ | — | — |
 | **Works as MCP server** | **✅** | — | — | — |
 
 Each tool has strengths. Observatory focuses on regression detection and CI-friendly workflows. mcp-recorder is great as a transparent proxy. MCPBench is the go-to for performance benchmarking. mcp-jest is ideal if you're already in a Jest workflow.
@@ -577,6 +632,10 @@ The record/replay/verify pattern is inspired by:
 - Custom WebSocket transports (e.g., BrowserTools MCP) are not supported
 - A few servers time out or close before init — see [known issues](./docs/known-issues.md) and [compatibility](./docs/compatibility.md)
 
+## Works with mcp-seatbelt
+
+Scan before you trust. Enforce at runtime with [mcp-seatbelt](https://github.com/KryptosAI/mcp-seatbelt) — an MCP proxy that consumes Observatory receipts and blocks out-of-contract tool calls in production. Observatory validates; seatbelt enforces.
+
 ## Contributors ✨
 
 Thanks to these amazing people who have contributed:
@@ -584,7 +643,6 @@ Thanks to these amazing people who have contributed:
 - [leemeo3](https://github.com/leemeo3) — 3 Safety Index targets (Git, Chrome DevTools, Filesystem MCP)
 - [tanishxdev](https://github.com/tanishxdev) — Legacy CLI deprecation warnings (#187)
 - [sansynx](https://github.com/sansynx) — CLI format validation (#182)
-- [tanishxdev](https://github.com/tanishxdev) — Legacy CLI deprecation warnings (#187)
 
 [See all contributors →](CONTRIBUTORS.md)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,24 +14,31 @@
 
 [![CI](https://github.com/KryptosAI/mcp-observatory/actions/workflows/ci.yml/badge.svg)](https://github.com/KryptosAI/mcp-observatory/actions/workflows/ci.yml)
 [![CodeQL](https://github.com/KryptosAI/mcp-observatory/actions/workflows/codeql.yml/badge.svg)](https://github.com/KryptosAI/mcp-observatory/actions/workflows/codeql.yml)
-[![Coverage](https://github.com/KryptosAI/mcp-observatory/actions/workflows/coverage.yml/badge.svg)](https://github.com/KryptosAI/mcp-observatory/actions/workflows/coverage.yml)
+[![覆盖率工作流](https://github.com/KryptosAI/mcp-observatory/actions/workflows/coverage.yml/badge.svg)](https://github.com/KryptosAI/mcp-observatory/actions/workflows/coverage.yml)
+[![npm](https://img.shields.io/npm/v/@kryptosai/mcp-observatory)](https://www.npmjs.com/package/@kryptosai/mcp-observatory)
+[![GitHub stars](https://img.shields.io/github/stars/KryptosAI/mcp-observatory?style=flat)](https://github.com/KryptosAI/mcp-observatory/stargazers)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
+
+<details>
+<summary>更多徽章</summary>
+
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/KryptosAI/mcp-observatory/badge)](https://securityscorecards.dev/viewer/?uri=github.com/KryptosAI/mcp-observatory)
 [![Dependabot](https://img.shields.io/badge/dependabot-enabled-025e8c?logo=dependabot)](./.github/dependabot.yml)
 [![npm provenance workflow](https://img.shields.io/badge/npm%20provenance-workflow-blue)](./.github/workflows/release.yml)
-[![npm](https://img.shields.io/npm/v/@kryptosai/mcp-observatory)](https://www.npmjs.com/package/@kryptosai/mcp-observatory)
 [![npm weekly downloads](https://img.shields.io/npm/dw/@kryptosai/mcp-observatory)](https://www.npmjs.com/package/@kryptosai/mcp-observatory)
-[![GitHub stars](https://img.shields.io/github/stars/KryptosAI/mcp-observatory?style=flat)](https://github.com/KryptosAI/mcp-observatory/stargazers)
-[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 [![Node >= 20](https://img.shields.io/badge/node-%3E%3D20-339933)](./package.json)
 [![Smithery](https://smithery.ai/badge/@kryptosai/mcp-observatory)](https://smithery.ai/server/@kryptosai/mcp-observatory)
 [![mcp-observatory MCP server](https://glama.ai/mcp/servers/KryptosAI/mcp-observatory/badges/score.svg)](https://glama.ai/mcp/servers/KryptosAI/mcp-observatory)
-[![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](./CONTRIBUTORS.md)
+[![All Contributors](https://img.shields.io/badge/all_contributors-4-orange.svg?style=flat-square)](./CONTRIBUTORS.md)
 [![Gitee Stars](https://gitee.com/williamweishuhn/mcp-observatory/badge/star.svg)](https://gitee.com/williamweishuhn/mcp-observatory)
 [![Gitee Forks](https://gitee.com/williamweishuhn/mcp-observatory/badge/fork.svg)](https://gitee.com/williamweishuhn/mcp-observatory)
 [![MCP Registry](https://img.shields.io/badge/MCP_Registry-listed-blue)](https://registry.modelcontextprotocol.io)
 [![MCP Market](https://img.shields.io/badge/MCP_Market-premium-gold)](https://mcpmarket.com)
 [![MCP Hub China](https://img.shields.io/badge/MCP_Hub_China-listed-red)](https://mcp-hub.cn)
 [![OpenTools](https://img.shields.io/badge/OpenTools-listed-green)](https://opentools.ai)
+[![Gitee](https://img.shields.io/badge/Gitee-镜像-orange)](https://gitee.com/williamweishuhn/mcp-observatory)
+
+</details>
 
 > 我们热烈欢迎中国开发者贡献代码、文档和新的 MCP 服务器安全索引条目。请查看 [CONTRIBUTING.zh-CN.md](CONTRIBUTING.zh-CN.md) 了解如何参与。
 
@@ -209,6 +216,20 @@ MCP Observatory 为安全和平台团队提供 MCP 服务器 CI、schema 漂移�
 
 运行 `npx @kryptosai/mcp-observatory cloud`，从 Issue 选择器发起试点请求，或参见 [COMMERCIAL.md](./COMMERCIAL.md)。另见[隐私与遥测](./PRIVACY.md)、[活动归因](./docs/campaign-attribution.md) 和[生产使用条款](./TERMS.md)。
 
+## 工具对比
+
+| 功能 | mcp-observatory | Snyk agent-scan | Cisco mcp-scanner | agent-shield |
+|---|---|---|---|---|
+| MCP原生 | ✓ | ✓ | ✓ | ✓ |
+| 攻击模拟 | ✓ | ✗ | ✗ | ✗ |
+| Schema漂移检测 | ✓ | ✗ | ✗ | ✗ |
+| 录制/回放/验证 | ✓ | ✗ | ✗ | ✗ |
+| 健康评分(0-100) | ✓ | ✗ | ✗ | ✗ |
+| SARIF输出 | ✓ | ✓ | ✓ | ✓ |
+| CI/CD原生(setup-ci) | ✓ | ✓ | ✓ | ✓ |
+| 安全索引(17+服务器) | ✓ | ✗ | ✗ | ✗ |
+| 通过mcp-seatbelt运行时强制执行 | ✓ | ✗ | ✗ | ✗ |
+
 ## 快速开始
 
 扫描 Claude 配置中的所有 MCP 服务器：
@@ -335,6 +356,42 @@ npx @kryptosai/mcp-observatory watch target.json
 - `~/Library/Application Support/Claude/claude_desktop_config.json` (Claude Desktop, macOS)
 - `%APPDATA%/Claude/claude_desktop_config.json` (Claude Desktop, Windows)
 - `.claude.json` 和 `.mcp.json` (当前目录)
+
+## 架构
+
+```
+                    ┌─────────────────────────┐
+                    │   MCP Observatory CLI    │
+                    │  npx @kryptosai/mcp-     │
+                    │     observatory scan     │
+                    └───────────┬─────────────┘
+                                │
+                    ┌───────────▼─────────────┐
+                    │   Config Discovery       │
+                    │  (Claude, Cursor, etc.)  │
+                    └───────────┬─────────────┘
+                                │
+              ┌─────────────────┼─────────────────┐
+              ▼                 ▼                  ▼
+    ┌─────────────────┐ ┌──────────────┐ ┌──────────────────┐
+    │   Security Scan  │ │  Attack Sim  │ │  Schema Drift    │
+    │  (shell, creds)  │ │ (tool poison)│ │  (version diff)  │
+    └────────┬────────┘ └──────┬───────┘ └────────┬─────────┘
+             │                 │                   │
+             └─────────────────┼───────────────────┘
+                               ▼
+                    ┌─────────────────────┐
+                    │   Health Score       │
+                    │  (0-100 + verdict)   │
+                    └──────────┬──────────┘
+                               │
+              ┌────────────────┼────────────────┐
+              ▼                ▼                 ▼
+    ┌──────────────┐  ┌──────────────┐  ┌──────────────┐
+    │  SARIF       │  │  Markdown    │  │  CI Gateway  │
+    │  (Code Scan) │  │  Report      │  │  (setup-ci)  │
+    └──────────────┘  └──────────────┘  └──────────────┘
+```
 
 ## CI / GitHub Action
 
@@ -576,6 +633,10 @@ npx @kryptosai/mcp-observatory run --target ./target.json
 - 不支持自定义 WebSocket 传输（如 BrowserTools MCP）
 - 少数服务器超时或在初始化前关闭 — 参见[已知问题](./docs/known-issues.md)和[兼容性](./docs/compatibility.md)
 
+## 与 mcp-seatbelt 协作
+
+扫描后再信任。通过 [mcp-seatbelt](https://github.com/KryptosAI/mcp-seatbelt) 进行运行时强制执行——这是一个 MCP 代理，消费 Observatory 凭证并在生产环境中阻止超出合约的工具调用。Observatory 验证；seatbelt 执行。
+
 ## 贡献
 
 欢迎贡献者！本项目遵循[贡献者公约行为准则](./CODE_OF_CONDUCT.md)。最快的参与方式：
@@ -587,8 +648,6 @@ git clone https://github.com/KryptosAI/mcp-observatory.git && cd mcp-observatory
 ```
 
 最常见的首次贡献是向安全索引添加一个 MCP 服务器（10-15 分钟）。完整的指南、代码标准和贡献者认可阶梯参见 [CONTRIBUTING.md](CONTRIBUTING.md)。
-
-我们特别欢迎来自中国和亚洲开发者社区的贡献。如果你对 MCP 安全感兴趣，这是一个早期参与并影响项目方向的机会。
 
 ---
 

--- a/docs/mcp-security-platform.md
+++ b/docs/mcp-security-platform.md
@@ -1,0 +1,203 @@
+# MCP Security Platform: Scan Before You Trust, Enforce at Runtime
+
+## The MCP Security Gap
+
+The Model Context Protocol ecosystem has exploded. With over 47,000 repositories on GitHub and more than 65 security-focused tools available, MCP has become the primary interface between AI agents and the systems they control.
+
+Yet a critical gap remains: **no single tool does both pre-install scanning AND runtime enforcement.**
+
+- **Scanners** tell you a server looks risky — but they don't stop a single call.
+- **Proxies** block traffic at runtime — but they don't tell you what to block until it's too late.
+- **Gateways and firewalls** apply network-level rules — but they don't understand MCP semantics, tool arguments, or agent intent.
+
+Enterprises deploying AI agents in production need both:
+
+1. **Verify** MCP servers for vulnerabilities, exposed secrets, supply-chain risks, and dangerous capabilities *before* connecting them.
+2. **Enforce** security policies on every tool call at runtime — allow, deny, warn, or redact — without modifying the agent or the server.
+
+Today, the status quo is manual security review, ad-hoc nginx proxies, or nothing at all. That changes now.
+
+---
+
+## Our Two-Tool Platform
+
+**mcp-observatory** scans before you trust. **mcp-seatbelt** enforces at runtime. Together, they form the only end-to-end MCP security platform.
+
+```
+PRE-INSTALL (observatory)          RUNTIME (seatbelt)
+─────────────────────────          ──────────────────
+npx observatory scan               npx seatbelt proxy
+         │                                  │
+         ▼                                  ▼
+  ┌──────────────┐                 ┌──────────────┐
+  │ Discover     │                 │ Intercept    │
+  │ Assess Risk  │                 │ Evaluate     │
+  │ Score (0-100)│                 │ Allow/Deny   │
+  │ Attack Sim   │                 │ Redact Args  │
+  │ SARIF Report │                 │ Audit Log    │
+  └──────┬───────┘                 └──────┬───────┘
+         │                                │
+         ▼                                ▼
+  observatory JSON artifact ───►  seatbelt policy rules
+         │                                │
+         ▼                                ▼
+  Safety Index (public)            Dashboard (live)
+```
+
+### mcp-observatory — Pre-Install Scanner
+
+- **Discover** MCP servers from npm registries, GitHub, Smithery, PulseMCP, and MCP Market
+- **Score** every server on a 0–100 safety index across 13 risk dimensions
+- **Attack simulation** tests servers against prompt injection, tool poisoning, path traversal, command injection, and resource exfiltration
+- **CVE mapping** cross-references server dependencies against known vulnerability databases
+- **SARIF 2.1.0 export** for CI/CD integration with GitHub Code Scanning, GitLab SAST, and DefectDojo
+- **Telemetry dashboard** showing ecosystem-wide safety trends — no personal data, no tracking
+
+### mcp-seatbelt — Runtime Enforcement Proxy
+
+- **Detect** MCP server configurations across 8 clients: Cursor, Claude Desktop, VS Code, Windsurf, ChatGPT Desktop, JetBrains, Codex, and project-local configs
+- **Transparent proxy** sits between your agent and MCP servers on port 9420 — no agent changes needed
+- **Policy engine** evaluates every JSON-RPC 2.0 call against 7 built-in policy rules: shell execution, sensitive paths, credential access, credential redaction, private network, process execution, and time-windowed filesystem writes
+- **Dual mode**: `audit` logs violations; `enforce` blocks denied calls
+- **Live dashboard** at `localhost:9421` for real-time visibility into every tool call
+- **CI/CD ready** with `mcp-seatbelt check` returning non-zero on critical risk detection
+
+---
+
+## Comparison: Us vs The Market
+
+| Tool | Pre-install Scan | Runtime Enforcement | Attack Simulation | Health Score | Argument Redaction | Learning Mode | Live Dashboard | Open Source |
+|---|---|---|---|---|---|---|---|---|
+| **mcp-observatory + mcp-seatbelt** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Snyk agent-scan | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Cisco mcp-scanner | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| IBM ContextForge | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| mcp-firewall | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ✅ |
+| mcp-guardian | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| Prismor | ❌ | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| agent-shield | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ |
+| Tencent AI-Infra-Guard | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+
+**No competitor checks both the "Pre-install Scan" and "Runtime Enforcement" columns.** Tools either scan and report, or proxy and block — never both. Our platform is the only solution that covers the full lifecycle: discover risk before connection, block danger at call time.
+
+---
+
+## How They Integrate
+
+### Direct Artifact Import
+
+```bash
+mcp-seatbelt import-observatory <artifact.json>
+```
+
+Observatory scan results convert directly into seatbelt policy rules. High and critical findings become `deny` rules. Medium findings become `warn` rules. The mapping is intelligent:
+
+- Observatory tool findings → seatbelt `command` target rules
+- Observatory path findings → seatbelt `file` target rules
+- Observatory network/host findings → seatbelt `network` target rules
+- Observatory env/credential findings → seatbelt `env` target rules
+
+Seatbelt automatically discovers observatory artifacts in `.mcp-observatory/runs/` and `.mcp-observatory-metrics/` directories. Run `import-observatory` with no arguments and it finds the latest scan results automatically.
+
+### Safety Index to Allowlist
+
+Observatory's 0–100 safety index pre-populates seatbelt allowlists. Servers scoring above 80 can be automatically allowlisted. Servers below 40 get strict-deny rules. Everything in between gets a warning.
+
+### Combined Telemetry & Metrics
+
+Observatory telemetry shows **what the ecosystem looks like** — which servers are risky, where vulnerabilities cluster, what attack surfaces dominate. Seatbelt telemetry shows **what your agents are doing** — which tools get called, what gets blocked, what gets redacted. Together they give you:
+
+- **Observatory metrics dashboard** (private): pre-install health scores across your MCP portfolio, CVE exposure trends, supply-chain risk distribution
+- **Seatbelt dashboard** (live at `:9421`): real-time tool call stream, block/allow/warn ratios, per-client and per-server enforcement stats
+
+### Unified CI/CD Pipeline
+
+```
+CI Pipeline:
+  1. npx observatory scan      → SARIF report uploaded to code scanning
+  2. npx observatory score     → safety index gates deployment
+  3. npx seatbelt check        → critical risk detection fails the build
+  4. npx seatbelt proxy        → runtime enforcement in staging/production
+```
+
+---
+
+## Quick Start
+
+```bash
+# Step 1: Scan before you trust
+npx @kryptosai/mcp-observatory scan
+npx @kryptosai/mcp-observatory score npx -y my-mcp-server
+
+# Step 2: Import findings into seatbelt
+npx mcp-seatbelt init
+npx mcp-seatbelt import-observatory .mcp-observatory/runs/latest.json
+
+# Step 3: Enforce at runtime
+npx mcp-seatbelt proxy --policy enforce
+npx mcp-seatbelt dashboard
+```
+
+That's it. Three commands, one platform, full coverage.
+
+---
+
+## Enterprise Story
+
+### Observatory Cloud — Hosted CI, Private Reports, Certification
+
+Security teams don't want to run scanners on developer laptops. Observatory Cloud provides:
+
+- Hosted scanning pipeline with private, per-organization reports
+- Certification badges for verified-safe MCP servers — publish your safety score on npm, Smithery, and GitHub
+- Compliance export for SOC 2, ISO 27001, and PCI DSS audit trails
+- Team dashboards showing MCP risk posture across all projects
+
+### Seatbelt Proxy — On-Premises Runtime Enforcement
+
+Runtime enforcement stays where your data lives. Seatbelt runs on-premises, in your VPC, behind your firewall:
+
+- No telemetry sent anywhere — all enforcement data stays local
+- Policy-as-code in YAML, version-controlled alongside your infrastructure
+- LDAP/OIDC integration for per-team, per-role policy assignment (roadmap)
+- Prometheus metrics endpoint for integration with existing monitoring stacks (roadmap)
+
+### Full Lifecycle MCP Security
+
+```
+DEVELOP          →    CI/CD          →    STAGING         →    PRODUCTION
+─────────────         ──────────          ───────────         ────────────
+observatory scan      observatory score   seatbelt audit       seatbelt enforce
+  ↓                     ↓                   ↓                    ↓
+Risk report           SARIF upload        Policy test          Live dashboard
+Safety index          Build gate          Dry-run blocks       Active blocking
+Attack simulation     PR comment          Import findings      Audit logging
+```
+
+**Scan in CI/CD. Enforce in production.** No gaps. No blind spots. No manual review bottleneck.
+
+### Contact
+
+For enterprise licensing, hosted observatory, or custom integrations:
+**william@banksey.com**
+
+---
+
+## What Makes This Unique
+
+- **Only MCP security platform** that covers pre-install scanning AND runtime enforcement — everybody else does one or the other
+- **20 total security checks** — 13 risk rules in observatory plus 7 policy rules in seatbelt
+- **686 tests** across both tools (212 in observatory + 474 in seatbelt) ensuring reliability at every layer
+- **8 client detectors** — auto-discovers MCP configs in Cursor, Claude Desktop, VS Code, Windsurf, ChatGPT Desktop, JetBrains, Codex, and project-local configs
+- **9 check modules** covering shell interpreters, docker sandboxing, network tools, process spawning, destructive filesystem ops, remote access, sensitive environment variables, package runner risks, and privilege escalation
+- **30 CLI commands** across both tools (22 in observatory + 8 in seatbelt) covering every security workflow
+- **Open source (MIT)**, npm-native, zero external dependencies beyond what you already trust
+- **CI/CD ready** with SARIF export, non-zero exit codes on failure, and GitHub Actions workflow templates
+- **Already listed** in the awesome-mcp-servers Security section — the ecosystem's canonical reference
+- **Argument redaction** — not just block/allow, but transparently redact credentials from tool calls before they reach the server
+- **Learning mode** — run in audit mode to observe real-world usage patterns before enforcing strict policies
+- **Time-windowed rules** — allow filesystem writes only during business hours, or block network access on weekends
+
+---
+
+**Scan before you trust. Enforce at runtime. That's the full picture.**


### PR DESCRIPTION
## Changes

**English README:**
- Consolidated 20 badges → 6 (CI, CodeQL, Coverage Workflow, npm, Stars, License)
- 15 marketplace/directory badges moved to collapsible <details> section
- Fixed coverage badge text: was misleading as 'Coverage', now 'Coverage Workflow'
- Fixed all-contributors badge: 3→4 (now matches .all-contributorsrc count)
- Added comparison table: observatory vs Snyk agent-scan, Cisco mcp-scanner, agent-shield
- Added architecture ASCII diagram
- Added 'Works with mcp-seatbelt' cross-reference section

**Chinese README (README.zh-CN.md):**
- Synced all-contributors badge to 4
- Added missing Gitee mirror badge
- Added comparison table with Chinese translations
- Added architecture diagram
- Added mcp-seatbelt cross-reference

**New:** docs/mcp-security-platform.md — combined platform positioning document

All 474 tests pass. No code changes — docs only.