### PR TITLE
Route free-user upgrade prompts into checkout

### DIFF
--- a/src/commercial.ts
+++ b/src/commercial.ts
@@ -5,6 +5,7 @@ import { getAccessToken, whoami } from "./auth.js";
 const CONTACT = "william@banksey.com";
 export const DEFAULT_CLOUD_UPLOAD_ENDPOINT = "https://app.mcp-observatory.com/api/v1/artifacts";
 export const DEFAULT_CLOUD_BASE_URL = "https://app.mcp-observatory.com";
+export const SELF_SERVE_PRICING_URL = `${DEFAULT_CLOUD_BASE_URL}/pricing`;
 
 export function getCloudBaseUrl(): string {
   return process.env["MCP_OBSERVATORY_CLOUD_URL"]?.trim() || DEFAULT_CLOUD_BASE_URL;
@@ -38,10 +39,13 @@ export function cloudUpgradeLine(context: "ci" | "security" | "fleet" | "general
         : context === "fleet"
           ? "MCP fleet visibility, drift reports, and production support"
           : "hosted reporting, security review, and enterprise support";
+  const plan = context === "ci" || context === "fleet" ? "team" : "individual";
+  const planLabel = plan === "team" ? "Team · $299/month" : "Individual Pro · $29/month";
 
   return [
     c(ANSI.dim, `  Production MCP teams: ${value}.`),
-    c(ANSI.dim, `  Run ${c(ANSI.cyan, `${bin} cloud`)} or contact ${CONTACT}.`),
+    c(ANSI.dim, `  Start ${c(ANSI.cyan, planLabel)}: ${c(ANSI.cyan, `${SELF_SERVE_PRICING_URL}?plan=${plan}`)}`),
+    c(ANSI.dim, `  Already subscribed? Run ${c(ANSI.cyan, `${bin} cloud login`)} to connect this CLI.`),
   ].join("\n");
 }
 
@@ -58,6 +62,11 @@ export function printCloudInfo(): void {
       "",
       "Free local OSS use remains available. Production teams can add hosted reporting,",
       "private-repo CI, security reports, certification, support, and MCP fleet visibility.",
+      "",
+      "Self-serve hosted plans:",
+      `  Individual Pro: $29/month — ${SELF_SERVE_PRICING_URL}?plan=individual`,
+      `  Team:           $299/month — ${SELF_SERVE_PRICING_URL}?plan=team`,
+      `  Already subscribed? Run ${getBinName()} cloud login to connect this CLI.`,
       "",
       "Pilot pricing:",
       "  Team Pilot:       starts at $299/month",

--- a/tests/commercial.test.ts
+++ b/tests/commercial.test.ts
@@ -45,7 +45,9 @@ describe("commercial cloud messaging", () => {
     expect(cloudUpgradeLine("security")).toContain("hosted security reports");
     expect(cloudUpgradeLine("fleet")).toContain("MCP fleet visibility");
     expect(cloudUpgradeLine("general")).toContain("hosted reporting");
-    expect(cloudUpgradeLine()).toContain("mcp-observatory cloud");
+    expect(cloudUpgradeLine()).toContain("https://app.mcp-observatory.com/pricing?plan=individual");
+    expect(cloudUpgradeLine("ci")).toContain("https://app.mcp-observatory.com/pricing?plan=team");
+    expect(cloudUpgradeLine()).toContain("mcp-observatory cloud login");
   });
 
   it("prints a CTA only when a cloud token is absent", () => {
@@ -85,6 +87,8 @@ describe("commercial cloud messaging", () => {
     printCloudInfo();
 
     expect(stdout.output()).toContain("MCP Observatory Cloud");
+    expect(stdout.output()).toContain("Individual Pro: $29/month");
+    expect(stdout.output()).toContain("pricing?plan=team");
     expect(stdout.output()).toContain("Team Pilot");
     expect(stdout.output()).toContain("cloud upload .mcp-observatory/runs/<run>.json");
     expect(stdout.output()).toContain("william@banksey.com");


### PR DESCRIPTION
Make the post-scan and post-CI CLI conversion path actionable. Context-specific prompts now link directly to Individual Pro or Team hosted checkout, and `cloud` now prints the self-serve plans plus the command to connect an existing subscription. Free local usage and quiet mode remain unchanged.

Validation: npm run typecheck; npm test -- --run tests/commercial.test.ts; git diff --check.