### PR TITLE
Add scan result summary line (closes #256)

### DIFF
--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -14,6 +14,8 @@ import { renderActionReceipt } from "../action-receipt.js";
 import { ANSI, LOGO, c, setupCiHint, useColor } from "./helpers.js";
 import { maybeConvertPassingCheckToCi, type SetupCiConversionFlags } from "./setup-ci-conversion.js";
 import { runEnforce } from "./enforce.js";
+import { renderScanSummaryTerminal } from "../reporters/terminal.js";
+
 
 // ── Scan implementation ─────────────────────────────────────────────────────
 
@@ -152,6 +154,10 @@ async function runScan(
       results.push({ targetId: t.config.targetId, gate: "fail", toolCount: 0, promptCount: 0, resourceCount: 0, error: friendlyMsg, diagnostics: [] });
       failCount++;
     }
+  }
+
+  if (format === "terminal" && artifacts.length > 0) {
+    process.stdout.write("\n" + renderScanSummaryTerminal(artifacts) + "\n");
   }
 
   // ── Summary ──────────────────────────────────────────────────────────

--- a/src/reporters/terminal.ts
+++ b/src/reporters/terminal.ts
@@ -332,6 +332,51 @@ function renderDiffTerminal(artifact: DiffArtifact): string {
   return lines.join("\n");
 }
 
+// ── Scan summary ─────────────────────────────────────────────────────
+
+type ScanOverallStatus = "passed" | "failed" | "warnings";
+
+// Classify a server by
+function classifyServerStatus(artifact: RunArtifact): ScanOverallStatus {
+  if (artifact.fatalError !== undefined || artifact.gate === "fail") return "failed";
+  const hasWarn = artifact.checks.some(c => c.status === "partial" || c.status === "flaky");
+  if (hasWarn) return "warnings";
+  return "passed";
+}
+
+export interface ScanSummaryCounts {
+  total: number;
+  passed: number;
+  failed: number;
+  warnings: number;
+}
+
+export function computeScanSummary(artifacts: RunArtifact[]): ScanSummaryCounts {
+  const counts: ScanSummaryCounts = { total: artifacts.length, passed: 0, failed: 0, warnings: 0 };
+  for (const artifact of artifacts) {
+    const status = classifyServerStatus(artifact);
+    if (status === "passed") counts.passed++;
+    else if (status === "failed") counts.failed++;
+    else counts.warnings++;
+  }
+  return counts;
+}
+
+export function renderScanSummaryTerminal(artifacts: RunArtifact[]): string {
+  const DIVIDER_WIDTH = 29;
+  const { total, passed, failed, warnings } = computeScanSummary(artifacts);
+  const divider = co(ANSI.dim, "─".repeat(DIVIDER_WIDTH));
+  const line = [
+    `${total} servers scanned: `,
+    co(ANSI.green, `${passed} passed`),
+    ", ",
+    co(ANSI.red, `${failed} failed`),
+    ", ",
+    co(ANSI.yellow, `${warnings} warnings`)
+  ].join("");
+  return `${divider}\n${line}`;
+}
+
 export function renderTerminal(artifact: RunArtifact | DiffArtifact): string {
   return artifact.artifactType === "run"
     ? renderRunTerminal(artifact)


### PR DESCRIPTION
## Summary

Adds a one-line summary at the end of `scan` output showing how many servers passed, failed, or had warnings. Each server gets classified by its worst check result — any fail (or fatal error) = "failed", no fails but a partial/flaky check = "warnings", otherwise "passed". Prints after a divider, with the counts color-coded.

Example:

\`\`\`
─────────────────────────────
2 servers scanned: 0 passed, 0 failed, 2 warnings
\`\`\`

## Code of Conduct

By submitting this pull request, you agree to follow the project's [Contributor Covenant Code of Conduct](./CODE_OF_CONDUCT.md).

## Validation

- [x] `npm run lint` — clean except pre-existing errors in files I didn't touch (`enforce.ts`, `test.ts`, `validate.ts`)
- [x] `npm run typecheck` — same, pre-existing errors in `runtime-profile.ts`, `diff.ts`, `validate.ts`
- [x] `npm test` — all 576 passing
- [x] `npm run smoke` — ran fine, fixture server scored 92/100

Tested it manually too with a local `.mcp.json` (two fake servers) to make sure the summary line actually shows up and looks right — screenshot in the issue thread if useful.

## Artifact Impact

No schema changes. Just two new functions in `src/reporters/terminal.ts` (`computeScanSummary`, `renderScanSummaryTerminal`) called from `src/commands/scan.ts` after the per-server loop. Doesn't touch `pr-comment-matrix` format or the Markdown report.

One note: issue #256 mentioned putting the counts in a `--json` payload, but this CLI doesn't have a `--json` format right now (just `terminal` and `pr-comment-matrix`), so that part didn't apply.