### PR TITLE
feat: enforce command — observation to action in one step

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,6 +22,7 @@ import { registerInitCiCommands } from "./commands/init-ci.js";
 import { registerLockCommands } from "./commands/lock.js";
 import { registerAttackSimCommands } from "./commands/attack-sim.js";
 import { registerAuditCommands } from "./commands/audit.js";
+import { registerEnforceCommands } from "./commands/enforce.js";
 import { registerReceiptCommands } from "./commands/receipt.js";
 import { registerRiskGraphCommands } from "./commands/risk-graph.js";
 import { registerSkillScanCommands } from "./commands/skill-scan.js";
@@ -293,6 +294,7 @@ async function main(): Promise<void> {
   registerInitCiCommands(program);
   registerLockCommands(program);
   registerAuditCommands(program);
+  registerEnforceCommands(program, bin);
   registerReceiptCommands(program);
   registerRiskGraphCommands(program);
   registerAttackSimCommands(program);

--- a/src/commands/enforce.ts
+++ b/src/commands/enforce.ts
@@ -118,23 +118,7 @@ async function isSeatbeltInstalled(): Promise<boolean> {
 }
 
 async function startSeatbeltProxy(policyPath: string, port: number): Promise<boolean> {
-  try {
-    execSync(`npx @kryptosai/mcp-seatbelt proxy --policy ${policyPath} --port ${port} &`, {
-      stdio: "ignore",
-      timeout: 5_000,
-    });
-    return true;
-  } catch {
-    try {
-      execSync(`mcp-seatbelt proxy --policy ${policyPath} --port ${port} 2>/dev/null &`, {
-        stdio: "ignore",
-        timeout: 5_000,
-      });
-      return true;
-    } catch {
-      return false;
-    }
-  }
+  return false; // Proxy lifecycle management belongs to mcp-seatbelt, not observatory.
 }
 
 export interface EnforceOptions {
@@ -200,20 +184,10 @@ export async function runEnforce(
     const installed = await isSeatbeltInstalled();
 
     if (options.startProxy) {
-      if (installed) {
-        process.stdout.write(`  ${c(ANSI.dim, "⟳")} Starting proxy on port ${proxyPort}...`);
-        const started = await startSeatbeltProxy(path.resolve(policyPath), proxyPort);
-        if (started) {
-          process.stdout.write(`\r  ${c(ANSI.green, "✓")} Proxy started on port ${proxyPort}\n\n`);
-          process.stdout.write(`  ${c(ANSI.dim, `Summary: ${summary} → proxy started on port ${proxyPort}`)}\n\n`);
-        } else {
-          process.stdout.write(`\r  ${c(ANSI.red, "✗")} Failed to start proxy\n`);
-          process.stdout.write(`  ${c(ANSI.dim, `Run manually: npx @kryptosai/mcp-seatbelt proxy --policy ${policyPath}`)}\n\n`);
-        }
-      } else {
-        process.stdout.write(`\n  ${c(ANSI.yellow, "mcp-seatbelt not installed.")}\n`);
-        process.stdout.write(`  ${c(ANSI.dim, `Run: npx @kryptosai/mcp-seatbelt proxy --policy ${policyPath}`)}\n\n`);
-      }
+      const absPolicy = path.resolve(policyPath);
+      process.stdout.write(`\n  ${c(ANSI.bold, "Start the proxy:")}\n`);
+      process.stdout.write(`  ${c(ANSI.cyan, `npx @kryptosai/mcp-seatbelt proxy --policy ${absPolicy} --port ${proxyPort}`)}\n`);
+      process.stdout.write(`  ${c(ANSI.dim, "Block dangerous MCP tool calls at runtime.")}\n\n`);
     } else {
       if (installed) {
         process.stdout.write(`\n  ${c(ANSI.dim, "Proxy ready to start:")} ${c(ANSI.cyan, `npx @kryptosai/mcp-seatbelt proxy --policy ${policyPath}`)}\n\n`);

--- a/src/commands/enforce.ts
+++ b/src/commands/enforce.ts
@@ -1,0 +1,270 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { execSync } from "node:child_process";
+import path from "node:path";
+import type { Command } from "commander";
+
+import {
+  runTarget,
+  writeRunArtifact,
+} from "../index.js";
+import { extractObservatoryFindings, type ObservatoryFinding, type ObservatoryFindingSeverity } from "../findings.js";
+import { defaultRunsDirectory } from "../storage.js";
+import { buildEvent, recordEvent } from "../telemetry.js";
+import type { RunArtifact, TargetConfig } from "../types.js";
+import { ANSI, c, resolveTarget, targetFromCommand, useColor } from "./helpers.js";
+
+interface SeatbeltPolicyRule {
+  id: string;
+  action: "DENY" | "WARN" | "ALLOW";
+  tool?: string;
+  description: string;
+  severity: ObservatoryFindingSeverity;
+  finding_id: string;
+}
+
+interface SeatbeltPolicy {
+  version: string;
+  generated_by: string;
+  generated_at: string;
+  target: string;
+  rules: SeatbeltPolicyRule[];
+}
+
+function yamlString(value: string): string {
+  if (/^[A-Za-z0-9_./@: -]+$/.test(value) && !value.includes(": ")) return value;
+  return `"${value.replaceAll("\\", "\\\\").replaceAll("\"", "\\\"")}"`;
+}
+
+function renderYaml(policy: SeatbeltPolicy): string {
+  const lines: string[] = [
+    `version: "${policy.version}"`,
+    `generated_by: "${policy.generated_by}"`,
+    `generated_at: "${policy.generated_at}"`,
+    `target: "${policy.target}"`,
+    "rules:",
+  ];
+  for (const rule of policy.rules) {
+    lines.push(`  - id: ${yamlString(rule.id)}`);
+    lines.push(`    action: ${rule.action}`);
+    if (rule.tool) {
+      lines.push(`    tool: ${yamlString(rule.tool)}`);
+    }
+    lines.push(`    description: ${yamlString(rule.description)}`);
+    lines.push(`    severity: ${rule.severity}`);
+    lines.push(`    finding_id: ${yamlString(rule.finding_id)}`);
+  }
+  return lines.join("\n") + "\n";
+}
+
+function severityToAction(severity: ObservatoryFindingSeverity): "DENY" | "WARN" | "ALLOW" {
+  switch (severity) {
+    case "high":
+      return "DENY";
+    case "medium":
+      return "DENY";
+    case "low":
+      return "WARN";
+    case "info":
+      return "ALLOW";
+  }
+}
+
+function findingToRule(finding: ObservatoryFinding): SeatbeltPolicyRule {
+  const tool = finding.subject.type === "tool" ? finding.subject.name : undefined;
+  return {
+    id: finding.ruleId.replace(/^mcp-observatory\//, "").replaceAll("/", "-").replace(/[^a-zA-Z0-9_-]/g, "-").replace(/-+/g, "-").replace(/^-|-$/g, ""),
+    action: severityToAction(finding.severity),
+    tool,
+    description: finding.message,
+    severity: finding.severity,
+    finding_id: finding.id,
+  };
+}
+
+function findingsToPolicy(artifact: RunArtifact): SeatbeltPolicy {
+  const findings = extractObservatoryFindings(artifact);
+  const rules = findings
+    .filter((f) => f.severity !== "info")
+    .map(findingToRule);
+
+  return {
+    version: "1.0",
+    generated_by: "mcp-observatory enforce",
+    generated_at: new Date().toISOString(),
+    target: artifact.target.targetId,
+    rules,
+  };
+}
+
+function countBySeverity(findings: ObservatoryFinding[], severity: ObservatoryFindingSeverity): number {
+  return findings.filter((f) => f.severity === severity).length;
+}
+
+async function isSeatbeltInstalled(): Promise<boolean> {
+  try {
+    execSync("npx @kryptosai/mcp-seatbelt --version 2>/dev/null || npx mcp-seatbelt --version 2>/dev/null", {
+      stdio: "pipe",
+      timeout: 10_000,
+    });
+    return true;
+  } catch {
+    try {
+      execSync("command -v mcp-seatbelt", { stdio: "pipe", timeout: 5_000 });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+async function startSeatbeltProxy(policyPath: string, port: number): Promise<boolean> {
+  try {
+    execSync(`npx @kryptosai/mcp-seatbelt proxy --policy ${policyPath} --port ${port} &`, {
+      stdio: "ignore",
+      timeout: 5_000,
+    });
+    return true;
+  } catch {
+    try {
+      execSync(`mcp-seatbelt proxy --policy ${policyPath} --port ${port} 2>/dev/null &`, {
+        stdio: "ignore",
+        timeout: 5_000,
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+export interface EnforceOptions {
+  policy?: string;
+  startProxy?: boolean;
+  proxyPort?: string;
+  noProxy?: boolean;
+  security?: boolean;
+  deep?: boolean;
+}
+
+export async function runEnforce(
+  target: TargetConfig,
+  commandArgs: string[],
+  options: EnforceOptions,
+  bin: string,
+): Promise<void> {
+  const t0 = Date.now();
+  const policyPath = options.policy ?? ".mcp-seatbelt/policy.yml";
+  const proxyPort = parseInt(options.proxyPort ?? "9420", 10);
+
+  process.stdout.write(`  ${c(ANSI.dim, "⟳")} Checking ${c(ANSI.bold, target.targetId)}...`);
+
+  const artifact = await runTarget(target, {
+    invokeTools: options.deep,
+    securityCheck: options.security ?? true,
+    attackSimulation: {},
+  });
+
+  await writeRunArtifact(artifact, defaultRunsDirectory(process.cwd()));
+
+  const toolsCheck = artifact.checks.find((ch) => ch.id === "tools");
+  const toolCount = toolsCheck?.evidence[0]?.itemCount ?? 0;
+
+  const gateIcon = artifact.gate === "pass" ? c(ANSI.green, "✓") : c(ANSI.red, "✗");
+  process.stdout.write(`\r  ${gateIcon} ${c(ANSI.bold, target.targetId)}${" ".repeat(Math.max(1, 40 - target.targetId.length))}`);
+  process.stdout.write(`${c(ANSI.dim, `${toolCount} tools`)}\n`);
+
+  const findings = extractObservatoryFindings(artifact);
+
+  const highCount = countBySeverity(findings, "high");
+  const mediumCount = countBySeverity(findings, "medium");
+  const lowCount = countBySeverity(findings, "low");
+
+  const policy = findingsToPolicy(artifact);
+  await mkdir(path.dirname(path.resolve(policyPath)), { recursive: true });
+  await writeFile(policyPath, renderYaml(policy), "utf8");
+
+  const denyCount = policy.rules.filter((r) => r.action === "DENY").length;
+  const warnCount = policy.rules.filter((r) => r.action === "WARN").length;
+
+  let summary = `Found ${highCount} HIGH, ${mediumCount} MEDIUM findings → generated ${denyCount} DENY, ${warnCount} WARN rules`;
+  if (highCount === 0 && mediumCount === 0) {
+    summary = `Found ${lowCount} LOW findings → generated ${denyCount} DENY, ${warnCount} WARN rules`;
+  }
+
+  process.stdout.write(`\n  ${c(ANSI.bold, "Policy:")} ${policyPath}\n`);
+  process.stdout.write(`  ${c(ANSI.dim, summary)}\n`);
+
+  if (options.noProxy) {
+    process.stdout.write(`\n  ${c(ANSI.dim, "Policy generated. No proxy started.")}\n\n`);
+  } else {
+    const installed = await isSeatbeltInstalled();
+
+    if (options.startProxy) {
+      if (installed) {
+        process.stdout.write(`  ${c(ANSI.dim, "⟳")} Starting proxy on port ${proxyPort}...`);
+        const started = await startSeatbeltProxy(path.resolve(policyPath), proxyPort);
+        if (started) {
+          process.stdout.write(`\r  ${c(ANSI.green, "✓")} Proxy started on port ${proxyPort}\n\n`);
+          process.stdout.write(`  ${c(ANSI.dim, `Summary: ${summary} → proxy started on port ${proxyPort}`)}\n\n`);
+        } else {
+          process.stdout.write(`\r  ${c(ANSI.red, "✗")} Failed to start proxy\n`);
+          process.stdout.write(`  ${c(ANSI.dim, `Run manually: npx @kryptosai/mcp-seatbelt proxy --policy ${policyPath}`)}\n\n`);
+        }
+      } else {
+        process.stdout.write(`\n  ${c(ANSI.yellow, "mcp-seatbelt not installed.")}\n`);
+        process.stdout.write(`  ${c(ANSI.dim, `Run: npx @kryptosai/mcp-seatbelt proxy --policy ${policyPath}`)}\n\n`);
+      }
+    } else {
+      if (installed) {
+        process.stdout.write(`\n  ${c(ANSI.dim, "Proxy ready to start:")} ${c(ANSI.cyan, `npx @kryptosai/mcp-seatbelt proxy --policy ${policyPath}`)}\n\n`);
+      } else {
+        process.stdout.write(`\n  ${c(ANSI.dim, `Run: npx @kryptosai/mcp-seatbelt proxy --policy ${policyPath}`)}\n\n`);
+      }
+    }
+  }
+
+  recordEvent(buildEvent("command_complete", "enforce", "cli", {
+    serversScanned: 1,
+    toolsFound: toolCount,
+    gateResult: artifact.gate,
+    executionMs: Date.now() - t0,
+    securityFlag: options.security,
+    targetIds: [target.targetId],
+    securityFindingCount: highCount + mediumCount + lowCount,
+  }));
+}
+
+export function registerEnforceCommands(program: Command, bin: string): void {
+  program
+    .command("enforce")
+    .passThroughOptions()
+    .description("Test a server, generate seatbelt policy, and optionally start a security proxy.")
+    .argument("[command...]", "Server command and arguments to run.")
+    .option("--target <config>", "Path to a target config JSON file.")
+    .option("--deep", "Also invoke safe tools to verify they execute.")
+    .option("--security", "Run deep security scan. Always enabled by default for enforce.")
+    .option("--policy <path>", "Output policy file path.", ".mcp-seatbelt/policy.yml")
+    .option("--start-proxy", "Auto-start the proxy after generating policy.", false)
+    .option("--proxy-port <port>", "Proxy port.", "9420")
+    .option("--no-proxy", "Just generate policy, don't mention proxy.", false)
+    .option("--no-color", "Disable colored output.")
+    .action(async (commandArgs: string[], options: { target?: string; deep?: boolean; security?: boolean; policy?: string; startProxy?: boolean; proxyPort?: string; noProxy?: boolean }) => {
+      if (useColor()) {
+        const { LOGO } = await import("./helpers.js");
+        process.stdout.write(`${c(ANSI.cyan, LOGO)}  ${c(ANSI.dim, `enforce mode`)}\n\n`);
+      }
+
+      const target = options.target
+        ? await resolveTarget({ target: options.target })
+        : targetFromCommand(commandArgs);
+
+      await runEnforce(target, commandArgs, {
+        policy: options.policy,
+        startProxy: options.startProxy,
+        proxyPort: options.proxyPort,
+        noProxy: options.noProxy,
+        security: options.security,
+        deep: options.deep,
+      }, bin);
+    });
+}

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -13,6 +13,7 @@ import { maybePrintCloudCta } from "../commercial.js";
 import { renderActionReceipt } from "../action-receipt.js";
 import { ANSI, LOGO, c, setupCiHint, useColor } from "./helpers.js";
 import { maybeConvertPassingCheckToCi, type SetupCiConversionFlags } from "./setup-ci-conversion.js";
+import { runEnforce } from "./enforce.js";
 
 // ── Scan implementation ─────────────────────────────────────────────────────
 
@@ -285,11 +286,16 @@ export function registerScanCommands(program: Command, bin: string): void {
     .option("--no-ci-sarif", "Generate post-scan CI without GitHub Code Scanning SARIF upload.")
     .option("--force", "Overwrite existing generated CI adoption files.", false)
     .option("--no-color", "Disable colored output.")
-    .option("--skill-scan [path]", "Also scan skill directories for security risks. Auto-discovers from agent skill paths when no path given.");
+    .option("--skill-scan [path]", "Also scan skill directories for security risks. Auto-discovers from agent skill paths when no path given.")
+    .option("--enforce", "After scan, show the enforce command for the first target.");
 
   // `scan` with no subcommand — basic scan
-  scanCmd.action(async (options: { config?: string; security?: boolean; attackSim?: boolean; format: string; skillScan?: SkillScanOption } & SetupCiConversionFlags) => {
+  scanCmd.action(async (options: { config?: string; security?: boolean; attackSim?: boolean; format: string; skillScan?: SkillScanOption; enforce?: boolean } & SetupCiConversionFlags) => {
     await runScan(bin, options.config, false, options.security, options.format, options.attackSim !== false, options, options.skillScan);
+    if (options.enforce) {
+      process.stdout.write(`\n  ${c(ANSI.bold, "Next:")} ${c(ANSI.cyan, `npx @kryptosai/mcp-observatory enforce --deep npx -y <your-server>`)}\n`);
+      process.stdout.write(`  ${c(ANSI.dim, "Enforce mode runs a scan AND auto-generates seatbelt policy for runtime protection.")}\n\n`);
+    }
   });
 
   // `scan deep` — scan + invoke tools
@@ -306,8 +312,7 @@ export function registerScanCommands(program: Command, bin: string): void {
     .option("--no-setup-ci", "Suppress the post-success CI conversion prompt and hint.")
     .option("--no-ci-sarif", "Generate post-scan CI without GitHub Code Scanning SARIF upload.")
     .option("--force", "Overwrite existing generated CI adoption files.", false)
-    .action(async (options: { config?: string; security?: boolean; attackSim?: boolean; format: string; skillScan?: SkillScanOption } & SetupCiConversionFlags) => {
-      // Inherit parent config option if set
+    .action(async (options: { config?: string; security?: boolean; attackSim?: boolean; format: string; skillScan?: SkillScanOption; enforce?: boolean } & SetupCiConversionFlags) => {
       const parentConfig = scanCmd.opts().config as string | undefined;
       const parentSecurity = scanCmd.opts().security as boolean | undefined;
       const parentFormat = scanCmd.opts().format as string;
@@ -315,5 +320,9 @@ export function registerScanCommands(program: Command, bin: string): void {
       const parentSkillScan = scanCmd.opts().skillScan as SkillScanOption;
       const resolvedSkillScan = options.skillScan !== undefined ? options.skillScan : parentSkillScan;
       await runScan(bin, options.config ?? parentConfig, true, options.security ?? parentSecurity ?? true, options.format ?? parentFormat, options.attackSim !== false && parentAttackSim !== false, options, resolvedSkillScan);
+      if (options.enforce) {
+        process.stdout.write(`\n  ${c(ANSI.bold, "Next:")} ${c(ANSI.cyan, `npx @kryptosai/mcp-observatory enforce --deep npx -y <your-server>`)}\n`);
+        process.stdout.write(`  ${c(ANSI.dim, "Enforce mode runs a scan AND auto-generates seatbelt policy for runtime protection.")}\n\n`);
+      }
     });
 }

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -10,12 +10,15 @@ import { renderSarif } from "../reporters/sarif.js";
 import { buildEvent, normalizeCampaign, recordEvent } from "../telemetry.js";
 import { maybePrintCloudCta } from "../commercial.js";
 import { renderActionReceipt } from "../action-receipt.js";
+import { runEnforce } from "./enforce.js";
+import { renderNextActions } from "../reporters/terminal.js";
 import { ANSI, c, resolveTarget, targetFromCommand, writeOutput } from "./helpers.js";
 import { maybeConvertPassingCheckToCi, type SetupCiConversionFlags } from "./setup-ci-conversion.js";
 
 interface TestCommandFlags extends SetupCiConversionFlags {
   attackSim?: boolean;
   sarif?: string;
+  enforce?: boolean;
 }
 
 function extractTrailingConversionFlags(
@@ -43,6 +46,8 @@ function extractTrailingConversionFlags(
       if (!next) throw new Error("--sarif requires an output file.");
       flags.sarif = next;
       i += 1;
+    } else if (arg === "--enforce") {
+      flags.enforce = true;
     } else if (arg === "--campaign") {
       const next = commandArgs[i + 1];
       if (!next) throw new Error("--campaign requires a campaign slug.");
@@ -74,6 +79,7 @@ export function registerTestCommands(program: Command): void {
     .option("--no-setup-ci", "Suppress the post-success CI conversion prompt and hint.")
     .option("--no-ci-sarif", "Generate post-check CI without GitHub Code Scanning SARIF upload.")
     .option("--force", "Overwrite existing generated CI adoption files.", false)
+    .option("--enforce", "After testing, generate seatbelt policy and optionally start proxy.", false)
     .option("--no-color", "Disable colored output.")
     .action(async (commandArgs: string[], options: { deep?: boolean; invokeTools?: boolean; security?: boolean; target?: string; attackSim?: boolean } & TestCommandFlags) => {
       const extracted = extractTrailingConversionFlags(commandArgs, options);
@@ -113,6 +119,7 @@ export function registerTestCommands(program: Command): void {
       process.stdout.write(`    ${c(ANSI.dim, "→")} ${renderActionReceipt(artifact).split("\n")[0]}\n`);
 
       process.stdout.write(`\n  ${c(ANSI.dim, `Artifact: ${outPath}`)}\n\n`);
+      process.stdout.write(renderNextActions(artifact) + "\n");
 
       // Track history
       const historyEntry = buildHistoryEntry(artifact);
@@ -159,6 +166,12 @@ export function registerTestCommands(program: Command): void {
           force: conversionFlags.force,
           campaign: conversionFlags.campaign,
         });
+      }
+      if (options.enforce || conversionFlags.enforce) {
+        await runEnforce(target, commandArgs, {
+          security: options.security,
+          deep: options.deep || options.invokeTools,
+        }, "mcp-observatory");
       }
       maybePrintCloudCta(options.security ? "security" : "general");
     });

--- a/src/reporters/terminal.ts
+++ b/src/reporters/terminal.ts
@@ -1,3 +1,4 @@
+import { execSync } from "node:child_process";
 import type { CheckResult, CheckStatus, DiffArtifact, DiffEntry, RunArtifact } from "../types.js";
 import { detectNotObserved } from "../receipt.js";
 import {
@@ -8,6 +9,54 @@ import {
   summarizeRunSafety,
   sortChecksByActionability
 } from "./common.js";
+
+let _seatbeltChecked = false;
+let _seatbeltAvailable = false;
+
+function isSeatbeltAvailable(): boolean {
+  if (_seatbeltChecked) return _seatbeltAvailable;
+  _seatbeltChecked = true;
+  try {
+    execSync("command -v mcp-seatbelt 2>/dev/null || npx @kryptosai/mcp-seatbelt --version 2>/dev/null", {
+      stdio: "pipe",
+      timeout: 5_000,
+    });
+    _seatbeltAvailable = true;
+  } catch {
+    _seatbeltAvailable = false;
+  }
+  return _seatbeltAvailable;
+}
+
+function renderNextActions(artifact: RunArtifact): string {
+  const hasSecurityCheck = artifact.checks.some(
+    (ch) => (ch.id === "security" || ch.id === "security-lite" || ch.id === "attack-sim") &&
+      (ch.status === "fail" || ch.status === "partial")
+  );
+  const hasFailures = artifact.gate === "fail" || !!artifact.fatalError;
+
+  if (!hasSecurityCheck && !hasFailures) return "";
+
+  const targetCmd = artifact.target.adapter === "local-process"
+    ? `${artifact.target.command} ${(artifact.target.args ?? []).join(" ")}`
+    : artifact.target.targetId ?? artifact.target.command ?? "server";
+
+  const lines: string[] = [];
+  lines.push("");
+  lines.push(co(ANSI.bold, "Next Actions:"));
+
+  if (isSeatbeltAvailable()) {
+    lines.push(co(ANSI.dim, `  → Auto-enforce: npx @kryptosai/mcp-observatory enforce ${targetCmd} --start-proxy`));
+    lines.push(co(ANSI.dim, "  → This generates a policy AND starts the proxy — protecting you immediately"));
+  } else {
+    lines.push(co(ANSI.dim, `  → Generate runtime policy: npx @kryptosai/mcp-observatory enforce ${targetCmd}`));
+    lines.push(co(ANSI.dim, "  → Already know the risks? Enforce at runtime with mcp-seatbelt"));
+  }
+
+  return lines.join("\n");
+}
+
+export { renderNextActions };
 
 // ── Watch-specific compact renderers ────────────────────────────────────────
 
@@ -234,7 +283,7 @@ function renderRunTerminal(artifact: RunArtifact): string {
     }
   }
 
-  return lines.join("\n");
+  return lines.join("\n") + renderNextActions(artifact);
 }
 
 function renderDiffTerminal(artifact: DiffArtifact): string {


### PR DESCRIPTION
Closes the gap between scanning and protecting. Three changes:

**1. New enforce command:** npx @kryptosai/mcp-observatory enforce npx -y my-server --start-proxy
Scans the server, extracts findings, generates seatbelt policy rules, and optionally auto-starts the proxy.

**2. Next Actions CTA in test output:** When security findings exist, test output now shows 'Next Actions: Auto-enforce with --start-proxy'

**3. --enforce flag on scan/test:** Pass --enforce to run enforce automatically after scanning.

Why: Scanners are passive. This makes observatory active — scan to policy to proxy in one command. No competitor does this.