### PR TITLE
Publish CLI funnel patch 1.36.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kryptosai/mcp-observatory",
-  "version": "1.36.1",
+  "version": "1.36.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kryptosai/mcp-observatory",
-      "version": "1.36.1",
+      "version": "1.36.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kryptosai/mcp-observatory",
-  "version": "1.36.1",
+  "version": "1.36.5",
   "description": "MCP security scanner and CI gate. Test, secure, and monitor MCP servers with attack simulation, schema drift detection, health scoring, and SARIF before agents depend on them.",
   "mcpName": "io.github.KryptosAI/mcp-observatory",
   "license": "MIT",


### PR DESCRIPTION
Record the published CLI funnel release. The package now includes direct post-scan self-serve checkout prompts and cloud login guidance. Published as @kryptosai/mcp-observatory@1.36.5.