### PR TITLE
[codex] activate HubSpot revenue funnel

### DIFF
--- a/dashboard/lead-config.js
+++ b/dashboard/lead-config.js
@@ -1,10 +1,10 @@
 // Public identifiers only. Configure these values after creating the HubSpot forms
 // and meeting page described in docs/hubspot-funnel-setup.md.
 window.MCP_OBSERVATORY_LEADS = {
-  hubspotPortalId: "",
-  hubspotRegion: "na1",
-  buyerFormId: "",
-  partnerFormId: "",
-  meetingUrl: "",
+  hubspotPortalId: "246903718",
+  hubspotRegion: "na2",
+  buyerFormId: "52c7e593-4500-4663-926a-f4ee34909754",
+  partnerFormId: "52c7e593-4500-4663-926a-f4ee34909754",
+  meetingUrl: "https://meetings-na2.hubspot.com/william-weishuhn",
   fallbackEmail: "william@banksey.com",
 };


### PR DESCRIPTION
## Activate HubSpot revenue funnel

### What changed
Adds the public HubSpot portal ID, published buyer form ID, partner intake route, and calendar-connected booking URL to the deployed site configuration.

### Why
The revenue-funnel UI and HubSpot submission code were already deployed, but intentionally had no external account identifiers. This change turns on the real submission path without adding credentials.

### Validation
- `node --check dashboard/lead-capture.js`
- Direct HubSpot Forms API submission returned HTTP 200 for the published form.
- HubSpot calendar connection completed and the meeting URL is live.

Only public identifiers are committed; no API key, credential, telemetry, or private repository data is included.