### PR TITLE
feat(scan): add passed/failed/warnings summary line

### DIFF
--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -17,6 +17,29 @@ import { maybeConvertPassingCheckToCi, type SetupCiConversionFlags } from "./set
 
 type SkillScanOption = string | boolean | undefined;
 
+export type ScanServerCategory = "passed" | "failed" | "warning";
+
+/**
+ * Categorizes a single server's scan result by its worst outcome:
+ * any failing check → "failed"; no failures but a partial/flaky check →
+ * "warning"; everything passed → "passed".
+ */
+export function categorizeServerResult(artifact: RunArtifact): ScanServerCategory {
+  if (artifact.gate === "fail") return "failed";
+  if (artifact.summary.partial > 0 || artifact.summary.flaky > 0) return "warning";
+  return "passed";
+}
+
+/** "3 servers scanned: 1 passed, 1 failed, 1 warnings" */
+export function formatScanSummaryLine(counts: {
+  passed: number;
+  failed: number;
+  warning: number;
+}): string {
+  const total = counts.passed + counts.failed + counts.warning;
+  return `${total} server${total === 1 ? "" : "s"} scanned: ${counts.passed} passed, ${counts.failed} failed, ${counts.warning} warnings`;
+}
+
 async function runScan(
   bin: string,
   configPath: string | undefined,
@@ -75,6 +98,7 @@ async function runScan(
   let totalTools = 0;
   let totalPrompts = 0;
   let totalResources = 0;
+  const categoryCounts: Record<ScanServerCategory, number> = { passed: 0, failed: 0, warning: 0 };
 
   for (const t of targets) {
     process.stdout.write(`  ${c(ANSI.dim, "⟳")} Checking ${c(ANSI.bold, t.config.targetId)}...`);
@@ -126,6 +150,7 @@ async function runScan(
 
       results.push({ targetId: t.config.targetId, gate: artifact.gate, toolCount, promptCount, resourceCount, diagnostics });
       if (artifact.gate === "pass") passCount++; else failCount++;
+      categoryCounts[categorizeServerResult(artifact)]++;
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
       let friendlyMsg = msg;
@@ -149,6 +174,7 @@ async function runScan(
 
       results.push({ targetId: t.config.targetId, gate: "fail", toolCount: 0, promptCount: 0, resourceCount: 0, error: friendlyMsg, diagnostics: [] });
       failCount++;
+      categoryCounts.failed++;
     }
   }
 
@@ -166,6 +192,15 @@ async function runScan(
       process.stdout.write("\n");
     }
   }
+
+  const scanTotal = categoryCounts.passed + categoryCounts.failed + categoryCounts.warning;
+  process.stdout.write(c(ANSI.dim, "  ─────────────────────────────\n"));
+  process.stdout.write(
+    `  ${scanTotal} server${scanTotal === 1 ? "" : "s"} scanned: ` +
+      `${c(ANSI.green, `${categoryCounts.passed} passed`)}, ` +
+      `${c(ANSI.red, `${categoryCounts.failed} failed`)}, ` +
+      `${c(ANSI.yellow, `${categoryCounts.warning} warnings`)}\n`,
+  );
 
   // Show diagnostics for failures or notable partials
   const issues = results.filter((r) => r.diagnostics.length > 0 && !r.error);

--- a/tests/scan-summary.test.ts
+++ b/tests/scan-summary.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { categorizeServerResult, formatScanSummaryLine } from "../src/commands/scan.js";
+import { makeArtifact } from "./fixtures/test-helpers.js";
+
+describe("categorizeServerResult", () => {
+  it("categorizes a fully passing server as passed", () => {
+    const artifact = { ...makeArtifact([]), gate: "pass" as const };
+    expect(categorizeServerResult(artifact)).toBe("passed");
+  });
+
+  it("categorizes a server with a failing gate as failed, even with partial checks", () => {
+    const artifact = {
+      ...makeArtifact([]),
+      gate: "fail" as const,
+      summary: { ...makeArtifact([]).summary, partial: 1 },
+    };
+    expect(categorizeServerResult(artifact)).toBe("failed");
+  });
+
+  it("categorizes a passing gate with a partial check as warning", () => {
+    const artifact = {
+      ...makeArtifact([]),
+      gate: "pass" as const,
+      summary: { ...makeArtifact([]).summary, partial: 1 },
+    };
+    expect(categorizeServerResult(artifact)).toBe("warning");
+  });
+
+  it("categorizes a passing gate with a flaky check as warning", () => {
+    const artifact = {
+      ...makeArtifact([]),
+      gate: "pass" as const,
+      summary: { ...makeArtifact([]).summary, flaky: 1 },
+    };
+    expect(categorizeServerResult(artifact)).toBe("warning");
+  });
+});
+
+describe("formatScanSummaryLine", () => {
+  it("matches the exact format from the issue", () => {
+    expect(formatScanSummaryLine({ passed: 1, failed: 1, warning: 1 })).toBe(
+      "3 servers scanned: 1 passed, 1 failed, 1 warnings",
+    );
+  });
+
+  it("uses singular 'server' for a single-server scan", () => {
+    expect(formatScanSummaryLine({ passed: 1, failed: 0, warning: 0 })).toBe(
+      "1 server scanned: 1 passed, 0 failed, 0 warnings",
+    );
+  });
+
+  it("handles zero servers", () => {
+    expect(formatScanSummaryLine({ passed: 0, failed: 0, warning: 0 })).toBe(
+      "0 servers scanned: 0 passed, 0 failed, 0 warnings",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #256.

The existing `scan` summary is binary — "✓ All N servers healthy" or "✗ N of M servers failing" — derived purely from each server's `gate` (pass/fail). That collapses a real distinction the rest of the codebase already tracks: a server can have `gate=pass` while still carrying `partial`/`flaky` check results (security findings, schema quality issues, etc.) that are worth surfacing separately from a clean pass.

## What changed

Added `categorizeServerResult()` (exported from `src/commands/scan.ts`), which classifies each server's *worst* outcome:
- `gate === "fail"` → **failed**
- `gate === "pass"` but `summary.partial > 0` or `summary.flaky > 0` → **warning**
- otherwise → **passed**

After the existing summary block, a new line prints:
```
  ─────────────────────────────
  3 servers scanned: 1 passed, 1 failed, 1 warnings
```
with color-coded counts (green/red/yellow), matching the format and coloring requested in the issue.

## Verified live

Ran an actual scan against `@modelcontextprotocol/server-filesystem` — it has medium-severity `security-lite`/`schema-quality` findings but `gate=pass`, so the *existing* summary line says "✓ All 1 server healthy", while the *new* line correctly shows `1 server scanned: 0 passed, 0 failed, 1 warnings`. That's the exact gap this issue was pointing at — the old summary genuinely can't distinguish this case.

## Scope note

Point 5 of the issue ("if `--json` output is active, include the counts in the JSON payload instead") doesn't map onto this command as it currently exists — `scan --format` only accepts `terminal` or `pr-comment-matrix` (a Markdown PR-comment format), there's no literal JSON output mode to add counts to. Left this out rather than force-fitting it; happy to add if a JSON format gets added later or if there's a payload I'm missing.

## Testing

- New tests in `tests/scan-summary.test.ts` covering `categorizeServerResult` (all three categories, including "pass gate + partial check → warning") and `formatScanSummaryLine` (exact format match, singular/plural, zero-server case)
- `npx tsc --noEmit`: clean
- `npx eslint src/commands/scan.ts tests/scan-summary.test.ts`: clean
- Full test suite: pre-existing failures in `cli-entrypoint`/`cli-mcp-parity`/`environment`/`postinstall`/`public-docs-privacy`/`schema` are environment-specific (`spawn npm ENOENT` on this Windows box) — confirmed identical with this change stashed out, unrelated to this PR