### PR TITLE
fix: wire --quiet flag across all commands (#243)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,7 +4,7 @@ import { readFile, writeFile } from "node:fs/promises";
 import { Command } from "commander";
 
 import { isCI } from "./ci.js";
-import { ANSI, LOGO, c, getBinName, setNoColor, setQuiet, useColor } from "./commands/helpers.js";
+import { ANSI, LOGO, c, getBinName, isQuiet, setNoColor, setQuiet, useColor } from "./commands/helpers.js";
 import { registerDemoCommands } from "./commands/demo.js";
 import { registerDiffCommands } from "./commands/diff.js";
 import { registerLegacyCommands } from "./commands/legacy.js";
@@ -256,7 +256,10 @@ async function main(): Promise<void> {
     .enablePositionalOptions()
     .description("Test your MCP servers for breaking changes.")
     .version(TOOL_VERSION)
-    .addHelpText("before", useColor() ? c(ANSI.cyan, LOGO) + `  ${c(ANSI.dim, `v${TOOL_VERSION}`)}\n` : LOGO + `  v${TOOL_VERSION}\n`)
+    .addHelpText("before", (() => {
+      if (isQuiet()) return "";
+      return useColor() ? c(ANSI.cyan, LOGO) + `  ${c(ANSI.dim, `v${TOOL_VERSION}`)}\n` : LOGO + `  v${TOOL_VERSION}\n`;
+    })())
     .option("--quiet", "Suppress logo and informational output.", false)
     .addHelpText("after", (() => {
       const lines = [

--- a/src/commands/attack-sim.ts
+++ b/src/commands/attack-sim.ts
@@ -10,7 +10,7 @@ import type { RunArtifact } from "../types.js";
 import { validateRunArtifact } from "../validate.js";
 import { renderActionReceipt } from "../action-receipt.js";
 import { maybePrintCloudCta } from "../commercial.js";
-import { ANSI, c, getBinName, quoteShell, resolveTarget, targetFromCommand, writeOutput } from "./helpers.js";
+import { ANSI, c, getBinName, isQuiet, quoteShell, resolveTarget, targetFromCommand, writeOutput } from "./helpers.js";
 import { maybeConvertPassingCheckToCi, type SetupCiConversionFlags } from "./setup-ci-conversion.js";
 
 interface AttackSimOptions extends SetupCiConversionFlags {
@@ -167,7 +167,9 @@ export function registerAttackSimCommands(program: Command): void {
         process.stdout.write(`    ${c(ANSI.dim, "→")} [${finding.severity}] ${finding.message}\n`);
       }
       process.stdout.write(`    ${c(ANSI.dim, "→")} ${renderActionReceipt(artifact).split("\n")[0]}\n`);
-      process.stdout.write(`\n  ${c(ANSI.bold, "Reproduce:")} ${c(ANSI.cyan, repro)}\n\n`);
+      if (!isQuiet()) {
+        process.stdout.write(`\n  ${c(ANSI.bold, "Reproduce:")} ${c(ANSI.cyan, repro)}\n\n`);
+      }
 
       if (options.json) {
         await writeOutput(JSON.stringify(artifact, null, 2), "json", options.json);

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -11,7 +11,7 @@ import {
 } from "../audit.js";
 import { buildMcpReceipt, receiptFormatFromPath, renderReceipt } from "../receipt.js";
 import { buildEvent, generateSessionId, recordEvent, recordSessionEnd, recordSessionStart } from "../telemetry.js";
-import { ANSI, c } from "./helpers.js";
+import { ANSI, c, isQuiet } from "./helpers.js";
 
 type AuditFormat = "json" | "markdown" | "sarif";
 
@@ -124,8 +124,10 @@ export function registerAuditCommands(program: Command): void {
       }
 
       const enforceTargetCmd = target.targetId;
-      process.stdout.write(`\n  ${c(ANSI.bold, "Protect at runtime:")} ${c(ANSI.cyan, `npx @kryptosai/mcp-observatory enforce ${enforceTargetCmd}`)}\n`);
-      process.stdout.write(`  ${c(ANSI.dim, "Generates seatbelt policy to block dangerous tool calls at runtime.")}\n\n`);
+      if (!isQuiet()) {
+        process.stdout.write(`\n  ${c(ANSI.bold, "Protect at runtime:")} ${c(ANSI.cyan, `npx @kryptosai/mcp-observatory enforce ${enforceTargetCmd}`)}\n`);
+        process.stdout.write(`  ${c(ANSI.dim, "Generates seatbelt policy to block dangerous tool calls at runtime.")}\n\n`);
+      }
 
       recordEvent(buildEvent("command_complete", "audit", "cli", {
         serversScanned: 1,

--- a/src/commands/demo.ts
+++ b/src/commands/demo.ts
@@ -274,37 +274,41 @@ export function registerDemoCommands(program: Command): void {
       if (artifact.gate === "pass") {
         process.stdout.write(`  ${c(ANSI.green, "✓")} ${c(ANSI.bold, "All checks passed!")}\n\n`);
 
-        process.stdout.write(`  ${c(ANSI.bold, "What's next?")}\n`);
-        const serverCount = targets.length > 1 ? targets.length : "";
-        if (serverCount) {
+        if (!isQuiet()) {
+          process.stdout.write(`  ${c(ANSI.bold, "What's next?")}\n`);
+          const serverCount = targets.length > 1 ? targets.length : "";
+          if (serverCount) {
+            process.stdout.write(
+              `    ${c(ANSI.cyan, "$")} ${c(ANSI.bold, `${bin} scan`)}${serverCount ? "" : ""} ${c(ANSI.dim, `— scan all ${serverCount} servers`)}\n`,
+            );
+          }
           process.stdout.write(
-            `    ${c(ANSI.cyan, "$")} ${c(ANSI.bold, `${bin} scan`)}${serverCount ? "" : ""} ${c(ANSI.dim, `— scan all ${serverCount} servers`)}\n`,
+            `    ${c(ANSI.cyan, "$")} ${c(ANSI.bold, `${bin} diff`)} <run1> <run2>  ${c(ANSI.dim, "- compare before/after")}\n`,
+          );
+          process.stdout.write(
+            `    ${c(ANSI.cyan, "$")} ${c(ANSI.bold, `${bin} badge`)} <server>      ${c(ANSI.dim, "- generate a safety badge")}\n`,
+          );
+          process.stdout.write(
+            `    ${c(ANSI.cyan, "$")} ${c(ANSI.bold, `${bin} setup-ci`)}             ${c(ANSI.dim, "- add to CI pipeline")}\n`,
           );
         }
-        process.stdout.write(
-          `    ${c(ANSI.cyan, "$")} ${c(ANSI.bold, `${bin} diff`)} <run1> <run2>  ${c(ANSI.dim, "- compare before/after")}\n`,
-        );
-        process.stdout.write(
-          `    ${c(ANSI.cyan, "$")} ${c(ANSI.bold, `${bin} badge`)} <server>      ${c(ANSI.dim, "- generate a safety badge")}\n`,
-        );
-        process.stdout.write(
-          `    ${c(ANSI.cyan, "$")} ${c(ANSI.bold, `${bin} setup-ci`)}             ${c(ANSI.dim, "- add to CI pipeline")}\n`,
-        );
 
         printCiConversionCta({ bin, context: "keep this safety grade visible in CI", target: targetConfig });
       } else {
         process.stdout.write(`  ${c(ANSI.yellow, "!")} ${c(ANSI.bold, "Some checks need attention")}\n\n`);
 
-        process.stdout.write(`  ${c(ANSI.bold, "Quick fixes:")}\n`);
-        process.stdout.write(
-          `    ${c(ANSI.cyan, "$")} ${c(ANSI.bold, `${bin} enforce`)} ${targetConfig.targetId}  ${c(ANSI.dim, "- generate runtime policy")}\n`,
+        if (!isQuiet()) {
+          process.stdout.write(`  ${c(ANSI.bold, "Quick fixes:")}\n`);
+          process.stdout.write(
+            `    ${c(ANSI.cyan, "$")} ${c(ANSI.bold, `${bin} enforce`)} ${targetConfig.targetId}  ${c(ANSI.dim, "- generate runtime policy")}\n`,
+          );
+          process.stdout.write(
+            `    ${c(ANSI.cyan, "$")} ${c(ANSI.bold, `${bin} audit`)} ${targetConfig.targetId}   ${c(ANSI.dim, "- deep security audit")}\n`,
+          );
+          process.stdout.write(
+            `    ${c(ANSI.cyan, "$")} ${c(ANSI.bold, `${bin} test --deep`)} ${targetConfig.targetId}  ${c(ANSI.dim, "- full tool invocation")}\n`,
         );
-        process.stdout.write(
-          `    ${c(ANSI.cyan, "$")} ${c(ANSI.bold, `${bin} audit`)} ${targetConfig.targetId}   ${c(ANSI.dim, "- deep security audit")}\n`,
-        );
-        process.stdout.write(
-          `    ${c(ANSI.cyan, "$")} ${c(ANSI.bold, `${bin} test --deep`)} ${targetConfig.targetId}  ${c(ANSI.dim, "- full tool invocation")}\n`,
-        );
+        }
       }
 
       process.stdout.write("\n");

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -237,17 +237,21 @@ async function runScan(
     const firstServerCmd = firstTarget.adapter === "local-process"
       ? `${firstTarget.command} ${(firstTarget.args ?? []).join(" ")}`
       : firstTarget.targetId;
-    process.stdout.write(`\n  ${c(ANSI.bold, "Protect at runtime:")} ${c(ANSI.cyan, `npx @kryptosai/mcp-observatory enforce ${firstServerCmd}`)}\n`);
+    if (!isQuiet()) {
+      process.stdout.write(`\n  ${c(ANSI.bold, "Protect at runtime:")} ${c(ANSI.cyan, `npx @kryptosai/mcp-observatory enforce ${firstServerCmd}`)}\n`);
+    }
   }
 
   // ── Next step ────────────────────────────────────────────────────────
-  process.stdout.write("\n");
-  if (!invokeTools && totalTools > 0) {
-    process.stdout.write(c(ANSI.dim, `  Next: ${c(ANSI.cyan, `${bin} scan deep`)} to also test that tools run\n`));
-  } else {
-    process.stdout.write(c(ANSI.dim, `  Run ${c(ANSI.cyan, `${bin} --help`)} for more commands\n`));
+  if (!isQuiet()) {
+    process.stdout.write("\n");
+    if (!invokeTools && totalTools > 0) {
+      process.stdout.write(c(ANSI.dim, `  Next: ${c(ANSI.cyan, `${bin} scan deep`)} to also test that tools run\n`));
+    } else {
+      process.stdout.write(c(ANSI.dim, `  Run ${c(ANSI.cyan, `${bin} --help`)} for more commands\n`));
+    }
+    process.stdout.write("\n");
   }
-  process.stdout.write("\n");
 
   if (failCount === 0) {
     if (artifacts.length === 1 && targets[0]) {
@@ -263,10 +267,12 @@ async function runScan(
         campaign: conversionFlags.campaign,
       });
     } else if (conversionFlags.noSetupCi !== true) {
-      const sarif = conversionFlags.ciSarif === false ? "" : " --sarif";
-      process.stdout.write(`CI conversion available for a specific target:\n  ${setupCiHint(undefined, undefined, bin)}${sarif} --schedule weekly\n`);
-      if (conversionFlags.setupCi === true) {
-        process.stdout.write("Non-interactive mode will only write files when --setup-ci --yes is present, and multi-target scans need a single target config.\n");
+      if (!isQuiet()) {
+        const sarif = conversionFlags.ciSarif === false ? "" : " --sarif";
+        process.stdout.write(`CI conversion available for a specific target:\n  ${setupCiHint(undefined, undefined, bin)}${sarif} --schedule weekly\n`);
+        if (conversionFlags.setupCi === true) {
+          process.stdout.write("Non-interactive mode will only write files when --setup-ci --yes is present, and multi-target scans need a single target config.\n");
+        }
       }
     }
   }
@@ -356,7 +362,7 @@ export function registerScanCommands(program: Command, bin: string): void {
   // `scan` with no subcommand — basic scan
   scanCmd.action(async (options: { config?: string; security?: boolean; attackSim?: boolean; format: string; skillScan?: SkillScanOption; enforce?: boolean } & SetupCiConversionFlags) => {
     await runScan(bin, options.config, false, options.security, options.format, options.attackSim !== false, options, options.skillScan);
-    if (options.enforce) {
+    if (options.enforce && !isQuiet()) {
       process.stdout.write(`\n  ${c(ANSI.bold, "Next:")} ${c(ANSI.cyan, `npx @kryptosai/mcp-observatory enforce --deep npx -y <your-server>`)}\n`);
       process.stdout.write(`  ${c(ANSI.dim, "Enforce mode runs a scan AND auto-generates seatbelt policy for runtime protection.")}\n\n`);
     }
@@ -385,9 +391,9 @@ export function registerScanCommands(program: Command, bin: string): void {
       const parentSkillScan = scanCmd.opts().skillScan as SkillScanOption;
       const resolvedSkillScan = options.skillScan !== undefined ? options.skillScan : parentSkillScan;
       await runScan(bin, options.config ?? parentConfig, true, options.security ?? parentSecurity ?? true, options.format ?? parentFormat, options.attackSim !== false && parentAttackSim !== false, options, resolvedSkillScan);
-      if (options.enforce) {
+      if (options.enforce && !isQuiet()) {
         process.stdout.write(`\n  ${c(ANSI.bold, "Next:")} ${c(ANSI.cyan, `npx @kryptosai/mcp-observatory enforce --deep npx -y <your-server>`)}\n`);
         process.stdout.write(`  ${c(ANSI.dim, "Enforce mode runs a scan AND auto-generates seatbelt policy for runtime protection.")}\n\n`);
       }
-    });
+  });
 }

--- a/src/commands/score.ts
+++ b/src/commands/score.ts
@@ -12,7 +12,7 @@ import { defaultRunsDirectory } from "../storage.js";
 import { buildEvent, generateSessionId, recordEvent, recordSessionEnd, recordSessionStart } from "../telemetry.js";
 import { maybePrintCloudCta } from "../commercial.js";
 import { extractObservatoryFindings } from "../findings.js";
-import { ANSI, c, formatOutput, printCiConversionCta, targetFromCommand, writeOutput } from "./helpers.js";
+import { ANSI, c, formatOutput, isQuiet, printCiConversionCta, targetFromCommand, writeOutput } from "./helpers.js";
 
 function extractTrailingProfileScoreFlags(
   args: string[],
@@ -186,12 +186,14 @@ export function registerScoreCommands(program: Command): void {
       const protectLine = "Protect this server at runtime:";
       const enforceLine = `npx @kryptosai/mcp-observatory enforce ${enforceTargetCmd}`;
       const pad = (s: string, w: number) => s + " ".repeat(Math.max(0, w - s.length));
-      process.stdout.write(`  ${c(ANSI.bold, "╔")}${"═".repeat(boxWidth)}${c(ANSI.bold, "╗")}\n`);
-      process.stdout.write(`  ${c(ANSI.bold, "║")}  ${pad(scoreLine, boxWidth - 2)}${c(ANSI.bold, "║")}\n`);
-      process.stdout.write(`  ${c(ANSI.bold, "║")}  ${pad(protectLine, boxWidth - 2)}${c(ANSI.bold, "║")}\n`);
-      process.stdout.write(`  ${c(ANSI.bold, "║")}  ${pad(enforceLine, boxWidth - 2)}${c(ANSI.bold, "║")}\n`);
-      process.stdout.write(`  ${c(ANSI.bold, "╚")}${"═".repeat(boxWidth)}${c(ANSI.bold, "╝")}\n`);
-      process.stdout.write("\n");
+      if (!isQuiet()) {
+        process.stdout.write(`  ${c(ANSI.bold, "╔")}${"═".repeat(boxWidth)}${c(ANSI.bold, "╗")}\n`);
+        process.stdout.write(`  ${c(ANSI.bold, "║")}  ${pad(scoreLine, boxWidth - 2)}${c(ANSI.bold, "║")}\n`);
+        process.stdout.write(`  ${c(ANSI.bold, "║")}  ${pad(protectLine, boxWidth - 2)}${c(ANSI.bold, "║")}\n`);
+        process.stdout.write(`  ${c(ANSI.bold, "║")}  ${pad(enforceLine, boxWidth - 2)}${c(ANSI.bold, "║")}\n`);
+        process.stdout.write(`  ${c(ANSI.bold, "╚")}${"═".repeat(boxWidth)}${c(ANSI.bold, "╝")}\n`);
+        process.stdout.write("\n");
+      }
 
       if (artifact.gate !== "fail") {
         printCiConversionCta({

--- a/src/commands/setup-ci-conversion.ts
+++ b/src/commands/setup-ci-conversion.ts
@@ -4,7 +4,7 @@ import type { Readable, Writable } from "node:stream";
 import type { RunArtifact, TargetConfig } from "../types.js";
 import { buildEvent, detectCiProvider, recordEvent } from "../telemetry.js";
 import { initCi, type InitCiOptions, type InitCiResult } from "./init-ci.js";
-import { ANSI, c, quoteShell, setupCiHint } from "./helpers.js";
+import { ANSI, c, isQuiet, quoteShell, setupCiHint } from "./helpers.js";
 
 export interface SetupCiConversionFlags {
   setupCi?: boolean;
@@ -157,9 +157,11 @@ export async function maybeConvertPassingCheckToCi(options: SetupCiConversionOpt
     return { status: "skipped", command };
   }
 
-  output.write(`\nCI conversion available:\n  ${command}\n`);
-  if (options.setupCi === true) {
-    output.write("Non-interactive mode will only write files when --setup-ci --yes is present.\n");
+  if (!isQuiet()) {
+    output.write(`\nCI conversion available:\n  ${command}\n`);
+    if (options.setupCi === true) {
+      output.write("Non-interactive mode will only write files when --setup-ci --yes is present.\n");
+    }
   }
   recordConversion("hinted", options);
   return { status: "hinted", command };


### PR DESCRIPTION
Wires the `--quiet` flag to suppress informational banners, CTAs, and hints across all CLI commands:

- **cli.ts**: Suppress ASCII logo in `--help` output
- **scan.ts**: Suppress "Protect at runtime", "Next", and CI conversion hints  
- **attack-sim.ts**: Suppress "Reproduce" command line
- **audit.ts**: Suppress "Protect at runtime" hint
- **score.ts**: Suppress protect box
- **demo.ts**: Suppress "What's next?" and "Quick fixes" blocks
- **setup-ci-conversion.ts**: Suppress "CI conversion available" hint

The flag was accepted but had no behavioral effect since PR #208. All `isQuiet()` guards follow the existing pattern already used in `printCiConversionCta()` and `maybePrintCloudCta()`.

Closes #243