### PR TITLE
feat: community-driven improvements — negative evidence fields and runtime profiles

### DIFF
--- a/src/checks/runtime-profile.ts
+++ b/src/checks/runtime-profile.ts
@@ -1,0 +1,236 @@
+import { performance } from "node:perf_hooks";
+
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+
+import { makeCheckResult, type ObservedCheck } from "./base.js";
+import type { EgressEntry, EvidenceSummary, RuntimeProfile, StateMutation } from "../types.js";
+
+const EGRESS_PARAM_PATTERNS = [
+  /^url$/i, /^uri$/i, /^endpoint$/i, /^host$/i, /^hostname$/i,
+  /^server$/i, /^address$/i, /^base_?url$/i,
+  /^webhook$/i, /^callback$/i, /^domain$/i, /^origin$/i,
+];
+
+const EGRESS_DESC_PATTERNS = [
+  /\burl\b/i, /\bhttps?\b/i, /\bendpoint\b/i,
+  /\bhost\b/i, /\bapi\b/i, /\bwebhook\b/i,
+];
+
+const MUTATION_PARAM_PATTERNS = [
+  /^path$/i, /^file$/i, /^filename$/i, /^filepath$/i, /^filePath$/i,
+  /^directory$/i, /^dir$/i, /^folder$/i,
+  /^env$/i, /^environ$/i, /^environment$/i,
+  /^command$/i, /^cmd$/i, /^exec$/i, /^shell$/i,
+];
+
+const MUTATION_DESC_PATTERNS = [
+  /\bwrite\b/i, /\bdelete\b/i, /\bremove\b/i, /\bcreate\b/i,
+  /\bexecute\b/i, /\brun\b/i, /\bset\b/i, /\bupdate\b/i,
+  /\bmodify\b/i, /\bsave\b/i, /\bfile\b/i, /\bpath\b/i,
+  /\bdirectory\b/i, /\benvironment\b/i, /\bcommand\b/i,
+];
+
+const MUTATION_NAME_PATTERNS = [
+  /write/i, /delete/i, /remove/i, /create/i,
+  /exec(ute)?/i, /run/i, /set/i, /update/i,
+  /modify/i, /save/i,
+];
+
+function inferProtocol(value: string): string {
+  if (/^https:\/\//i.test(value)) return "HTTPS";
+  if (/^http:\/\//i.test(value)) return "HTTP";
+  if (/^wss?:\/\//i.test(value)) return "WSS";
+  if (/^tcp:\/\//i.test(value)) return "TCP";
+  if (/^udp:\/\//i.test(value)) return "UDP";
+  return "unknown";
+}
+
+function inferMutationResource(paramName: string): string {
+  if (/^env|^environ/i.test(paramName)) return "environment";
+  if (/^(command|cmd|exec|shell)$/i.test(paramName)) return "network";
+  return "filesystem";
+}
+
+function inferMutationOperation(toolName: string, paramName: string): string {
+  if (/\bdelet|remov\b/i.test(toolName)) return "delete";
+  if (/\bwrit|creat|sav\b/i.test(toolName)) return "write";
+  if (/\bexec|run|command|shell|cmd\b/i.test(toolName) || /^command|cmd|exec|shell$/i.test(paramName)) return "execute";
+  return "write";
+}
+
+function inferMutationScope(schemaProperties: Record<string, Record<string, unknown>> | undefined, paramName: string, toolName: string): string {
+  if (/^env|^environ/i.test(paramName)) return "global";
+  if (/^(command|cmd|exec|shell)$/i.test(paramName)) return "specific_path";
+  if (schemaProperties?.[paramName]?.default !== undefined) return "specific_path";
+  return "working_directory";
+}
+
+function stringValue(value: unknown): string {
+  if (typeof value === "string") return value;
+  return JSON.stringify(value);
+}
+
+function normalizeToolSchema(tool: Tool): {
+  name: string;
+  description: string;
+  propertyNames: string[];
+  propertyDescriptions: string[];
+  properties: Record<string, Record<string, unknown>> | undefined;
+} {
+  const schema = tool.inputSchema as Record<string, unknown> | undefined;
+  const properties = schema?.["properties"] as Record<string, Record<string, unknown>> | undefined;
+  const propertyNames = properties ? Object.keys(properties) : [];
+  const propertyDescriptions = propertyNames
+    .map((name) => stringValue(properties![name]?.description ?? ""))
+    .filter(Boolean);
+  return {
+    name: tool.name,
+    description: stringValue(tool.description ?? ""),
+    propertyNames,
+    propertyDescriptions,
+    properties,
+  };
+}
+
+export function analyzeRuntimeProfile(tools: Tool[]): RuntimeProfile {
+  const egress: EgressEntry[] = [];
+  const mutations: StateMutation[] = [];
+
+  for (const tool of tools) {
+    const normalized = normalizeToolSchema(tool);
+
+    for (const paramName of normalized.propertyNames) {
+      if (EGRESS_PARAM_PATTERNS.some((p) => p.test(paramName))) {
+        const paramSchema = normalized.properties?.[paramName];
+        const defaultVal = stringValue(paramSchema?.default ?? paramSchema?.example ?? paramName);
+        egress.push({
+          target: defaultVal,
+          protocol: inferProtocol(defaultVal),
+          source: "tool_schema",
+          confidence: "high",
+        });
+      }
+
+      if (MUTATION_PARAM_PATTERNS.some((p) => p.test(paramName))) {
+        mutations.push({
+          resource: inferMutationResource(paramName),
+          operation: inferMutationOperation(tool.name, paramName),
+          scope: inferMutationScope(normalized.properties, paramName, tool.name),
+          source: "tool_schema",
+        });
+      }
+    }
+
+    for (const desc of normalized.propertyDescriptions) {
+      if (EGRESS_DESC_PATTERNS.some((p) => p.test(desc))) {
+        egress.push({
+          target: desc,
+          protocol: "unknown",
+          source: "description_analysis",
+          confidence: "medium",
+        });
+      }
+      if (MUTATION_DESC_PATTERNS.some((p) => p.test(desc))) {
+        mutations.push({
+          resource: "filesystem",
+          operation: "write",
+          scope: "working_directory",
+          source: "description_analysis",
+        });
+      }
+    }
+
+    if (EGRESS_DESC_PATTERNS.some((p) => p.test(normalized.description))) {
+      egress.push({
+        target: normalized.name,
+        protocol: "unknown",
+        source: "description_analysis",
+        confidence: "low",
+      });
+    }
+
+    if (MUTATION_DESC_PATTERNS.some((p) => p.test(normalized.description))) {
+      mutations.push({
+        resource: "filesystem",
+        operation: "write",
+        scope: "working_directory",
+        source: "description_analysis",
+      });
+    }
+
+    if (MUTATION_NAME_PATTERNS.some((p) => p.test(normalized.name))) {
+      mutations.push({
+        resource: "filesystem",
+        operation: inferMutationOperation(tool.name, ""),
+        scope: "working_directory",
+        source: "description_analysis",
+      });
+    }
+  }
+
+  const confidence: "high" | "medium" | "low" =
+    egress.some((e) => e.confidence === "high") || mutations.some((m) => m.source === "tool_schema")
+      ? "high"
+      : egress.length > 0 || mutations.length > 0
+        ? "medium"
+        : "low";
+
+  return {
+    egress: egress.length > 0 ? egress : undefined,
+    stateMutations: mutations.length > 0 ? mutations : undefined,
+    analyzedAt: new Date().toISOString(),
+    confidence,
+  };
+}
+
+function structuredEgressFindings(entries: EgressEntry[]): Array<Record<string, unknown>> {
+  return entries.map((e) => ({ ...e }));
+}
+
+function structuredMutationFindings(entries: StateMutation[]): Array<Record<string, unknown>> {
+  return entries.map((m) => ({ ...m }));
+}
+
+export function runRuntimeProfileCheck(tools: Tool[]): ObservedCheck {
+  const startedAt = performance.now();
+  const profile = analyzeRuntimeProfile(tools);
+
+  const egressCount = profile.egress?.length ?? 0;
+  const mutationCount = profile.stateMutations?.length ?? 0;
+
+  let status: "pass" | "partial" | "fail";
+  let message: string;
+
+  if (egressCount === 0 && mutationCount === 0) {
+    status = "pass";
+    message = "No egress or state mutation indicators detected in tool schemas.";
+  } else if (profile.confidence === "high") {
+    status = "partial";
+    message = `Detected ${egressCount} potential egress target(s) and ${mutationCount} potential state mutation(s) with high confidence.`;
+  } else {
+    status = "pass";
+    message = `Detected ${egressCount} potential egress target(s) and ${mutationCount} potential state mutation(s) with low confidence.`;
+  }
+
+  const evidenceList: EvidenceSummary[] = [];
+  if (egressCount > 0 || mutationCount > 0) {
+    evidenceList.push({
+      endpoint: "runtime-profile/analyze",
+      advertised: true,
+      responded: true,
+      minimalShapePresent: true,
+      itemCount: egressCount + mutationCount,
+      diagnostics: [
+        `Egress entries: ${egressCount}`,
+        `State mutations: ${mutationCount}`,
+        `Confidence: ${profile.confidence}`,
+      ],
+      findings: [
+        ...(profile.egress ? structuredEgressFindings(profile.egress) : []),
+        ...(profile.stateMutations ? structuredMutationFindings(profile.stateMutations) : []),
+      ],
+    });
+  }
+
+  return { result: makeCheckResult("runtime-profile", status, performance.now() - startedAt, message, evidenceList) };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ export { runConformanceCheck } from "./checks/conformance.js";
 export { runSchemaQualityCheck } from "./checks/schema-quality.js";
 export { runAttackSimulationCheck, type AttackSimulationFinding, type AttackSimulationOptions } from "./checks/attack-sim.js";
 export { runLightweightSecurityCheck, runSecurityCheck } from "./checks/security.js";
+export { analyzeRuntimeProfile, runRuntimeProfileCheck } from "./checks/runtime-profile.js";
 export { SECURITY_RULES, type SecurityFinding, type SecurityRule, type ToolInfo } from "./checks/security-rules.js";
 export { diffArtifacts } from "./diff.js";
 export { scanForTargets } from "./discovery.js";

--- a/src/receipt.ts
+++ b/src/receipt.ts
@@ -5,7 +5,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { type AuditReport, type AuditSeverity, type NormalizedSecurityFinding, type TrustStatus, auditScore, renderAuditMarkdown, renderAuditSarif } from "./audit.js";
-import type { TargetConfig } from "./types.js";
+import type { NotObserved, RunArtifact, TargetConfig } from "./types.js";
 
 export type ReceiptEnvironmentClass = "local" | "ci" | "public_safety_index" | "private_fleet";
 export type ReceiptState = "ready_for_ci" | "needs_review" | "blocked" | "could_not_evaluate";
@@ -49,6 +49,7 @@ export interface ReceiptEvidence {
   tool_surface_summary: string;
   attack_simulation_summary: string;
   baseline_or_drift_summary: string;
+  runtime_profile_summary: string;
 }
 
 export interface ReceiptVerdict {
@@ -91,6 +92,7 @@ export interface McpReceipt {
   evidence: ReceiptEvidence;
   verdict: ReceiptVerdict;
   findings: ReceiptFinding[];
+  notObserved: NotObserved[];
   reproduction: ReceiptReproduction;
   maintainer_cta: ReceiptCta[];
   buyer_cta: ReceiptCta[];
@@ -211,6 +213,84 @@ function driftSummary(report: AuditReport): string {
   return `${driftFindings.length} baseline/drift finding(s) summarized.`;
 }
 
+function runtimeProfileSummary(report: AuditReport): string {
+  const profile = report.artifact.runtimeProfile;
+  if (!profile) return "Runtime profile was not generated for this run.";
+  const egressCount = profile.egress?.length ?? 0;
+  const mutationCount = profile.stateMutations?.length ?? 0;
+  if (egressCount === 0 && mutationCount === 0) {
+    return `No egress or state mutation indicators detected (confidence: ${profile.confidence}).`;
+  }
+  const parts: string[] = [];
+  if (egressCount > 0) parts.push(`${egressCount} egress target(s) detected`);
+  if (mutationCount > 0) parts.push(`${mutationCount} state mutation(s) detected`);
+  return `${parts.join(", ")} (confidence: ${profile.confidence}).`;
+}
+
+export function detectNotObserved(artifact: RunArtifact): NotObserved[] {
+  const notObserved: NotObserved[] = [];
+  const allToolIds = new Set<string>();
+  const networkPattern = /url|http|https|fetch|request|api|web|curl|wget|net|socket|connect|download|upload/i;
+  const fsPattern = /read|write|delete|remove|create|mkdir|rmdir|file[_-]|fs[_-]|^cp$|^mv$|^ln$|touch|chmod|chown|move|copy|rename|dir/i;
+
+  for (const check of artifact.checks) {
+    for (const ev of check.evidence) {
+      for (const id of ev.identifiers ?? []) {
+        allToolIds.add(id);
+      }
+      if (ev.endpoint === "tools/list" && typeof ev.responseSnapshots?.tools === "object") {
+        const tools = (ev.responseSnapshots as Record<string, unknown>).tools as Array<{ name: string }> | undefined;
+        if (tools) {
+          for (const tool of tools) {
+            if (typeof tool.name === "string") allToolIds.add(tool.name);
+          }
+        }
+      }
+    }
+  }
+
+  const hasNetworkTool = [...allToolIds].some((t) => networkPattern.test(t));
+  if (!hasNetworkTool) {
+    notObserved.push({
+      category: "network_egress",
+      detail: "No outbound network calls were attempted during scan",
+      severity: "warning",
+    });
+  }
+
+  const hasFsTool = [...allToolIds].some((t) => fsPattern.test(t));
+  if (!hasFsTool) {
+    notObserved.push({
+      category: "filesystem_mutation",
+      detail: "Filesystem write operations were not exercised",
+      severity: "warning",
+    });
+  }
+
+  const securityCheck = artifact.checks.find((c) => c.id === "security" || c.id === "security-lite");
+  if (!securityCheck) {
+    notObserved.push({
+      category: "credential_access",
+      detail: "Credential scanning was not performed",
+      severity: "warning",
+    });
+  } else {
+    notObserved.push({
+      category: "credential_access",
+      detail: "Credential scanning was performed (see security findings)",
+      severity: "info",
+    });
+  }
+
+  notObserved.push({
+    category: "destructive_payloads",
+    detail: "Destructive payloads were not attempted (safe-mode only)",
+    severity: "info",
+  });
+
+  return notObserved;
+}
+
 export function mapStatusToReceiptVerdict(report: AuditReport): ReceiptVerdict {
   if (report.artifact.fatalError) {
     return {
@@ -326,9 +406,11 @@ export async function buildMcpReceipt(report: AuditReport, target: TargetConfig,
       tool_surface_summary: toolSurfaceSummary(report),
       attack_simulation_summary: attackSimulationSummary(report),
       baseline_or_drift_summary: driftSummary(report),
+      runtime_profile_summary: runtimeProfileSummary(report),
     },
     verdict: mapStatusToReceiptVerdict(report),
     findings: receiptFindings(report, options.topFindingsLimit ?? 5),
+    notObserved: detectNotObserved(report.artifact),
     reproduction: {
       rerun_command: rerunCommand(target, report.summary.profile),
       ci_command: ciCommand(target),
@@ -424,6 +506,14 @@ export function renderReceiptMarkdown(receipt: McpReceipt): string {
     `- Tool surface summary: ${receipt.evidence.tool_surface_summary}`,
     `- Attack simulation summary: ${receipt.evidence.attack_simulation_summary}`,
     `- Baseline/drift summary: ${receipt.evidence.baseline_or_drift_summary}`,
+    `- Runtime profile summary: ${receipt.evidence.runtime_profile_summary}`,
+    "",
+    "## What Was Not Tested",
+    "",
+    ...receipt.notObserved.map((entry) => {
+      const icon = entry.severity === "warning" ? "🔒" : "ℹ️";
+      return `- ${icon} ${entry.category}: ${entry.detail}`;
+    }),
     "",
     "## Top Findings",
     "",

--- a/src/reporters/markdown.ts
+++ b/src/reporters/markdown.ts
@@ -1,4 +1,5 @@
-import type { CheckResult, DiffArtifact, EvidenceSummary, RunArtifact } from "../types.js";
+import type { CheckResult, DiffArtifact, EgressEntry, EvidenceSummary, RunArtifact, StateMutation } from "../types.js";
+import { detectNotObserved } from "../receipt.js";
 import {
   describeCheckList,
   findChecksByStatus,
@@ -92,6 +93,42 @@ function renderCheckSection(check: CheckResult): string[] {
   ];
 }
 
+function renderEgressTable(entries: EgressEntry[]): string {
+  return table([
+    ["Target", "Protocol", "Source", "Confidence"],
+    ...entries.map((e) => [e.target, e.protocol, e.source, e.confidence]),
+  ]);
+}
+
+function renderStateMutationsTable(entries: StateMutation[]): string {
+  return table([
+    ["Resource", "Operation", "Scope", "Source"],
+    ...entries.map((m) => [m.resource, m.operation, m.scope, m.source]),
+  ]);
+}
+
+function renderRuntimeProfile(artifact: RunArtifact): string[] {
+  const profile = artifact.runtimeProfile;
+  if (!profile) return [];
+
+  const lines: string[] = ["## Runtime Profile", ""];
+
+  if (profile.egress && profile.egress.length > 0) {
+    lines.push("### Egress Manifest", "");
+    lines.push(`The following targets were identified as potentially reachable by this server (confidence: **${profile.confidence}**):`, "");
+    lines.push(renderEgressTable(profile.egress), "");
+  }
+
+  if (profile.stateMutations && profile.stateMutations.length > 0) {
+    lines.push("### State Mutations", "");
+    lines.push("The following state-modifying operations were identified from tool schemas:", "");
+    lines.push(renderStateMutationsTable(profile.stateMutations), "");
+  }
+
+  lines.push(`_Analyzed at ${profile.analyzedAt}_`, "");
+  return lines;
+}
+
 function renderRunMarkdown(artifact: RunArtifact): string {
   const orderedChecks = sortChecksByActionability(artifact.checks);
   return [
@@ -135,6 +172,14 @@ function renderRunMarkdown(artifact: RunArtifact): string {
     ``,
     renderRunAtAGlance(artifact),
     ``,
+    `## What Was Not Tested`,
+    ``,
+    ...((artifact.notObserved ?? detectNotObserved(artifact)).map((entry) => {
+      const icon = entry.severity === "warning" ? "🔒" : "ℹ️";
+      return `- ${icon} ${entry.category}: ${entry.detail}`;
+    })),
+    ``,
+    ...renderRuntimeProfile(artifact),
     `## Regressions and Recoveries`,
     ``,
     `_Use the \`diff\` command against another run artifact to classify regressions and recoveries over time._`,

--- a/src/reporters/terminal.ts
+++ b/src/reporters/terminal.ts
@@ -1,4 +1,5 @@
 import type { CheckResult, CheckStatus, DiffArtifact, DiffEntry, RunArtifact } from "../types.js";
+import { detectNotObserved } from "../receipt.js";
 import {
   describeCheckList,
   findChecksByStatus,
@@ -205,6 +206,16 @@ function renderRunTerminal(artifact: RunArtifact): string {
   lines.push("Checks (most actionable first):");
   for (const check of orderedChecks) {
     lines.push(formatCheck(check));
+  }
+
+  const notObserved = artifact.notObserved ?? detectNotObserved(artifact);
+  if (notObserved.length > 0) {
+    lines.push("");
+    lines.push(co(ANSI.bold, "What Was Not Tested:"));
+    for (const entry of notObserved) {
+      const icon = entry.severity === "warning" ? co(ANSI.yellow, "⚠") : co(ANSI.dim, "ℹ");
+      lines.push(`  ${icon} ${entry.category}: ${entry.detail}`);
+    }
   }
 
   // Show security-lite findings prominently even without --security flag

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -12,11 +12,12 @@ import { runResourcesCheck } from "./checks/resources.js";
 import { runSchemaQualityCheck } from "./checks/schema-quality.js";
 import { runToolsCheck } from "./checks/tools.js";
 import { runLightweightSecurityCheck, runSecurityCheck } from "./checks/security.js";
+import { analyzeRuntimeProfile, runRuntimeProfileCheck } from "./checks/runtime-profile.js";
 import { runToolsInvokeCheck } from "./checks/tools-invoke.js";
 import { computeHealthScore } from "./score.js";
 import { errorMessage } from "./utils/errors.js";
 import { RecordingTransport } from "./transport/recording-transport.js";
-import type { CheckResult, Gate, PerformanceMetrics, RunArtifact, StatusCounts, TargetConfig } from "./types.js";
+import type { CheckResult, Gate, PerformanceMetrics, RunArtifact, RuntimeProfile, StatusCounts, TargetConfig } from "./types.js";
 import { SCHEMA_VERSION } from "./types.js";
 import { buildRunId } from "./utils/ids.js";
 import { TOOL_VERSION } from "./version.js";
@@ -97,6 +98,7 @@ async function runTargetWithRecording(target: TargetConfig, options?: RunOptions
   let serverName: string | undefined;
   let serverVersion: string | undefined;
   let performanceMetrics: PerformanceMetrics | undefined;
+  let runtimeProfile: RuntimeProfile | undefined;
 
   let cassetteEntries: CassetteEntry[] | undefined;
 
@@ -137,6 +139,10 @@ async function runTargetWithRecording(target: TargetConfig, options?: RunOptions
         const toolsResp = await session.client.listTools(undefined, { timeout: checkContext.timeoutMs });
         const liteSecCheck = runLightweightSecurityCheck(toolsResp.tools, target);
         checks.push(liteSecCheck.result);
+
+        const runtimeProfileCheck = runRuntimeProfileCheck(toolsResp.tools);
+        checks.push(runtimeProfileCheck.result);
+        runtimeProfile = analyzeRuntimeProfile(toolsResp.tools);
       } catch {
         // If listing tools fails, skip lightweight security (tools check already reports the error)
       }
@@ -250,6 +256,7 @@ async function runTargetWithRecording(target: TargetConfig, options?: RunOptions
     checks,
     healthScore,
     performanceMetrics,
+    runtimeProfile,
     fatalError
   };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,7 @@ export type CheckStatus =
   | "unsupported"
   | "flaky"
   | "skipped";
-export type CheckId = "tools" | "prompts" | "resources" | "tools-invoke" | "security" | "security-lite" | "attack-sim" | "conformance" | "schema-quality";
+export type CheckId = "tools" | "prompts" | "resources" | "tools-invoke" | "security" | "security-lite" | "attack-sim" | "conformance" | "schema-quality" | "runtime-profile";
 
 export const STATUS_RANK: Record<CheckStatus, number> = {
   pass: 6, partial: 5, flaky: 4, unsupported: 3, skipped: 2, fail: 1
@@ -112,7 +112,9 @@ export interface RunArtifact {
   checks: CheckResult[];
   healthScore?: HealthScore;
   performanceMetrics?: PerformanceMetrics;
+  runtimeProfile?: RuntimeProfile;
   fatalError?: string;
+  notObserved?: NotObserved[];
 }
 
 export type HealthGrade = "A" | "B" | "C" | "D" | "F";
@@ -128,6 +130,33 @@ export interface HealthScore {
   overall: number;
   grade: HealthGrade;
   dimensions: ScoreDimension[];
+}
+
+export interface NotObserved {
+  category: string;
+  detail: string;
+  severity: "info" | "warning";
+}
+
+export interface EgressEntry {
+  target: string;
+  protocol: string;
+  source: string;
+  confidence: "high" | "medium" | "low";
+}
+
+export interface StateMutation {
+  resource: string;
+  operation: string;
+  scope: string;
+  source: string;
+}
+
+export interface RuntimeProfile {
+  egress?: EgressEntry[];
+  stateMutations?: StateMutation[];
+  analyzedAt: string;
+  confidence: "high" | "medium" | "low";
 }
 
 export interface PerformanceMetrics {

--- a/tests/receipt.test.ts
+++ b/tests/receipt.test.ts
@@ -6,7 +6,7 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import { buildActionReceipt, recommendedActionForFinding, renderActionReceipt } from "../src/action-receipt.js";
 import { buildAuditReport } from "../src/audit.js";
-import { buildMcpReceipt, mapStatusToReceiptVerdict, receiptFormatFromPath, renderReceipt, renderReceiptMarkdown } from "../src/receipt.js";
+import { buildMcpReceipt, detectNotObserved, mapStatusToReceiptVerdict, receiptFormatFromPath, renderReceipt, renderReceiptMarkdown } from "../src/receipt.js";
 import { makeArtifact } from "./fixtures/test-helpers.js";
 
 const target = {
@@ -294,5 +294,186 @@ describe("MCP receipts", () => {
       ruleId: "mcp-observatory/attack-sim/contract-drift/destructive-tool-added",
     });
     expect(renderActionReceipt(artifact)).toContain("Top evidence:");
+  });
+
+  it("detectNotObserved returns network_egress warning when no network tools found", () => {
+    const artifact = makeArtifact([
+      {
+        id: "tools",
+        capability: "tools",
+        status: "pass",
+        durationMs: 5,
+        message: "1 tool",
+        evidence: [{
+          endpoint: "tools/list",
+          advertised: true,
+          responded: true,
+          minimalShapePresent: true,
+          identifiers: ["echo"],
+        }],
+      },
+    ]);
+
+    const result = detectNotObserved(artifact);
+    const networkEntry = result.find((e) => e.category === "network_egress");
+    expect(networkEntry).toBeDefined();
+    expect(networkEntry!.severity).toBe("warning");
+    expect(networkEntry!.detail).toContain("outbound network");
+  });
+
+  it("detectNotObserved returns filesystem_mutation warning when no fs tools found", () => {
+    const artifact = makeArtifact([
+      {
+        id: "tools",
+        capability: "tools",
+        status: "pass",
+        durationMs: 5,
+        message: "1 tool",
+        evidence: [{
+          endpoint: "tools/list",
+          advertised: true,
+          responded: true,
+          minimalShapePresent: true,
+          identifiers: ["echo"],
+        }],
+      },
+    ]);
+
+    const result = detectNotObserved(artifact);
+    const fsEntry = result.find((e) => e.category === "filesystem_mutation");
+    expect(fsEntry).toBeDefined();
+    expect(fsEntry!.severity).toBe("warning");
+    expect(fsEntry!.detail).toContain("Filesystem write");
+  });
+
+  it("detectNotObserved returns credential_access info when security check exists", () => {
+    const artifact = makeArtifact([
+      {
+        id: "security-lite",
+        capability: "security-lite",
+        status: "pass",
+        durationMs: 5,
+        message: "No issues found",
+        evidence: [{
+          endpoint: "security-lite/scan",
+          advertised: true,
+          responded: true,
+          minimalShapePresent: true,
+        }],
+      },
+    ]);
+
+    const result = detectNotObserved(artifact);
+    const credEntry = result.find((e) => e.category === "credential_access");
+    expect(credEntry).toBeDefined();
+    expect(credEntry!.severity).toBe("info");
+    expect(credEntry!.detail).toContain("performed");
+  });
+
+  it("detectNotObserved returns credential_access warning when no security check", () => {
+    const artifact = makeArtifact([]);
+
+    const result = detectNotObserved(artifact);
+    const credEntry = result.find((e) => e.category === "credential_access");
+    expect(credEntry).toBeDefined();
+    expect(credEntry!.severity).toBe("warning");
+    expect(credEntry!.detail).toContain("not performed");
+  });
+
+  it("detectNotObserved always includes destructive_payloads info", () => {
+    const artifact = makeArtifact([]);
+
+    const result = detectNotObserved(artifact);
+    const destructiveEntry = result.find((e) => e.category === "destructive_payloads");
+    expect(destructiveEntry).toBeDefined();
+    expect(destructiveEntry!.severity).toBe("info");
+    expect(destructiveEntry!.detail).toContain("safe-mode");
+  });
+
+  it("detectNotObserved skips network_egress when network tools are present", () => {
+    const artifact = makeArtifact([
+      {
+        id: "tools",
+        capability: "tools",
+        status: "pass",
+        durationMs: 5,
+        message: "2 tools",
+        evidence: [{
+          endpoint: "tools/list",
+          advertised: true,
+          responded: true,
+          minimalShapePresent: true,
+          identifiers: ["fetch_url", "echo"],
+        }],
+      },
+    ]);
+
+    const result = detectNotObserved(artifact);
+    const networkEntry = result.find((e) => e.category === "network_egress");
+    expect(networkEntry).toBeUndefined();
+  });
+
+  it("detectNotObserved skips filesystem_mutation when fs tools are present", () => {
+    const artifact = makeArtifact([
+      {
+        id: "tools",
+        capability: "tools",
+        status: "pass",
+        durationMs: 5,
+        message: "2 tools",
+        evidence: [{
+          endpoint: "tools/list",
+          advertised: true,
+          responded: true,
+          minimalShapePresent: true,
+          identifiers: ["write_file", "echo"],
+        }],
+      },
+    ]);
+
+    const result = detectNotObserved(artifact);
+    const fsEntry = result.find((e) => e.category === "filesystem_mutation");
+    expect(fsEntry).toBeUndefined();
+  });
+
+  it("receipt markdown includes the What Was Not Tested section", async () => {
+    const report = buildAuditReport(makeArtifact([
+      {
+        id: "tools",
+        capability: "tools",
+        status: "pass",
+        durationMs: 5,
+        message: "1 tool",
+        evidence: [{
+          endpoint: "tools/list",
+          advertised: true,
+          responded: true,
+          minimalShapePresent: true,
+          identifiers: ["echo"],
+        }],
+      },
+      {
+        id: "security-lite",
+        capability: "security-lite",
+        status: "pass",
+        durationMs: 5,
+        message: "Clean",
+        evidence: [{
+          endpoint: "security-lite/scan",
+          advertised: true,
+          responded: true,
+          minimalShapePresent: true,
+        }],
+      },
+    ]), { ...target, metadata: { audit: "structured events" } });
+    const receipt = await buildMcpReceipt(report, target);
+    const markdown = renderReceiptMarkdown(receipt);
+
+    expect(markdown).toContain("## What Was Not Tested");
+    expect(markdown).toContain("network_egress");
+    expect(markdown).toContain("filesystem_mutation");
+    expect(markdown).toContain("credential_access");
+    expect(markdown).toContain("destructive_payloads");
+    expect(receipt.notObserved.length).toBeGreaterThanOrEqual(3);
   });
 });

--- a/tests/runner.test.ts
+++ b/tests/runner.test.ts
@@ -18,13 +18,14 @@ describe("runTarget", () => {
     expect(artifact.artifactType).toBe("run");
     expect(artifact.schemaVersion).toBe("1.0.0");
     expect(artifact.gate).toBe("pass");
-    expect(artifact.summary.total).toBe(6);
+    expect(artifact.summary.total).toBe(7);
     expect(artifact.summary.fail).toBe(0);
     expect(artifact.checks.map((check) => check.id)).toEqual([
       "tools",
       "prompts",
       "resources",
       "security-lite",
+      "runtime-profile",
       "conformance",
       "schema-quality",
     ]);

--- a/tests/runtime-profile.test.ts
+++ b/tests/runtime-profile.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from "vitest";
+
+import { analyzeRuntimeProfile, runRuntimeProfileCheck } from "../src/checks/runtime-profile.js";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+
+function makeTool(overrides: Partial<Tool> = {}): Tool {
+  return {
+    name: "test_tool",
+    inputSchema: { type: "object", properties: {} },
+    ...overrides,
+  };
+}
+
+describe("runtime-profile check", () => {
+  describe("analyzeRuntimeProfile", () => {
+    it("detects egress from URL/host parameters", () => {
+      const tools: Tool[] = [
+        makeTool({
+          name: "fetch_data",
+          description: "Fetch data from an API.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              url: { type: "string", description: "URL to fetch" },
+              host: { type: "string", description: "Host to connect" },
+            },
+          },
+        }),
+      ];
+
+      const profile = analyzeRuntimeProfile(tools);
+      expect(profile.confidence).toBe("high");
+      expect(profile.egress).toBeDefined();
+      expect(profile.egress!.length).toBeGreaterThanOrEqual(2);
+      expect(profile.egress!.some((e) => e.source === "tool_schema")).toBe(true);
+    });
+
+    it("detects egress from endpoint/hostname parameters", () => {
+      const tools: Tool[] = [
+        makeTool({
+          name: "call_service",
+          inputSchema: {
+            type: "object",
+            properties: {
+              endpoint: { type: "string", example: "https://api.example.com" },
+              hostname: { type: "string", default: "db.internal" },
+            },
+          },
+        }),
+      ];
+
+      const profile = analyzeRuntimeProfile(tools);
+      expect(profile.egress).toBeDefined();
+      expect(profile.egress!.some((e) => e.protocol === "HTTPS")).toBe(true);
+    });
+
+    it("detects state mutations from file/path parameters", () => {
+      const tools: Tool[] = [
+        makeTool({
+          name: "write_file",
+          description: "Write content to a file.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              path: { type: "string", description: "Path to write to" },
+              filename: { type: "string" },
+              directory: { type: "string", default: "/tmp/output" },
+            },
+          },
+        }),
+      ];
+
+      const profile = analyzeRuntimeProfile(tools);
+      expect(profile.stateMutations).toBeDefined();
+      expect(profile.stateMutations!.length).toBeGreaterThanOrEqual(2);
+      expect(profile.stateMutations!.some((m) => m.resource === "filesystem")).toBe(true);
+      expect(profile.stateMutations!.some((m) => m.scope === "specific_path")).toBe(true);
+    });
+
+    it("detects state mutations from command execution parameters", () => {
+      const tools: Tool[] = [
+        makeTool({
+          name: "execute_code",
+          description: "Execute arbitrary code.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              command: { type: "string", description: "Command to run" },
+            },
+          },
+        }),
+      ];
+
+      const profile = analyzeRuntimeProfile(tools);
+      expect(profile.stateMutations).toBeDefined();
+      expect(profile.stateMutations!.some((m) => m.operation === "execute")).toBe(true);
+      expect(profile.stateMutations!.some((m) => m.resource === "network")).toBe(true);
+    });
+
+    it("detects state mutations from environment variable parameters", () => {
+      const tools: Tool[] = [
+        makeTool({
+          name: "set_config",
+          inputSchema: {
+            type: "object",
+            properties: {
+              env: { type: "string", description: "Environment variable name" },
+            },
+          },
+        }),
+      ];
+
+      const profile = analyzeRuntimeProfile(tools);
+      expect(profile.stateMutations).toBeDefined();
+      expect(profile.stateMutations!.some((m) => m.resource === "environment")).toBe(true);
+      expect(profile.stateMutations!.some((m) => m.scope === "global")).toBe(true);
+    });
+
+    it("detects mutations from tool descriptions mentioning write/delete", () => {
+      const tools: Tool[] = [
+        makeTool({
+          name: "cleanup",
+          description: "Delete temporary files from the working directory.",
+          inputSchema: {
+            type: "object",
+            properties: { pattern: { type: "string" } },
+          },
+        }),
+      ];
+
+      const profile = analyzeRuntimeProfile(tools);
+      expect(profile.stateMutations).toBeDefined();
+      expect(profile.stateMutations!.some((m) => m.source === "description_analysis")).toBe(true);
+    });
+
+    it("detects mutations from tool names suggesting write/exec", () => {
+      const tools: Tool[] = [
+        makeTool({
+          name: "delete_file",
+          inputSchema: { type: "object", properties: {} },
+        }),
+      ];
+
+      const profile = analyzeRuntimeProfile(tools);
+      expect(profile.stateMutations).toBeDefined();
+      expect(profile.stateMutations!.some((m) => m.operation === "delete")).toBe(true);
+      expect(profile.stateMutations!.some((m) => m.source === "description_analysis")).toBe(true);
+    });
+
+    it("returns low confidence with empty arrays for clean tools", () => {
+      const tools: Tool[] = [
+        makeTool({
+          name: "get_weather",
+          description: "Get the weather for a city.",
+          inputSchema: {
+            type: "object",
+            properties: { city: { type: "string" } },
+          },
+        }),
+      ];
+
+      const profile = analyzeRuntimeProfile(tools);
+      expect(profile.confidence).toBe("low");
+      expect(profile.egress).toBeUndefined();
+      expect(profile.stateMutations).toBeUndefined();
+    });
+
+    it("handles tools without inputSchema", () => {
+      const tools: Tool[] = [
+        { name: "bare_tool" } as Tool,
+      ];
+
+      const profile = analyzeRuntimeProfile(tools);
+      expect(profile.confidence).toBe("low");
+    });
+
+    it("handles an empty tools array", () => {
+      const profile = analyzeRuntimeProfile([]);
+      expect(profile.confidence).toBe("low");
+      expect(profile.egress).toBeUndefined();
+      expect(profile.stateMutations).toBeUndefined();
+    });
+  });
+
+  describe("runRuntimeProfileCheck", () => {
+    it("returns a passing check with no findings", () => {
+      const check = runRuntimeProfileCheck([
+        makeTool({ name: "echo", inputSchema: { type: "object", properties: {} } }),
+      ]);
+
+      expect(check.result.id).toBe("runtime-profile");
+      expect(check.result.status).toBe("pass");
+      expect(check.result.message).toContain("No egress");
+    });
+
+    it("returns a partial check when high-confidence findings exist", () => {
+      const check = runRuntimeProfileCheck([
+        makeTool({
+          name: "fetch_url",
+          inputSchema: { type: "object", properties: { url: { type: "string" } } },
+        }),
+      ]);
+
+      expect(check.result.id).toBe("runtime-profile");
+      expect(check.result.status).toBe("partial");
+      expect(check.result.evidence[0]?.itemCount).toBeGreaterThan(0);
+    });
+
+    it("includes structured findings in evidence", () => {
+      const check = runRuntimeProfileCheck([
+        makeTool({
+          name: "download",
+          inputSchema: {
+            type: "object",
+            properties: {
+              url: { type: "string" },
+              path: { type: "string" },
+            },
+          },
+        }),
+      ]);
+
+      const findings = check.result.evidence[0]?.findings;
+      expect(findings).toBeDefined();
+      expect(findings!.some((f) => (f as Record<string, unknown>)["source"] === "tool_schema")).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Based on the Moltbook 'receipts not badges' thread (alfred_wallace, stillos, klavdii_rpi, cohesivity, jontheagent):

- **Negative evidence fields** — receipts now disclose what was NOT tested
- **Runtime profiles** — egress manifest + state mutation tracking from schema analysis
- 495 tests, all passing