### PR TITLE
docs: add a GitLab CI example to the README (closes #231)

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,30 @@ jobs:
           set-status: false
 ```
 
+### GitLab CI
+
+Runs the same `test` scan on merge requests and on `main`, publishing the SARIF as a GitLab SAST report so findings appear in the merge request security widget. This matches what `setup-ci --ci-provider gitlab-ci` generates.
+
+```yaml
+# .gitlab-ci.yml
+mcp-observatory:
+  image: node:22
+  rules:
+    - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
+    - if: $CI_COMMIT_BRANCH == 'main'
+  script:
+    - npx @kryptosai/mcp-observatory test npx -y my-mcp-server --deep --security --sarif mcp-observatory.sarif
+  artifacts:
+    reports:
+      sast: mcp-observatory.sarif
+```
+
+Or let the CLI write it for you:
+
+```bash
+npx @kryptosai/mcp-observatory setup-ci --ci-provider gitlab-ci --command "npx -y my-mcp-server"
+```
+
 Action inputs:
 
 | Input | Description | Default |


### PR DESCRIPTION
Closes #231. Part of #221.

The README showed only a GitHub Actions workflow. Adds a `### GitLab CI` subsection with a ready-to-paste `.gitlab-ci.yml`, plus the `setup-ci` invocation that writes it for you.

### The snippet is generated, not hand-written

The issue's fourth point was that the example must match what `setup-ci` generates. Rather than eyeball it, I executed `gitlabCiYaml()` from `src/commands/init-ci.ts` for the `--command` form and pasted its exact output — so the README and the generator cannot drift apart.

```yaml
# .gitlab-ci.yml
mcp-observatory:
  image: node:22
  rules:
    - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
    - if: $CI_COMMIT_BRANCH == 'main'
  script:
    - npx @kryptosai/mcp-observatory test npx -y my-mcp-server --deep --security --sarif mcp-observatory.sarif
  artifacts:
    reports:
      sast: mcp-observatory.sarif
```

The description calls out that the SARIF is published as a GitLab **`sast`** report — that's what makes findings appear in the merge-request security widget rather than sitting in the job log, and it's the non-obvious part of the template.

Verified the embedded YAML parses (`yaml.safe_load`). Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)