### PR TITLE
docs: operationalize partner channel sprint

### DIFF
--- a/docs/channel-sprint.md
+++ b/docs/channel-sprint.md
@@ -1,0 +1,51 @@
+# MCP Observatory: 30-Day Channel Sprint
+
+**Objective:** Secure three credible partners able to introduce qualified buyers for the `$15,000` MCP Release Gate Pilot. This is a distribution experiment, not an effort to maximize email volume.
+
+## Owner split
+
+| Work | Owner | Definition of done |
+| --- | --- | --- |
+| Offer, demo, evidence, scoping | MCP Observatory founder | Technical call and delivery materials are ready |
+| Account research and draft preparation | AI + founder approval | Every target has public-source rationale and a reviewed draft |
+| First messages and partner calls | Founder or fractional commercial operator | No automated first sends; all claims checked |
+| Customer access and commercial coordination | Partner | Registered qualified referral |
+
+## Week 1 — readiness and selection
+
+1. Review the first 12 firms in [`partner-target-queue.md`](./partner-target-queue.md). Select 8 that are credible, non-overlapping, and reachable through a relevant public contact path or warm connection.
+2. Record a named practice lead only after confirming it from the firm's public site or LinkedIn. Do not guess email addresses.
+3. Tailor the opening factual sentence and approve eight first-message drafts using [`enterprise-outreach-playbook.md`](./enterprise-outreach-playbook.md).
+4. Rehearse the five-part founder demo in [`release-gate-pilot-runbook.md`](./release-gate-pilot-runbook.md) until it takes under seven minutes.
+
+**Exit criterion:** eight approved partner messages, demo rehearsed, and all customer-facing materials linked from the public site.
+
+## Week 2 — first partner conversations
+
+1. Send the approved first messages manually from the founder or commercial operator’s real account.
+2. Hold conversations only to assess client overlap; do not pitch a partnership contract on the first call.
+3. Ask each credible firm: “Which clients already have an MCP approval decision blocked by security, platform ownership, or CI confidence?”
+4. Send the co-sell kit after a call, not as an attachment blast.
+
+**Exit criterion:** three held partner calls or a documented reason the segment is wrong.
+
+## Week 3 — turn interest into a buyer introduction
+
+1. For each interested partner, agree on qualification, partner role, referral economics, and the exact customer-introduction language.
+2. Ask for one named introduction rather than a vague commitment to “keep you in mind.”
+3. On buyer calls, run the qualification checklist. Sell the fixed pilot only when a live decision exists.
+
+**Exit criterion:** at least one registered buyer introduction or a specific objection pattern worth fixing.
+
+## Week 4 — decision review
+
+Write a one-page operating note with:
+
+- firms targeted, approved, sent, replied, and called;
+- objections in the prospect’s own words;
+- partner-to-buyer conversion;
+- qualified buyer count and proposals sent;
+- one change to the offer, targeting, or proof; and
+- the owner and due date of the next experiment.
+
+**Day-30 decision:** continue only if the motion has five partner calls and three credible partners willing to introduce qualified buyers. Otherwise change the target segment or recruit a fractional commercial operator; do not add product scope.

--- a/docs/enterprise-outreach-playbook.md
+++ b/docs/enterprise-outreach-playbook.md
@@ -1,83 +1,89 @@
-# Enterprise Outreach Playbook
+# MCP Release Gate Channel Outreach Playbook
 
-Use this playbook after running:
+This is a partner-recruitment motion, not a high-volume end-customer campaign. Its purpose is to find consultancies and advisors that already serve the platform, security, and AI owners who must approve MCP dependencies.
 
-```bash
-npm run telemetry:intelligence -- --input <private-telemetry-export.jsonl> --out-dir reports
-```
+## The only offer
 
-Start from `reports/telemetry-usage-summary.html` to confirm external usage before reading account rankings. Do not treat first-party CI, release workflows, or internal/personal sessions as market traction.
+> **MCP Release Gate Pilot** — `$15,000` fixed scope for 1–3 critical MCP servers over ten business days. The customer receives safe-mode evidence, an approve/gate/defer decision, CI/SARIF handoff, and owner-ready remediation.
 
-Raw telemetry is allowed for internal account intelligence only. Do not include personal emails, hostnames, private URLs, target commands, tokens, proprietary schemas, customer names, or private telemetry exports in public issues, posts, docs, or customer-facing outreach without explicit permission. Keep account-specific rankings in ignored `reports/` outputs or private notes.
+Do not offer monthly tiers, certification, a generic penetration test, or an unbounded AI-security engagement. The founding-design-partner price is `$10,000` only for the first two qualified customers and only in exchange for structured feedback and permission to describe an anonymized outcome.
 
-## Priority Accounts
+## Target profile
 
