### PR TITLE
fix: repair broken build on main (5 merge leftovers)

### DIFF
--- a/src/checks/runtime-profile.ts
+++ b/src/checks/runtime-profile.ts
@@ -116,7 +116,7 @@ export function analyzeRuntimeProfile(tools: Tool[]): RuntimeProfile {
         mutations.push({
           resource: inferMutationResource(paramName),
           operation: inferMutationOperation(tool.name, paramName),
-          scope: inferMutationScope(normalized.properties, paramName),
+          scope: inferMutationScope(normalized.properties, paramName, tool.name),
           source: "tool_schema",
         });
       }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -252,7 +252,6 @@ async function main(): Promise<void> {
     .addHelpText("before", useColor() ? c(ANSI.cyan, LOGO) + `  ${c(ANSI.dim, `v${TOOL_VERSION}`)}\n` : LOGO + `  v${TOOL_VERSION}\n`)
     .option("--quiet", "Suppress logo and informational output.", false)
     .addHelpText("after", (() => {
-    .option("--quiet", "Suppress logo and informational output.", false)
       const lines = [
         "",
         `  ${c(ANSI.bold, "Quick Start")}`,

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -1,6 +1,6 @@
 import { detectPermissionDeltas } from "./permission-delta.js";
 import { diffSchemas } from "./schema-diff.js";
-import type { CheckResult, DiffArtifact, DiffEntry, ResponseChangeEntry, RunArtifact, SchemaDriftEntry, SchemaDriftSeverity } from "./types.js";
+import type { CheckResult, DiffArtifact, DiffEntry, PermissionDeltaEntry, ResponseChangeEntry, RunArtifact, SchemaDriftEntry, SchemaDriftSeverity } from "./types.js";
 import { SCHEMA_VERSION, STATUS_RANK } from "./types.js";
 
 export interface DiffOptions {

--- a/src/risk-taxonomy.ts
+++ b/src/risk-taxonomy.ts
@@ -10,7 +10,7 @@ interface TaxonomySource {
   category?: string;
 }
 
-const RULE_TAXONOMY: Record<string, RiskTaxonomy> = {
+export const RULE_TAXONOMY: Record<string, RiskTaxonomy> = {
   "mcp-observatory/security/shell-injection": {
     cwe: ["CWE-78"],
     owasp: ["OWASP Top 10 2021 A03: Injection"],
@@ -70,7 +70,7 @@ const RULE_TAXONOMY: Record<string, RiskTaxonomy> = {
   },
 };
 
-const CATEGORY_TAXONOMY: Record<string, RiskTaxonomy> = {
+export const CATEGORY_TAXONOMY: Record<string, RiskTaxonomy> = {
   "schema-quality": {
     cwe: ["CWE-20"],
     owasp: ["OWASP API Security Top 10 2023 API8: Security Misconfiguration"],

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -75,6 +75,15 @@ function optionalSchemaDriftSeverityCounts(value: unknown): Record<SchemaDriftSe
   };
 }
 
+function optionalPermissionDeltaRiskCounts(value: unknown): Record<PermissionDeltaRisk, number> | undefined {
+  if (!isObject(value)) return undefined;
+  return {
+    neutral: typeof value["neutral"] === "number" ? value["neutral"] : 0,
+    review: typeof value["review"] === "number" ? value["review"] : 0,
+    widening: typeof value["widening"] === "number" ? value["widening"] : 0,
+  };
+}
+
 function requireGate(value: unknown, label: string): Gate {
   if (value !== "pass" && value !== "fail") {
     throw new Error(`${label} has invalid gate '${String(value)}'.`);


### PR DESCRIPTION
## Summary

`npx tsc --noEmit -p tsconfig.json` fails on current `main` with a syntax error plus three type errors, and two taxonomy tests fail on import — all five look like merge leftovers. This PR repairs them with the minimal change in each spot:

1. **`src/cli.ts`** — a stray duplicated `.option("--quiet", …)` line landed *inside* the `addHelpText("after", (() => {…}` callback body: `error TS1128`. The CLI cannot start at all (`tsx src/cli.ts` throws). Removed the stray line; the flag stays registered once, right above.
2. **`src/diff.ts`** — `PermissionDeltaEntry` used but missing from the `import type` list.
3. **`src/validate.ts`** — `optionalPermissionDeltaRiskCounts` referenced but never defined. Added it, modeled 1:1 on the neighbouring `optionalSchemaDriftSeverityCounts` (defaults `neutral`/`review`/`widening` to 0).
4. **`src/checks/runtime-profile.ts`** — the `inferMutationScope(…)` call site dropped its third argument; passes `tool.name` to match the signature.
5. **`src/risk-taxonomy.ts`** — `RULE_TAXONOMY` / `CATEGORY_TAXONOMY` lost their `export` keywords, which `tests/risk-taxonomy.test.ts` imports directly.

User-visible effect: the package builds and the CLI starts again; no behavior change beyond restoring what the surrounding code already intended.

## Code of Conduct

By submitting this pull request, you agree to follow the project's [Contributor Covenant Code of Conduct](./CODE_OF_CONDUCT.md).

## Validation

- [x] `npm run lint` — clean on the five touched files
- [x] `npm run typecheck` — `tsc --noEmit` clean (was failing before this PR)
- [x] `npm test` — risk-taxonomy, diff, validate, reporters suites green; remaining local failures are Windows-environment artifacts (`node_modules/.bin/tsx` shim, `spawn npm` ENOENT, `\` path separators), present independently of this change
- [x] `npm run smoke` — `tsx src/cli.ts --version` → `1.31.0`; `--quiet` parses

## Artifact Impact

- No artifact schema changes. `optionalPermissionDeltaRiskCounts` only restores parsing for the already-documented `permissionDeltaRiskCounts` summary field.
- Markdown report unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)