### PR TITLE
feat(score): trust tier calculation (Platinum 90+ / Gold 80+ / Silver 65+ / Bronze 50+)

### DIFF
--- a/src/score.ts
+++ b/src/score.ts
@@ -1,7 +1,7 @@
 // IMPORTANT: Scoring logic is duplicated in api/src/worker.ts for the Cloudflare Worker
 // deployment (which can't import from src/). Keep both files in sync when making changes.
 
-import type { CheckResult, HealthGrade, HealthScore, PerformanceMetrics, ScoreDimension } from "./types.js";
+import type { CheckResult, HealthGrade, HealthScore, PerformanceMetrics, ScoreDimension, TrustTier } from "./types.js";
 
 export interface ScoreWeights {
   protocolCompliance: number;
@@ -38,6 +38,15 @@ export function gradeFromScore(score: number): HealthGrade {
   if (score >= 70) return "C";
   if (score >= 60) return "D";
   return "F";
+}
+
+/** Bucket a Safety Index score into a trust tier for at-a-glance display (badges, CLI output). Pure. */
+export function getTrustTier(score: number): TrustTier {
+  if (score >= 90) return "platinum";
+  if (score >= 80) return "gold";
+  if (score >= 65) return "silver";
+  if (score >= 50) return "bronze";
+  return "unrated";
 }
 
 function scoreDimension(

--- a/src/types.ts
+++ b/src/types.ts
@@ -119,6 +119,9 @@ export interface RunArtifact {
 
 export type HealthGrade = "A" | "B" | "C" | "D" | "F";
 
+/** Safety Index score bucketed for at-a-glance communication (badges, CLI display). */
+export type TrustTier = "platinum" | "gold" | "silver" | "bronze" | "unrated";
+
 export interface ScoreDimension {
   name: string;
   weight: number;

--- a/tests/score.test.ts
+++ b/tests/score.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { computeHealthScore, gradeFromScore } from "../src/score.js";
+import { computeHealthScore, getTrustTier, gradeFromScore } from "../src/score.js";
 import type { CheckResult, PerformanceMetrics } from "../src/types.js";
 
 function makeCheck(id: string, status: string): CheckResult {
@@ -24,6 +24,26 @@ describe("gradeFromScore", () => {
     expect(gradeFromScore(65)).toBe("D");
     expect(gradeFromScore(55)).toBe("F");
     expect(gradeFromScore(0)).toBe("F");
+  });
+});
+
+describe("getTrustTier", () => {
+  it("buckets scores into tiers at the documented thresholds", () => {
+    expect(getTrustTier(100)).toBe("platinum");
+    expect(getTrustTier(92)).toBe("platinum");
+    expect(getTrustTier(90)).toBe("platinum"); // boundary
+    expect(getTrustTier(89)).toBe("gold");
+    expect(getTrustTier(81)).toBe("gold");
+    expect(getTrustTier(80)).toBe("gold"); // boundary
+    expect(getTrustTier(79)).toBe("silver");
+    expect(getTrustTier(67)).toBe("silver");
+    expect(getTrustTier(65)).toBe("silver"); // boundary
+    expect(getTrustTier(64)).toBe("bronze");
+    expect(getTrustTier(52)).toBe("bronze");
+    expect(getTrustTier(50)).toBe("bronze"); // boundary
+    expect(getTrustTier(49)).toBe("unrated");
+    expect(getTrustTier(30)).toBe("unrated");
+    expect(getTrustTier(0)).toBe("unrated");
   });
 });
 


### PR DESCRIPTION
Closes #234 (part of the #174 roadmap)

- `TrustTier` string union in `src/types.ts` (next to `HealthGrade`): `"platinum" | "gold" | "silver" | "bronze" | "unrated"`
- Pure exported `getTrustTier(score: number): TrustTier` in `src/score.ts`, placed beside `gradeFromScore` and following its shape — no side effects, no I/O — ready for `badge.ts` (#235) and the CLI display (#236) to import.
- Boundary-complete unit test in `tests/score.test.ts` (90/80/65/50 inclusive edges plus the issue's example values).

Verification: `vitest run tests/score.test.ts` — 11 passed (10 existing + 1 new). `tsc --noEmit` reports only the 3 pre-existing errors already on `main` (`runtime-profile.ts`, `diff.ts`, `validate.ts`) — this change adds none. ESLint clean on the touched files.

Note: I did NOT mirror this into `api/src/worker.ts` (the file-header sync warning) since no worker code consumes tiers yet — happy to add it there too if you'd like it in this PR.