-| Priority | Account | Evidence | Motion |
-| ---: | --- | --- | --- |
-| 1 | Private account A | Repeated external sessions, CI usage, private-target signal, or security workflow evidence | Enterprise pilot |
-| 2 | Private account B | Recent usage across multiple sessions or repos | Business pilot / design partner |
-| 3 | Private account C | Small usage cluster with clear owner signal | Business pilot / testimonial ask |
-| 4 | Private account D | Single company or team signal | Team pilot / feedback ask |
-| 5 | GitHub org/user signals | CI or repo-based usage | Team pilot unless company identity is confirmed |
+Prioritize firms that publicly show all of the following:
 
-## First Email Template
+1. Enterprise AI-agent, platform-engineering, DevSecOps, or AI-security work.
+2. An advisory or implementation relationship with buyers; not a competing point product.
+3. A public business contact route and a relevant practice lead.
 
-Subject: MCP security reporting for production agent workflows
+Use only public sources. Do not use private telemetry, inferred identities, guessed email addresses, or customer-specific facts in a first message.
 
-Hi,
+## Human-approved sequence
 
-I build MCP Observatory, an open source tool for testing, securing, and monitoring MCP servers before agents depend on them.
+AI may research public sources, summarize the account, draft a message, and classify replies. A human verifies every claim and sends every first message.
 
-I am opening a small number of enterprise pilots for teams that want hosted MCP security reports, private-repo CI history, and fleet visibility across agent environments.
+### First message
 
-If your team is running MCP servers in production, I can prepare a short evidence-based report and a pilot proposal focused on:
+Subject: A fixed MCP approval offer for your agent clients
 
-- MCP compatibility
-- private HTTP MCP health checks
-- security findings and schema drift
-- CI history and controlled drift review
-- MCP fleet visibility across teams
+Hi {{first_name}},
 
