### PR TITLE
feat(cli): add --ci-provider flag to setup-ci

### DIFF
--- a/src/commands/init-ci.ts
+++ b/src/commands/init-ci.ts
@@ -51,6 +51,14 @@ function providerLabel(provider: string): string {
   return PROVIDER_LABELS[provider] ?? "CI Workflow";
 }
 
+const VALID_CI_PROVIDERS = Object.keys(CI_FILE_PATHS);
+
+function validateCiProvider(provider: string | undefined): void {
+  if (provider !== undefined && !VALID_CI_PROVIDERS.includes(provider)) {
+    throw new Error(`Invalid --ci-provider "${provider}". Valid options: ${VALID_CI_PROVIDERS.join(", ")}.`);
+  }
+}
+
 const DEFAULT_WORKFLOW_PATH = ".github/workflows/mcp-observatory.yml";
 const DEFAULT_BADGE_PATH = "docs/mcp-observatory-badge.md";
 const DEFAULT_TARGET_CONFIG_PATH = "mcp-observatory.target.json";
@@ -495,6 +503,7 @@ function doctorFixOptions(options: InitCiOptions, workflow: string | undefined):
 }
 
 export async function doctorSetupCi(options: InitCiOptions = {}): Promise<SetupCiDoctorResult> {
+  validateCiProvider(options.ciProvider);
   const detectedProvider = options.ciProvider ?? detectCiProvider() ?? "github-actions";
   const defaultPath = CI_FILE_PATHS[detectedProvider] ?? DEFAULT_WORKFLOW_PATH;
   const workflowPath = options.workflow ?? defaultPath;
@@ -595,6 +604,7 @@ export async function doctorSetupCi(options: InitCiOptions = {}): Promise<SetupC
 }
 
 export async function initCi(options: InitCiOptions): Promise<InitCiResult> {
+  validateCiProvider(options.ciProvider);
   if (options.command && options.target) {
     throw new Error("Use either --command or --target, not both.");
   }
@@ -644,7 +654,8 @@ function addInitCiOptions(command: Command): Command {
   return command
     .option("--command <command>", "MCP server command to test, for example: 'npx -y my-mcp-server'")
     .option("--target <file>", "Target config JSON path to use instead of a command.")
-    .option("--workflow <file>", "Workflow output path.", DEFAULT_WORKFLOW_PATH)
+    .option("--workflow <file>", "Workflow output path. Defaults to the path for the detected or selected CI provider.")
+    .option("--ci-provider <provider>", `Override auto-detected CI provider (${VALID_CI_PROVIDERS.join(", ")}).`)
     .option("--badge", "Also write a README badge snippet.", false)
     .option("--badge-file <file>", "Badge snippet output path.", DEFAULT_BADGE_PATH)
     .option("--target-config [file]", "Also write an example target config and point the workflow at it.")

--- a/tests/init-ci.test.ts
+++ b/tests/init-ci.test.ts
@@ -287,4 +287,45 @@ describe("init-ci", () => {
   it("rejects target config generation when an existing target is supplied", async () => {
     await expect(initCi({ target: "./target.json", targetConfig: true })).rejects.toThrow("Use either --target or --target-config");
   });
+
+  it("honors an explicit --ci-provider override instead of auto-detecting", async () => {
+    const dir = await tempDir();
+    const workflow = path.join(dir, ".gitlab-ci.yml");
+
+    const result = await initCi({
+      command: "npx -y @example/mcp-server",
+      workflow,
+      ciProvider: "gitlab-ci",
+    });
+
+    expect(result.workflowStatus).toBe("created");
+    const workflowText = await readFile(workflow, "utf8");
+    expect(workflowText).toContain("mcp-observatory:");
+    expect(workflowText).toContain("npx @kryptosai/mcp-observatory test npx -y @example/mcp-server");
+  });
+
+  it("rejects an invalid --ci-provider value and lists the valid options", async () => {
+    await expect(initCi({ command: "npx -y server", ciProvider: "jenkins" as never })).rejects.toThrow(
+      'Invalid --ci-provider "jenkins". Valid options: github-actions, gitlab-ci, circleci, bitbucket-pipelines, azure-pipelines.',
+    );
+  });
+
+  it("validates --ci-provider in doctor mode too", async () => {
+    await expect(doctorSetupCi({ ciProvider: "travis" as never })).rejects.toThrow('Invalid --ci-provider "travis"');
+  });
+
+  it("derives the default workflow path from --ci-provider when --workflow is omitted", async () => {
+    const dir = await tempDir();
+    const originalCwd = process.cwd();
+    process.chdir(dir);
+    try {
+      const result = await initCi({ command: "npx -y @example/mcp-server", ciProvider: "gitlab-ci" });
+      expect(result.workflowPath).toBe(".gitlab-ci.yml");
+      expect(result.workflowStatus).toBe("created");
+      const workflowText = await readFile(path.join(dir, ".gitlab-ci.yml"), "utf8");
+      expect(workflowText).toContain("mcp-observatory:");
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #289. `setup-ci` (`init-ci`) already generated config for 5 CI providers (`InitCiOptions.ciProvider`), but there was no CLI flag to select one explicitly — only auto-detection via env vars.

## Changes

- Added `--ci-provider <provider>` to `setup-ci`/`init-ci`, accepting `github-actions`, `gitlab-ci`, `circleci`, `bitbucket-pipelines`, `azure-pipelines`.
- Added validation (`validateCiProvider`) shared by `initCi` and `doctorSetupCi`, so an invalid value throws a clear error listing the valid options instead of silently falling through — applies to `setup-ci` and `setup-ci --doctor` alike.
- Omitting the flag still auto-detects via `detectCiProvider()`, unchanged.
- **Also fixed a related bug that made the flag a no-op in real usage:** `--workflow` had a hardcoded default (`DEFAULT_WORKFLOW_PATH`) baked into the Commander option itself, so `options.workflow` was never `undefined` when invoked from the actual CLI. That meant the existing `options.workflow ?? defaultPath` provider-based path selection could never trigger outside of direct function calls/tests — `--ci-provider gitlab-ci` would still write to `.github/workflows/mcp-observatory.yml` instead of `.gitlab-ci.yml`. Removed the baked-in default so the provider-based default path resolves correctly; behavior for the github-actions case (the ultimate fallback) is unchanged.

## Acceptance criteria (from #289)

- [x] `--ci-provider` accepts: github-actions, gitlab-ci, circleci, bitbucket-pipelines, azure-pipelines
- [x] Omitting the flag auto-detects as before
- [x] Invalid value shows a clear error with valid options
- [x] Tests for flag parsing

## Validation

```bash
npm run typecheck   # passes
npm run lint        # 0 errors (1 pre-existing unrelated warning in scripts/populate-safety-index-kv.ts)
npm test            # 604/604 passing
npm run build

# manual, one full round-trip per provider from a clean temp dir:
node dist/src/cli.js setup-ci --command "npx -y demo-server" --ci-provider gitlab-ci
node dist/src/cli.js setup-ci --command "npx -y demo-server" --ci-provider circleci
node dist/src/cli.js setup-ci --command "npx -y demo-server" --ci-provider bitbucket-pipelines
node dist/src/cli.js setup-ci --command "npx -y demo-server" --ci-provider azure-pipelines
node dist/src/cli.js setup-ci --command "npx -y demo-server" --ci-provider jenkins   # -> clean error, exit 1
node dist/src/cli.js setup-ci --command "npx -y demo-server"                        # -> auto-detect fallback unchanged
```

Each provider produced the correct config file with correct content; the invalid value produced a clean non-zero-exit error instead of silently defaulting; omitting the flag left auto-detection behavior unchanged.

Files touched: `src/commands/init-ci.ts`, `tests/init-ci.test.ts`.