### PR TITLE
fix(cli): wire up --quiet to actually suppress logo and CTAs

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,7 +4,7 @@ import { readFile, writeFile } from "node:fs/promises";
 import { Command } from "commander";
 
 import { isCI } from "./ci.js";
-import { ANSI, LOGO, c, getBinName, setNoColor, useColor } from "./commands/helpers.js";
+import { ANSI, LOGO, c, getBinName, setNoColor, setQuiet, useColor } from "./commands/helpers.js";
 import { registerDiffCommands } from "./commands/diff.js";
 import { registerLegacyCommands } from "./commands/legacy.js";
 import { registerRecordReplayCommands } from "./commands/record-replay.js";
@@ -218,6 +218,12 @@ async function main(): Promise<void> {
   // Capture --no-color before Commander strips it from process.argv
   if (process.argv.includes("--no-color")) {
     setNoColor(true);
+  }
+  // Capture --quiet the same way -- subcommands print their own logo/CTAs
+  // before their own local options are parsed, so this needs to be read
+  // from argv up front, same as --no-color above.
+  if (process.argv.includes("--quiet")) {
+    setQuiet(true);
   }
 
   const bin = getBinName();

--- a/src/commands/enforce.ts
+++ b/src/commands/enforce.ts
@@ -11,7 +11,7 @@ import { extractObservatoryFindings, type ObservatoryFinding, type ObservatoryFi
 import { defaultRunsDirectory } from "../storage.js";
 import { buildEvent, recordEvent } from "../telemetry.js";
 import type { RunArtifact, TargetConfig } from "../types.js";
-import { ANSI, c, resolveTarget, targetFromCommand, useColor } from "./helpers.js";
+import { ANSI, c, isQuiet, resolveTarget, targetFromCommand, useColor } from "./helpers.js";
 
 interface SeatbeltPolicyRule {
   id: string;
@@ -218,7 +218,7 @@ export function registerEnforceCommands(program: Command): void {
     .option("--no-proxy", "Just generate policy, don't mention proxy.", false)
     .option("--no-color", "Disable colored output.")
     .action(async (commandArgs: string[], options: { target?: string; deep?: boolean; security?: boolean; policy?: string; startProxy?: boolean; proxyPort?: string; noProxy?: boolean }) => {
-      if (useColor()) {
+      if (!isQuiet() && useColor()) {
         const { LOGO } = await import("./helpers.js");
         process.stdout.write(`${c(ANSI.cyan, LOGO)}  ${c(ANSI.dim, `enforce mode`)}\n\n`);
       }

--- a/src/commands/helpers.ts
+++ b/src/commands/helpers.ts
@@ -49,6 +49,16 @@ export function useColor(): boolean {
   return !process.env["NO_COLOR"] && !_noColor;
 }
 
+let _quiet = false;
+
+export function setQuiet(value: boolean): void {
+  _quiet = value;
+}
+
+export function isQuiet(): boolean {
+  return _quiet;
+}
+
 export function c(code: string, text: string): string {
   return useColor() ? `${code}${text}${ANSI.reset}` : text;
 }
@@ -192,7 +202,7 @@ export function printCiConversionCta(options: {
   target?: TargetConfig;
   targetPath?: string;
 }): void {
-  if (!shouldPrintConversionCta()) return;
+  if (isQuiet() || !shouldPrintConversionCta()) return;
   const bin = options.bin ?? "npx @kryptosai/mcp-observatory";
   process.stdout.write(`  ${c(ANSI.bold, "Next:")} ${options.context ?? "keep this passing in CI"}\n`);
   process.stdout.write(`  ${c(ANSI.dim, "$")} ${c(ANSI.cyan, setupCiHint(options.target, options.targetPath, bin))}\n`);

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -11,7 +11,7 @@ import type { RunArtifact } from "../types.js";
 import { TOOL_VERSION } from "../version.js";
 import { maybePrintCloudCta } from "../commercial.js";
 import { renderActionReceipt } from "../action-receipt.js";
-import { ANSI, LOGO, c, setupCiHint, useColor } from "./helpers.js";
+import { ANSI, LOGO, c, isQuiet, setupCiHint, useColor } from "./helpers.js";
 import { maybeConvertPassingCheckToCi, type SetupCiConversionFlags } from "./setup-ci-conversion.js";
 // ── Scan implementation ─────────────────────────────────────────────────────
 
@@ -29,7 +29,9 @@ async function runScan(
 ): Promise<void> {
   if (conversionFlags.campaign) conversionFlags.campaign = normalizeCampaign(conversionFlags.campaign);
   const t0 = Date.now();
-  process.stdout.write(useColor() ? c(ANSI.cyan, LOGO) + `  ${c(ANSI.dim, `v${TOOL_VERSION}`)}\n\n` : LOGO + `  v${TOOL_VERSION}\n\n`);
+  if (!isQuiet()) {
+    process.stdout.write(useColor() ? c(ANSI.cyan, LOGO) + `  ${c(ANSI.dim, `v${TOOL_VERSION}`)}\n\n` : LOGO + `  v${TOOL_VERSION}\n\n`);
+  }
 
   if (configPath) {
     try {
@@ -293,6 +295,7 @@ export function registerScanCommands(program: Command, bin: string): void {
     .option("--no-ci-sarif", "Generate post-scan CI without GitHub Code Scanning SARIF upload.")
     .option("--force", "Overwrite existing generated CI adoption files.", false)
     .option("--no-color", "Disable colored output.")
+    .option("--quiet", "Suppress logo and informational output.", false)
     .option("--skill-scan [path]", "Also scan skill directories for security risks. Auto-discovers from agent skill paths when no path given.")
     .option("--enforce", "After scan, show the enforce command for the first target.");
 
@@ -319,6 +322,7 @@ export function registerScanCommands(program: Command, bin: string): void {
     .option("--no-setup-ci", "Suppress the post-success CI conversion prompt and hint.")
     .option("--no-ci-sarif", "Generate post-scan CI without GitHub Code Scanning SARIF upload.")
     .option("--force", "Overwrite existing generated CI adoption files.", false)
+    .option("--quiet", "Suppress logo and informational output.", false)
     .action(async (options: { config?: string; security?: boolean; attackSim?: boolean; format: string; skillScan?: SkillScanOption; enforce?: boolean } & SetupCiConversionFlags) => {
       const parentConfig = scanCmd.opts().config as string | undefined;
       const parentSecurity = scanCmd.opts().security as boolean | undefined;

--- a/src/commands/skill-scan.ts
+++ b/src/commands/skill-scan.ts
@@ -12,7 +12,7 @@ import {
   summarizeScan,
   type SkillScanResult,
 } from "../checks/skill-scan.js";
-import { ANSI, c, LOGO, useColor } from "./helpers.js";
+import { ANSI, c, LOGO, isQuiet, useColor } from "./helpers.js";
 import { TOOL_VERSION } from "../version.js";
 
 export async function runSkillScan(
@@ -30,8 +30,10 @@ export async function runSkillScan(
     return;
   }
 
-  process.stdout.write(useColor() ? c(ANSI.cyan, LOGO) + `  ${c(ANSI.dim, `v${TOOL_VERSION}`)}\n\n` : LOGO + `  v${TOOL_VERSION}\n\n`);
-  process.stdout.write(c(ANSI.bold, `  Scanning skills at: ${inputPath}\n\n`));
+  if (!isQuiet()) {
+    process.stdout.write(useColor() ? c(ANSI.cyan, LOGO) + `  ${c(ANSI.dim, `v${TOOL_VERSION}`)}\n\n` : LOGO + `  v${TOOL_VERSION}\n\n`);
+    process.stdout.write(c(ANSI.bold, `  Scanning skills at: ${inputPath}\n\n`));
+  }
 
   const results: SkillScanResult[] = await scanPath(inputPath);
   const healthScore = computeSkillHealthScore(results);

--- a/src/commercial.ts
+++ b/src/commercial.ts
@@ -1,4 +1,4 @@
-import { ANSI, c, getBinName } from "./commands/helpers.js";
+import { ANSI, c, getBinName, isQuiet } from "./commands/helpers.js";
 
 const CONTACT = "william@banksey.com";
 export const DEFAULT_CLOUD_UPLOAD_ENDPOINT = "https://mcp-observatory-api.kryptosai.workers.dev/api/v1/artifacts";
@@ -25,7 +25,7 @@ export function cloudUpgradeLine(context: "ci" | "security" | "fleet" | "general
 }
 
 export function maybePrintCloudCta(context: "ci" | "security" | "fleet" | "general" = "general"): void {
-  if (hasCloudToken()) return;
+  if (isQuiet() || hasCloudToken()) return;
   process.stdout.write(`${cloudUpgradeLine(context)}\n\n`);
 }
 

--- a/tests/commands-helpers.test.ts
+++ b/tests/commands-helpers.test.ts
@@ -9,8 +9,10 @@ import {
   colorStatus,
   formatOutput,
   getBinName,
+  isQuiet,
   quoteShell,
   setNoColor,
+  setQuiet,
   setupCiHint,
   targetFromCommand,
   useColor,
@@ -25,6 +27,7 @@ afterEach(() => {
   process.argv = [...originalArgv];
   process.env = { ...originalEnv };
   setNoColor(false);
+  setQuiet(false);
   vi.restoreAllMocks();
 });
 
@@ -79,6 +82,14 @@ describe("command helper formatting", () => {
     setNoColor(true);
     expect(useColor()).toBe(false);
     setNoColor(false);
+  });
+
+  it("isQuiet reflects setQuiet, defaulting to false", () => {
+    expect(isQuiet()).toBe(false);
+    setQuiet(true);
+    expect(isQuiet()).toBe(true);
+    setQuiet(false);
+    expect(isQuiet()).toBe(false);
   });
 
   it("colors known statuses and leaves unknown statuses unchanged", () => {

--- a/tests/commercial.test.ts
+++ b/tests/commercial.test.ts
@@ -1,11 +1,13 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { cloudUpgradeLine, hasCloudToken, maybePrintCloudCta, printCloudInfo } from "../src/commercial.js";
+import { setQuiet } from "../src/commands/helpers.js";
 
 const originalEnv = { ...process.env };
 
 afterEach(() => {
   process.env = { ...originalEnv };
+  setQuiet(false);
   vi.restoreAllMocks();
 });
 
@@ -54,6 +56,17 @@ describe("commercial cloud messaging", () => {
     maybePrintCloudCta("ci");
 
     expect(second.output()).toBe("");
+  });
+
+  it("suppresses the CTA in quiet mode even without a cloud token", () => {
+    process.env["NO_COLOR"] = "1";
+    delete process.env["MCP_OBSERVATORY_CLOUD_TOKEN"];
+    setQuiet(true);
+    const stdout = captureStdout();
+
+    maybePrintCloudCta("ci");
+
+    expect(stdout.output()).toBe("");
   });
 
   it("prints cloud pricing and upload guidance", () => {


### PR DESCRIPTION
## Summary

Fixes #243.

`--quiet` was added to the top-level `program` in #208 but nothing ever read the parsed value — it accepted the flag and did nothing with it.

## Fix

Wired it up the same way `--no-color` already works in this codebase: a module-level flag (`setQuiet`/`isQuiet` in `helpers.ts`), captured from `process.argv` early in `main()` before Commander strips it — necessary because subcommand action handlers don't automatically inherit parent-level option values here.

- `printCiConversionCta` (`helpers.ts`) and `maybePrintCloudCta` (`commercial.ts`) now no-op when quiet — this covers CTAs across every command that calls them, without needing to touch each call site individually
- Logo prints in `scan.ts`, `skill-scan.ts`, and `enforce.ts` are now gated on `!isQuiet()`
- `serve.ts` already had its own working local `--quiet` (a separate, subcommand-scoped flag, already correctly gating its own banner) — left untouched
- Added `--quiet` to `scan`/`scan deep`'s own option lists. Without this, Commander throws `unknown option '--quiet'` when it's placed *after* the subcommand — which is the exact usage in the issue's own expected-behavior example (`mcp-observatory scan --quiet`). It already worked positioned before the subcommand (top-level declaration covers that), just not after.

## Verified live

```
$ npx tsx src/cli.ts scan --config <config> --quiet
  Found 1 MCP server:
  ...
```
No logo banner, no cloud CTA. Confirmed the same command *without* `--quiet` prints both.

## Scope notes

- `scan.ts` has a few of its own inline CTA-ish lines ("Protect at runtime:", "Next: mcp-observatory scan deep...", "CI conversion available:") that aren't part of `printCiConversionCta`/`maybePrintCloudCta` and aren't suppressed by this PR — happy to fold those in if you'd like `--quiet` to be fully silent on `scan`.
- Only `scan`/`scan deep` got the local `--quiet` option needed to accept it positioned after the subcommand. 12 other commands redeclare `--no-color` the same way `scan` did and would need the identical one-line addition if `--quiet` should work post-subcommand everywhere, not just for `scan` (the case this issue's expected-behavior example named). Kept this PR scoped to what was asked rather than sweeping all commands.

## Testing

- New tests: `isQuiet reflects setQuiet, defaulting to false` (`commands-helpers.test.ts`), `suppresses the CTA in quiet mode even without a cloud token` (`commercial.test.ts`)
- `printCiConversionCta`'s quiet check isn't separately unit tested — it needs `process.stdout.isTTY` mocking that doesn't exist in this test suite yet, and `shouldPrintConversionCta()` already gates on TTY before my check even runs. It's the identical one-line `isQuiet() ||` pattern as `maybePrintCloudCta`, which is tested.
- `npx tsc --noEmit`: clean
- `npx eslint` on all changed files: clean
- Full test suite: 526/585 passing, same 59 pre-existing failures as `main` (environment-specific `spawn npm ENOENT` on Windows, unrelated to this change)