### PR TITLE
fix: update telemetry endpoint to working worker

### DIFF
--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -148,7 +148,7 @@ export interface TelemetryEvent extends TelemetryEnrichment {
 
 const CONFIG_DIR = path.join(os.homedir(), ".mcp-observatory");
 const CONFIG_PATH = path.join(CONFIG_DIR, "config.json");
-const DEFAULT_ENDPOINT = "https://mcp-observatory-telemetry.kryptosai.workers.dev/v1/events";
+const DEFAULT_ENDPOINT = "https://mcp-observatory-telemetry.william-weishuhn.workers.dev/v1/events";
 const FIRST_PARTY_GITHUB_REPOSITORY = "kryptosai/mcp-observatory";
 const CAMPAIGN_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._-]{1,63}$/;
 


### PR DESCRIPTION
## Problem

The previous telemetry worker at `mcp-observatory-telemetry.kryptosai.workers.dev` had a broken D1 binding — POST /v1/events returned 200 but data never reached the database. Zero production telemetry events were ever collected.

## Root Cause

The worker's D1 binding in production was disconnected from the database. The worker source code in the `mcp-observatory-telemetry` repo also had uncommitted changes (101 lines) needed to match the full D1 schema.

## Fix

- Redeployed the worker with corrected D1 binding and full schema support
- Verified end-to-end: POST → D1 write → data visible in `SELECT * FROM events`
- Updated `DEFAULT_ENDPOINT` to the new working URL

The original Banksey account deployment is still broken (needs an API token with Worker deploy permissions). The working deployment is in the personal Cloudflare account for now.