### PR TITLE
feat(cli): add --timeout flag to demo command

### DIFF
--- a/src/commands/demo.ts
+++ b/src/commands/demo.ts
@@ -76,13 +76,22 @@ export function registerDemoCommands(program: Command): void {
     .command("demo")
     .description("Quick interactive demo — scan your MCP servers and see your safety grade")
     .option("--server <name>", `Demo with a built-in server: ${DEMO_SERVERS.map(s => s.name).join(", ")}`)
+    .option("--timeout <ms>", "Timeout in milliseconds", "15000")
     .option("--deep", "Run full tool invocation and security checks (takes longer)", false)
     .option("--no-color", "Disable colored output")
-    .action(async (options: { server?: string; deep?: boolean }) => {
+    .action(async (options: { server?: string; deep?: boolean; timeout?: string }) => {
       const sessionId = generateSessionId();
       recordSessionStart(sessionId);
       const t0 = Date.now();
       const bin = getBinName();
+
+      const timeoutMs = parseInt(options.timeout ?? "15000", 10);
+      if (isNaN(timeoutMs) || timeoutMs <= 0 || String(timeoutMs) !== (options.timeout ?? "15000")) {
+        process.stderr.write(`\n  ${c(ANSI.red, "✗")} Invalid timeout value: must be a positive integer number.\n\n`);
+        process.exitCode = 1;
+        recordSessionEnd(sessionId);
+        return;
+      }
 
       if (!isQuiet()) {
         process.stdout.write(LOGO + "\n");
@@ -157,6 +166,8 @@ export function registerDemoCommands(program: Command): void {
           `    ${c(ANSI.dim, `Tip: ${bin} suggest  → discover servers for your stack`)}\n`,
         );
       }
+
+      targetConfig.timeoutMs = timeoutMs;
 
       process.stdout.write("\n");
 

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { describe, expect, it, vi, beforeEach } from "vitest";
 
 vi.mock("node:fs/promises", () => ({
   readFile: vi.fn(),
@@ -211,7 +211,7 @@ describe("auth module", () => {
       const auth = await importAuth();
       const mockFetch = vi.fn().mockResolvedValue({
         ok: true,
-        json: async () => ({
+        json: () => Promise.resolve({
           issuer: "https://auth.example.com",
           token_endpoint: "https://auth.example.com/token",
         }),
@@ -230,7 +230,7 @@ describe("auth module", () => {
       const mockFetch = vi.fn()
         .mockResolvedValueOnce({
           ok: true,
-          json: async () => ({
+          json: () => Promise.resolve({
             device_authorization_endpoint: "https://auth.example.com/device",
             token_endpoint: "https://auth.example.com/token",
           }),
@@ -238,7 +238,7 @@ describe("auth module", () => {
         .mockResolvedValueOnce({
           ok: false,
           status: 400,
-          text: async () => "invalid_client",
+          text: () => Promise.resolve("invalid_client"),
         });
       vi.stubGlobal("fetch", mockFetch);
 
@@ -259,14 +259,14 @@ describe("auth module", () => {
       const mockFetch = vi.fn()
         .mockResolvedValueOnce({
           ok: true,
-          json: async () => ({
+          json: () => Promise.resolve({
             device_authorization_endpoint: "https://auth.example.com/device",
             token_endpoint: "https://auth.example.com/token",
           }),
         })
         .mockResolvedValueOnce({
           ok: true,
-          json: async () => ({
+          json: () => Promise.resolve({
             device_code: "device-123",
             user_code: "ABCD-EFGH",
             verification_uri: "https://auth.example.com/activate",
@@ -276,7 +276,7 @@ describe("auth module", () => {
         })
         .mockResolvedValueOnce({
           ok: true,
-          json: async () => ({
+          json: () => Promise.resolve({
             access_token: "new-access-token",
             refresh_token: "new-refresh-token",
             expires_in: 3600,

--- a/tests/ci-issue.test.ts
+++ b/tests/ci-issue.test.ts
@@ -196,10 +196,10 @@ describe("createOrUpdateIssue", () => {
 
 describe("execCommand", () => {
   it("resolves with stdout and stderr on success", async () => {
-    mockedExecFile.mockImplementation(
+    (mockedExecFile as unknown as { mockImplementation: (fn: (cmd: string, args: string[], callback: (err: Error | null, stdout: string, stderr: string) => void) => unknown) => void }).mockImplementation(
       (_cmd, _args, callback) => {
         callback(null, "output", "");
-        return {} as never;
+        return {};
       },
     );
     const { execCommand } = await import("../src/ci-issue.js");
@@ -208,10 +208,10 @@ describe("execCommand", () => {
   });
 
   it("rejects with error on failure", async () => {
-    mockedExecFile.mockImplementation(
+    (mockedExecFile as unknown as { mockImplementation: (fn: (cmd: string, args: string[], callback: (err: Error | null, stdout: string, stderr: string) => void) => unknown) => void }).mockImplementation(
       (_cmd, _args, callback) => {
         callback(new Error("command not found"), "", "");
-        return {} as never;
+        return {};
       },
     );
     const { execCommand } = await import("../src/ci-issue.js");
@@ -219,10 +219,10 @@ describe("execCommand", () => {
   });
 
   it("handles null stdout/stderr from execFile", async () => {
-    mockedExecFile.mockImplementation(
+    (mockedExecFile as unknown as { mockImplementation: (fn: (cmd: string, args: string[], callback: (err: Error | null, stdout: unknown, stderr: unknown) => void) => unknown) => void }).mockImplementation(
       (_cmd, _args, callback) => {
-        callback(null, null as never, null as never);
-        return {} as never;
+        callback(null, null, null);
+        return {};
       },
     );
     const { execCommand } = await import("../src/ci-issue.js");

--- a/tests/demo-command.test.ts
+++ b/tests/demo-command.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { Command } from "commander";
+import { registerDemoCommands } from "../src/commands/demo.js";
+import { runTarget } from "../src/index.js";
+
+vi.mock("../src/index.js", () => ({
+  runTarget: vi.fn().mockResolvedValue({
+    artifactType: "run",
+    gate: "pass",
+    checks: [],
+    summary: { pass: 0, fail: 0, partial: 0, flaky: 0, unsupported: 0, skipped: 0 },
+  }),
+}));
+
+vi.mock("../src/discovery.js", () => ({
+  scanForTargets: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("../src/telemetry.js", () => ({
+  generateSessionId: vi.fn().mockReturnValue("test-session"),
+  recordSessionStart: vi.fn(),
+  recordSessionEnd: vi.fn(),
+  buildEvent: vi.fn().mockReturnValue({}),
+  recordEvent: vi.fn(),
+}));
+
+vi.mock("../src/commercial.js", () => ({
+  maybePrintCloudCta: vi.fn(),
+}));
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("demo command", () => {
+  it("uses default timeout of 15000ms", async () => {
+    const program = new Command();
+    registerDemoCommands(program);
+
+    await program.parseAsync(["node", "cli.js", "demo"]);
+
+    expect(runTarget).toHaveBeenCalledWith(
+      expect.objectContaining({
+        timeoutMs: 15000,
+      }),
+      expect.anything()
+    );
+  });
+
+  it("respects custom timeout value", async () => {
+    const program = new Command();
+    registerDemoCommands(program);
+
+    await program.parseAsync(["node", "cli.js", "demo", "--timeout", "30000"]);
+
+    expect(runTarget).toHaveBeenCalledWith(
+      expect.objectContaining({
+        timeoutMs: 30000,
+      }),
+      expect.anything()
+    );
+  });
+
+  it("shows clear error for non-number timeout value", async () => {
+    const program = new Command();
+    registerDemoCommands(program);
+
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    process.exitCode = undefined;
+
+    await program.parseAsync(["node", "cli.js", "demo", "--timeout", "abc"]);
+
+    expect(stderr).toHaveBeenCalledWith(
+      expect.stringContaining("Invalid timeout value")
+    );
+    expect(process.exitCode).toBe(1);
+    process.exitCode = undefined;
+  });
+});


### PR DESCRIPTION
## Summary

- Added the `--timeout <ms>` option to the `demo` command to support configurable timeouts for built-in or discovered MCP servers.
- Passes `timeoutMs` to `runTarget()` via the target config, defaulting to `15000`ms when the flag is omitted.
- Invalid non-number values throw a clear validation error.

## Code of Conduct

By submitting this pull request, you agree to follow the project's [Contributor Covenant Code of Conduct](./CODE_OF_CONDUCT.md).

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (Verified default/custom timeout and invalid value validation in `tests/demo-command.test.ts`)
- [x] `npm run smoke`

## Artifact Impact

- No artifact schema changes.
- No changes to the Markdown report formatting.