### PR TITLE
v1.32.1 — Deterministic CI fingerprints + deprecation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kryptosai/mcp-observatory",
-  "version": "1.32.0",
+  "version": "1.32.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kryptosai/mcp-observatory",
-      "version": "1.32.0",
+      "version": "1.32.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kryptosai/mcp-observatory",
-  "version": "1.32.0",
+  "version": "1.32.1",
   "description": "GitHub-native CI, SARIF, Code Scanning, and security gates for MCP servers before agents depend on them.",
   "mcpName": "io.github.KryptosAI/mcp-observatory",
   "license": "MIT",

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -196,7 +196,8 @@ export function _resetConfigCache(): void {
 }
 
 export function computeFingerprint(): string {
-  const input = `${process.platform}-${process.arch}-${process.version}-${os.homedir()}`;
+  const repo = process.env["GITHUB_REPOSITORY"] || "";
+  const input = `${process.platform}-${process.arch}-${process.version}-${os.homedir()}-${repo}`;
   return createHash("sha256").update(input).digest("hex").slice(0, 16);
 }
 


### PR DESCRIPTION
## What's Changed

- **computeFingerprint includes GITHUB_REPOSITORY** — CI fingerprints survive Docker restarts. Same repo = same identity across runs.
- **Deprecated 57 versions <1.32.1** — pushes users to @latest via npm deprecation warnings on every install.
- Everything else already uses `@latest` — no template or doc changes needed.