### PR TITLE
fix(history): apply --target filter to --json output

### DIFF
--- a/src/commands/history.ts
+++ b/src/commands/history.ts
@@ -1,5 +1,5 @@
 import type { Command } from "commander";
-import { readHistory, getTrend, renderTrendLabel } from "../history.js";
+import { readHistory, filterHistory, getTrend, renderTrendLabel } from "../history.js";
 import { buildEvent, recordEvent } from "../telemetry.js";
 import { ANSI, c } from "./helpers.js";
 
@@ -14,7 +14,8 @@ export function registerHistoryCommands(program: Command): void {
       const history = await readHistory();
 
       if (options.json) {
-        process.stdout.write(JSON.stringify(history, null, 2) + "\n");
+        // --target applies to JSON output too (it used to be silently ignored here).
+        process.stdout.write(JSON.stringify(filterHistory(history, options.target), null, 2) + "\n");
         return;
       }
 

--- a/src/history.ts
+++ b/src/history.ts
@@ -81,6 +81,13 @@ export function buildHistoryEntry(artifact: RunArtifact): HistoryEntry {
   };
 }
 
+/** The history restricted to one target (same shape, so JSON output stays parseable
+ *  the same way whether or not a filter was applied). No target = the input unchanged. */
+export function filterHistory(history: HistoryFile, targetId?: string): HistoryFile {
+  if (!targetId) return history;
+  return { ...history, entries: history.entries.filter((e) => e.targetId === targetId) };
+}
+
 // ── Trend computation ────────────────────────────────────────────────────────
 
 export function getTrend(

--- a/tests/history.test.ts
+++ b/tests/history.test.ts
@@ -7,6 +7,7 @@ import {
   readHistory,
   appendHistory,
   buildHistoryEntry,
+  filterHistory,
   getTrend,
   renderTrendLabel,
   type HistoryEntry,
@@ -124,6 +125,37 @@ describe("buildHistoryEntry", () => {
     expect(entry.promptCount).toBe(3);
     expect(entry.resourceCount).toBe(5);
     expect(entry.gate).toBe("pass");
+  });
+});
+
+describe("filterHistory", () => {
+  const history: HistoryFile = {
+    version: 1,
+    entries: [
+      makeEntry({ targetId: "a", healthScore: 90 }),
+      makeEntry({ targetId: "b", healthScore: 70 }),
+      makeEntry({ targetId: "a", healthScore: 95 }),
+    ],
+  };
+
+  it("keeps only the requested target, preserving order and shape", () => {
+    const filtered = filterHistory(history, "a");
+    expect(filtered.version).toBe(1);
+    expect(filtered.entries.map((e) => e.healthScore)).toEqual([90, 95]);
+    expect(filtered.entries.every((e) => e.targetId === "a")).toBe(true);
+  });
+
+  it("returns the input unchanged when no target is given", () => {
+    expect(filterHistory(history)).toBe(history);
+  });
+
+  it("yields an empty entries list for an unknown target", () => {
+    expect(filterHistory(history, "nope").entries).toEqual([]);
+  });
+
+  it("does not mutate the original history", () => {
+    filterHistory(history, "a");
+    expect(history.entries).toHaveLength(3);
   });
 });
 


### PR DESCRIPTION
Addresses #240.

## Heads-up: the issue's premise is partly stale

`history --json` already exists — it landed in #182 (July 7, before the issue was filed) and prints the full `{version, entries[]}` document to stdout with all table fields included. So most of #240 is already done on `main`.

What was genuinely missing: **`--target` was silently ignored in the JSON path** — the `options.json` branch returned before the target filtering, so `history --target X --json` dumped every target's history.

## Change

- `src/history.ts`: pure `filterHistory(history, targetId?)` — same `HistoryFile` shape in and out (so `jq` consumers parse identically with or without a filter), input returned unchanged when no target, no mutation.
- `src/commands/history.ts`: the JSON branch now writes `filterHistory(history, options.target)`.
- `tests/history.test.ts`: 4 new unit tests (filtering + order, no-filter passthrough, unknown target → empty entries, no mutation).

I kept the existing `{version, entries}` output shape rather than switching to the issue's bare-array example — it's been the published `--json` shape since #182 and changing it would break existing consumers.

## Verification

- `vitest run tests/history.test.ts` — 17 passed (13 existing + 4 new); eslint clean on touched files.
- End-to-end: with a two-target history file, `history --json --target a` now emits only target `a`'s entries (previously both), and plain `history --json` is unchanged.

If you'd rather close #240 as already-shipped and take this as its own issue, happy to retitle.