### PR TITLE
feat(test): add --watch mode, re-running whenever the target config changes

### DIFF
--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -1,5 +1,6 @@
 import { createInterface } from "node:readline";
 import { execSync } from "node:child_process";
+import { watch as fsWatch } from "node:fs";
 import type { Command } from "commander";
 
 import {
@@ -17,14 +18,15 @@ import { renderNextActions } from "../reporters/terminal.js";
 import { ANSI, c, resolveTarget, targetFromCommand, writeOutput } from "./helpers.js";
 import { maybeConvertPassingCheckToCi, type SetupCiConversionFlags } from "./setup-ci-conversion.js";
 
-interface TestCommandFlags extends SetupCiConversionFlags {
+export interface TestCommandFlags extends SetupCiConversionFlags {
   attackSim?: boolean;
   sarif?: string;
   enforce?: boolean;
   autoEnforce?: boolean;
+  watch?: boolean;
 }
 
-function extractTrailingConversionFlags(
+export function extractTrailingConversionFlags(
   commandArgs: string[],
   options: TestCommandFlags,
 ): { commandArgs: string[]; flags: TestCommandFlags } {
@@ -53,6 +55,8 @@ function extractTrailingConversionFlags(
       flags.enforce = true;
     } else if (arg === "--auto-enforce") {
       flags.autoEnforce = true;
+    } else if (arg === "--watch") {
+      flags.watch = true;
     } else if (arg === "--campaign") {
       const next = commandArgs[i + 1];
       if (!next) throw new Error("--campaign requires a campaign slug.");
@@ -64,6 +68,51 @@ function extractTrailingConversionFlags(
   }
   if (flags.campaign) flags.campaign = normalizeCampaign(flags.campaign);
   return { commandArgs: targetArgs, flags };
+}
+
+/**
+ * Watches a target config file for changes and re-runs a one-shot
+ * check+diff on each change, reusing watch.ts's existing render/diff logic
+ * rather than test.ts's own richer (interactive, enforce-prompting) flow --
+ * that flow only makes sense for a one-time initial run, not a loop.
+ */
+export async function watchAndRerun(configPath: string | undefined): Promise<void> {
+  if (!configPath) {
+    process.stderr.write(
+      `\n  ${c(ANSI.red, "✗ --watch requires --target <config.json> — there's no file to watch for a raw command target.")}\n`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const { runWatchOneShot } = await import("./watch.js");
+  const outDir = defaultRunsDirectory(process.cwd());
+
+  process.stdout.write(`\n  ${c(ANSI.dim, `Watching for changes... (${configPath}, Ctrl+C to stop)`)}\n`);
+
+  let debounceTimer: NodeJS.Timeout | undefined;
+  const watcher = fsWatch(configPath, () => {
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+      void (async () => {
+        process.stdout.write(`\n${c(ANSI.dim, `--- ${new Date().toLocaleTimeString()} ---`)}\n`);
+        try {
+          const changedTarget = await resolveTarget({ target: configPath });
+          await runWatchOneShot(changedTarget, outDir, { format: "terminal", failOnRegression: false });
+        } catch (err) {
+          process.stderr.write(`  [watch] ${err instanceof Error ? err.message : String(err)}\n`);
+        }
+      })();
+    }, 300);
+  });
+
+  await new Promise<void>((resolve) => {
+    process.on("SIGINT", () => {
+      watcher.close();
+      process.stdout.write("\n  Watch mode stopped.\n");
+      resolve();
+    });
+  });
 }
 
 export function registerTestCommands(program: Command): void {
@@ -86,8 +135,9 @@ export function registerTestCommands(program: Command): void {
     .option("--force", "Overwrite existing generated CI adoption files.", false)
     .option("--enforce", "After testing, generate seatbelt policy and optionally start proxy.", false)
     .option("--auto-enforce", "Skip interactive prompt and always enforce after testing.", false)
+    .option("--watch", "After the initial test, re-run and diff whenever the target config file changes. Requires --target.", false)
     .option("--no-color", "Disable colored output.")
-    .action(async (commandArgs: string[], options: { deep?: boolean; invokeTools?: boolean; security?: boolean; target?: string; attackSim?: boolean } & TestCommandFlags) => {
+    .action(async (commandArgs: string[], options: { deep?: boolean; invokeTools?: boolean; security?: boolean; target?: string; attackSim?: boolean; watch?: boolean } & TestCommandFlags) => {
       const extracted = extractTrailingConversionFlags(commandArgs, options);
       commandArgs = extracted.commandArgs;
       const conversionFlags = extracted.flags;
@@ -214,5 +264,9 @@ export function registerTestCommands(program: Command): void {
         });
       }
       maybePrintCloudCta(options.security ? "security" : "general");
+
+      if (options.watch || conversionFlags.watch) {
+        await watchAndRerun(options.target);
+      }
     });
 }

--- a/tests/test-command.test.ts
+++ b/tests/test-command.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { extractTrailingConversionFlags, watchAndRerun } from "../src/commands/test.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("extractTrailingConversionFlags", () => {
+  it("extracts --watch from the trailing args and leaves the server command intact", () => {
+    const { commandArgs, flags } = extractTrailingConversionFlags(
+      ["npx", "-y", "@modelcontextprotocol/server-memory", "--watch"],
+      {},
+    );
+    expect(commandArgs).toEqual(["npx", "-y", "@modelcontextprotocol/server-memory"]);
+    expect(flags.watch).toBe(true);
+  });
+
+  it("leaves watch undefined when --watch isn't present", () => {
+    const { flags } = extractTrailingConversionFlags(["npx", "-y", "server"], {});
+    expect(flags.watch).toBeUndefined();
+  });
+
+  it("extracts --watch alongside other trailing conversion flags", () => {
+    const { commandArgs, flags } = extractTrailingConversionFlags(
+      ["npx", "-y", "server", "--no-attack-sim", "--watch", "--no-setup-ci"],
+      {},
+    );
+    expect(commandArgs).toEqual(["npx", "-y", "server"]);
+    expect(flags.attackSim).toBe(false);
+    expect(flags.watch).toBe(true);
+    expect(flags.noSetupCi).toBe(true);
+  });
+});
+
+describe("watchAndRerun", () => {
+  it("errors clearly and sets a non-zero exit code when no --target was given", async () => {
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    process.exitCode = undefined;
+
+    await watchAndRerun(undefined);
+
+    expect(stderr).toHaveBeenCalledWith(
+      expect.stringContaining("--watch requires --target <config.json>"),
+    );
+    expect(process.exitCode).toBe(1);
+    process.exitCode = undefined;
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #254.

Adds `--watch` to `test`: after the initial check, watches the target config file and re-runs a check+diff whenever it changes, until Ctrl+C.

## Design choices

- **`fs.watch` over `chokidar`** — the issue offered either; `chokidar` isn't a dependency here and watching a single file doesn't need glob support, so no new dependency.
- **Reused `watch.ts`'s `runWatchOneShot`** for the re-run/render/diff logic on each change, rather than re-running `test`'s own much richer flow (interactive enforce prompts, CI-conversion offers, SARIF writing) — that flow makes sense once, at the start, not on every file save. The initial check still gets `test`'s full behavior unchanged; only the watch-triggered re-runs use the lighter `watch`-style rendering.
- **300ms debounce** — `fs.watch` commonly fires multiple events for a single file write; without debouncing this would re-run 2-3x per save.

## A real ambiguity in the issue, and how I resolved it

The issue's own expected-usage example is:
```bash
mcp-observatory test --watch npx -y @modelcontextprotocol/server-memory
```
That's a **raw command**, not `--target <file>` — there's no config file to actually watch in that invocation. I made `--watch` require `--target` and error clearly when it's missing, rather than silently doing nothing:
```
✗ --watch requires --target <config.json> — there's no file to watch for a raw command target.
```

## A real bug this surfaced (fixed as part of this PR)

Testing the issue's own example command (`test <raw-command> --watch`) initially did *nothing* — no error, `--watch` just silently had no effect. Root cause: `test` uses `passThroughOptions()` with a variadic `[command...]` argument, so flags placed *after* a raw command get swallowed into the command-args array meant for the server invocation, instead of being parsed as `test`'s own options. This repo already has a known, existing workaround for exactly this (`extractTrailingConversionFlags`, which manually re-extracts `--setup-ci`/`--enforce`/`--auto-enforce`/etc. out of the trailing args) — `--watch` just wasn't added to that list. Fixed, with a regression test covering the exact scenario.

## Verified live

Initial run + watch message:
```
$ mcp-observatory test --target config.json --watch
  ✓ filesystem   14 tools, 0 prompts, 0 resources
  ...
  Watching for changes... (config.json, Ctrl+C to stop)
```
Edited the config file → detected, debounced, re-ran, rendered via `watch.ts`'s diff renderer:
```
--- 6:52:46 PM ---
secure-filesystem-server 0.2.0 — 77/100 (C) — pass
✓ No changes
Artifact: .../filesystem.json
```
No-`--target` error path also confirmed (exit code 1, clear message) — including with the issue's exact raw-command example, after the `extractTrailingConversionFlags` fix above.

## Testing

- New tests: 3 for `--watch` extraction via `extractTrailingConversionFlags` (including the exact "raw command + trailing `--watch`" scenario that was broken), 1 for `watchAndRerun`'s no-`--target` error path
- `npx tsc --noEmit`: clean
- `npx eslint` on changed files: clean
- Full suite: same 59 pre-existing failures as `main`, unrelated (see #280/#281/#283)