-Would it be useful to compare notes this week?
+{{one factual sentence about the firm's public AI, DevSecOps, or security-advisory practice.}}
 
-William
+MCP Observatory addresses a narrow decision: before a production agent depends on MCP tools, a platform or security owner needs an evidence-backed **approve, gate, or defer** decision. The fixed Release Gate Pilot covers 1–3 servers in ten business days and produces safe-mode evidence, CI/SARIF handoff, and owner-ready remediation.
 
-## Pilot Routing
+We work through a small number of consultancies and advisors. Partners retain the client relationship and receive 25% of collected first-year revenue for registered, qualified referrals.
 
-- Repeated sessions + internal/private target: Enterprise Pilot, starts at `$3k/month`.
-- Major platform, AI lab, or very large company: Strategic only, `$250k+/year` anchor.
-- Light but recent company usage: Business Pilot, starts at `$999/month`.
-- GitHub-user-only or hobby-looking usage: Team Pilot, starts at `$299/month`.
+Would a 20-minute conversation be useful to decide whether this fits your practice?
 
-## Call Agenda
+### Follow-up 1 — day 4
 
-1. Confirm whether MCP is already in production or only evaluation.
-2. Identify the owner: platform, security, AI infra, developer productivity, or app team.
-3. Ask which value matters most: CI, security report, dashboard, certification, fleet inventory, or private deployment.
-4. Offer to generate a static enterprise report from their first pilot run.
-5. Quote manually. Do not route large companies to self-serve Team/Business pricing.
+Hi {{first_name}},
 
-## Evidence Packet
+The specific value is a bounded pre-production MCP decision: your client gets a release verdict and CI evidence without asking your team to build a scanner or run a broad AI-security engagement.
 
-Prepare this before outreach:
+If agent/tool approval is outside your practice, I will close the loop.
 
-```bash
-npx @kryptosai/mcp-observatory enterprise-report \
-  --account "Account Name" \
-  --format html \
-  --output reports/account-enterprise-report.html
-```
+### Follow-up 2 — day 10
 
-Include only aggregate facts:
+Hi {{first_name}},
 
-- company or GitHub organization domain
-- event count
-- unique sessions
-- first seen / last seen
-- commands used
-- targets seen
-- CI/private-network/security signals
-- confidence
-- recommended pilot tier
+Closing the loop. The partner offer, qualification criteria, and evidence sample are here:
 
-Do not include raw hostnames, personal emails, tokens, or private URLs in external outreach.
+- https://mcp-observatory.com/partners/
+- https://mcp-observatory.com/partner-co-sell-kit/
+- https://mcp-observatory.com/release-gate-evidence-pack/
+
+If there is a more relevant owner, a redirect is welcome.
+
+## Qualification and handoff
+
+Register an opportunity only if it has all four:
+
+- a named platform, engineering, or security decision owner;
+- private, pre-production, or production MCP use;
+- a decision in the next 60 days; and
+- acceptance that the `$15,000` pilot is the starting offer.
+
+The partner owns account access and commercial coordination. MCP Observatory owns the evidence method and delivery. No referral payment is due until revenue is collected.
+
+## Scorecard
+
+Update this once each Friday. Do not substitute anonymous telemetry, stars, downloads, opens, or page views for funnel progress.
+
+| Stage | Weekly measure |
+| --- | --- |
+| Targeted | New firms with a public-source rationale |
+| Approved | Firms whose first message was human-approved |
+| Sent | First messages sent |
+| Replied | Replies, segmented by interested / not-now / referral / opt-out |
+| Partner call | Held conversations |
+| Active partner | Partner agreed to introduce qualified buyers |
+| Buyer introduction | Named buyer introduction received |
+| Qualified buyer | Meets all four qualification criteria |
+| Proposal | Fixed-scope proposal sent |
+| Deposit | Signed agreement and first payment received |
+
+## Stop rule
+
+At day 30, stop broadening the target list and inspect the evidence. The motion is working only if it produces at least five partner conversations and three partners willing to introduce qualified buyers. At day 90, it needs ten qualified buyer conversations, three repeat external organizations, and one active partner. At day 180, it needs a paid pilot or signed contract plus a channel that repeatedly creates qualified opportunities.

--- a/docs/partner-target-queue.md
+++ b/docs/partner-target-queue.md
@@ -1,0 +1,30 @@
+# Initial Partner Target Queue
+
+This is a research queue, not a mailing list. Every entry is based on a public description of services and must be manually qualified before any outreach. Use the firm’s public contact or booking route; do not infer individual email addresses.
+
+| Priority | Firm | Public rationale | Public source / contact starting point | First-call hypothesis |
+| ---: | --- | --- | --- | --- |
+| 1 | Akto | Publicly offers agentic security services explicitly for AI agents and MCP servers. | [Services page](https://www.akto.io/agentic-security-services) | Their AI-security engagements may need a bounded pre-production MCP release verdict. |
+| 2 | NomadX | Publicly describes MCP integrations alongside Kubernetes and DevSecOps work. | [Services page](https://nomadx.ae/) | A practical integrator may introduce a client that needs MCP approval before rollout. |
+| 3 | ChakraSec | Publicly serves teams adopting GenAI, RAG, and agentic systems with AI-security services. | [Services page](https://chakra.group/) | Observatory can be a productized MCP evidence layer beside broader advisory work. |
+| 4 | Quinine Cybersecurity | Publicly offers agentic-AI testing and AI-architecture security reviews. | [Services page](https://quininecybersecurity.com/) | The offer may sharpen the MCP-server part of an AI-agent review without competing for the full engagement. |
+| 5 | Citadel Cloud Management | Publicly offers fixed-fee enterprise AI consulting across security, governance, deployment, and operations. | [Enterprise AI consulting](https://www.citadelcloudmanagement.com/) | Fixed-scope pricing and governed production agents suggest an accessible co-sell conversation. |
+| 6 | Delbion | Publicly positions secure enterprise AI-agent deployment with security and compliance expertise. | [Enterprise agents page](https://www.delbion.com/en/agents/) | Its production agent customers may need a technical MCP dependency release decision. |
+| 7 | SecureLayer7 | Publicly offers AI/LLM security assessment services for enterprises. | [AI security assessment](https://securelayer7.net/uk/services/ai-security-assessment) | A specialist assessment firm can add MCP release evidence as a defined module. |
+| 8 | Cithonic | Publicly offers AI security and LLM-red-teaming services. | [Services page](https://cithonic.com/) | The release gate could complement, rather than claim to replace, adversarial assessment work. |
+| 9 | Forge Agents | Publicly offers secure and compliant AI implementation. | [Secure AI implementation](https://forgeagents.ai/services/secure-ai-implementation) | Implementation projects are a likely source of pre-production MCP approval decisions. |
+| 10 | Nexus AI Consulting | Publicly offers enterprise-scale agent architecture, security, and governance advisory. | [Company site](https://www.nexusaiconsulting.com/) | Their readiness assessments may uncover a current MCP dependency decision. |
+| 11 | Secure AI | Publicly combines AI consulting and cybersecurity advisory. | [Company site](https://secureai.llc/) | A security advisory practice may use Observatory as a repeatable technical deliverable. |
+| 12 | CyberProof | Publicly describes services covering the AI-security lifecycle from discovery through remediation. | [AI-security brief](https://go.cyberproof.com/hubfs/solution-brief-securing-agentic-ai-systems.pdf) | A mature provider is a learning conversation; prioritize only if a relevant practice lead is reachable. |
+
+## Required preparation per selected firm
+
+Before a message is sent, append these fields in the private CRM or working note:
+
+- named practice lead and the public page where that role is confirmed;
+- one factual opening sentence and source URL;
+- public contact route;
+- potential conflict/overlap and why a referral model still makes sense;
+- status: `researching`, `approved`, `sent`, `replied`, `partner-call`, `active-partner`, or `closed-lost`.
+
+Do not publish contact names, email addresses, outreach history, or reply content in this repository.


### PR DESCRIPTION
## Summary\n- replace obsolete tiered outreach with the k fixed Release Gate Pilot\n- add a 30-day partner-channel operating sprint and scorecard\n- add a public-source research queue for initial partner selection\n\n## Validation\n- \n\nNo outreach has been sent; the queue requires human review and sends.