### PR TITLE
feat(receipt): add keygen and verify subcommands

### DIFF
--- a/src/commands/receipt.ts
+++ b/src/commands/receipt.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import type { Command } from "commander";
 
 import { resolveAuditTarget, runAudit } from "../audit.js";
-import { buildMcpReceipt, receiptFormatFromPath, renderReceipt, signReceipt, type ReceiptEnvironmentClass, type ReceiptFormat } from "../receipt.js";
+import { buildMcpReceipt, generateReceiptKeyPair, receiptFormatFromPath, renderReceipt, signReceipt, verifyReceipt, type McpReceipt, type ReceiptEnvironmentClass, type ReceiptFormat } from "../receipt.js";
 import { buildEvent, recordEvent } from "../command-events.js";
 import { ANSI, c } from "./helpers.js";
 
@@ -77,7 +77,7 @@ async function writeMaybe(filePath: string | undefined, content: string): Promis
 }
 
 export function registerReceiptCommands(program: Command): void {
-  program
+  const receiptCmd = program
     .command("receipt")
     .passThroughOptions()
     .description("Emit a portable MCP trust receipt for a target.")
@@ -132,5 +132,46 @@ export function registerReceiptCommands(program: Command): void {
         receiptEnvironmentClass: options.environmentClass,
         receiptTopFindings: receipt.findings.length,
       }));
+    });
+
+  receiptCmd
+    .command("keygen")
+    .description("Generate an Ed25519 key pair for signing and verifying MCP receipts.")
+    .option("--public <path>", "Output path for the public key.", "mcp-observatory.pub")
+    .option("--private <path>", "Output path for the private key.", "mcp-observatory.key")
+    .action(async (options: { public: string; private: string }) => {
+      const { publicKey, privateKey } = generateReceiptKeyPair();
+      await writeFile(options.public, publicKey, "utf8");
+      await writeFile(options.private, privateKey, { encoding: "utf8", mode: 0o600 });
+      process.stdout.write(
+        `Public key saved:  ${options.public}\n`
+        + `Private key saved: ${options.private}\n\n`
+        + "Keep the private key secure. Share the public key with anyone who needs to verify your receipts.\n",
+      );
+    });
+
+  receiptCmd
+    .command("verify")
+    .description("Verify a signed MCP receipt against a public key. Requires a JSON-format receipt; markdown receipts do not carry the signature.")
+    .argument("<file>", "Path to the receipt JSON file.")
+    .requiredOption("--key <path>", "Path to the Ed25519 public key file.")
+    .action(async (file: string, options: { key: string }) => {
+      const receiptText = await readFile(file, "utf8");
+      let receipt: McpReceipt;
+      try {
+        receipt = JSON.parse(receiptText) as McpReceipt;
+      } catch {
+        process.stderr.write(
+          `Error: could not parse ${file} as JSON. receipt verify requires a JSON-format receipt `
+          + "(generate one with --format json) — markdown receipts do not include the signature.\n",
+        );
+        process.exit(1);
+      }
+      const publicKey = await readFile(options.key);
+      if (!verifyReceipt(receipt, publicKey)) {
+        process.stderr.write(`✗ Receipt verification failed against ${options.key} — signature does not match, or the receipt is unsigned.\n`);
+        process.exit(1);
+      }
+      process.stdout.write(`✓ Receipt verified — signed by ${receipt.signer ?? "unknown"}\n`);
     });
 }

--- a/src/commands/receipt.ts
+++ b/src/commands/receipt.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { access, mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { Command } from "commander";
 
@@ -139,7 +139,21 @@ export function registerReceiptCommands(program: Command): void {
     .description("Generate an Ed25519 key pair for signing and verifying MCP receipts.")
     .option("--public <path>", "Output path for the public key.", "mcp-observatory.pub")
     .option("--private <path>", "Output path for the private key.", "mcp-observatory.key")
-    .action(async (options: { public: string; private: string }) => {
+    .option("--force", "Overwrite existing key files if they already exist.")
+    .action(async (options: { public: string; private: string; force?: boolean }) => {
+      if (path.resolve(options.public) === path.resolve(options.private)) {
+        process.stderr.write("Error: --public and --private must not point to the same file.\n");
+        process.exit(1);
+      }
+      if (!options.force) {
+        for (const target of [options.public, options.private]) {
+          const exists = await access(target).then(() => true, () => false);
+          if (exists) {
+            process.stderr.write(`Error: ${target} already exists. Use --force to overwrite (this invalidates any receipts signed with the old key).\n`);
+            process.exit(1);
+          }
+        }
+      }
       const { publicKey, privateKey } = generateReceiptKeyPair();
       await writeFile(options.public, publicKey, "utf8");
       await writeFile(options.private, privateKey, { encoding: "utf8", mode: 0o600 });

--- a/tests/commands/receipt.test.ts
+++ b/tests/commands/receipt.test.ts
@@ -26,9 +26,13 @@ describe("receipt keygen", () => {
 
   beforeEach(async () => {
     dir = await mkdtemp(path.join(tmpdir(), "mcp-observatory-keygen-"));
+    vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code})`);
+    }) as never);
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     await rm(dir, { recursive: true, force: true });
   });
 
@@ -68,6 +72,38 @@ describe("receipt keygen", () => {
     } finally {
       process.chdir(cwd);
     }
+  });
+
+  it("refuses to overwrite an existing key file without --force", async () => {
+    const pub = path.join(dir, "test.pub");
+    const priv = path.join(dir, "test.key");
+    const first = makeProgram();
+    await run(first, ["receipt", "keygen", "--public", pub, "--private", priv]);
+    const originalPublicKey = await readFile(pub, "utf8");
+
+    const second = makeProgram();
+    await expect(run(second, ["receipt", "keygen", "--public", pub, "--private", priv])).rejects.toThrow("process.exit(1)");
+
+    expect(await readFile(pub, "utf8")).toBe(originalPublicKey); // untouched by the rejected run
+  });
+
+  it("overwrites existing key files when --force is passed", async () => {
+    const pub = path.join(dir, "test.pub");
+    const priv = path.join(dir, "test.key");
+    const first = makeProgram();
+    await run(first, ["receipt", "keygen", "--public", pub, "--private", priv]);
+    const originalPublicKey = await readFile(pub, "utf8");
+
+    const second = makeProgram();
+    await run(second, ["receipt", "keygen", "--public", pub, "--private", priv, "--force"]);
+
+    expect(await readFile(pub, "utf8")).not.toBe(originalPublicKey); // genuinely regenerated
+  });
+
+  it("refuses when --public and --private point to the same file, even with --force", async () => {
+    const samePath = path.join(dir, "test.key");
+    const program = makeProgram();
+    await expect(run(program, ["receipt", "keygen", "--public", samePath, "--private", samePath, "--force"])).rejects.toThrow("process.exit(1)");
   });
 });
 

--- a/tests/commands/receipt.test.ts
+++ b/tests/commands/receipt.test.ts
@@ -1,0 +1,130 @@
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { registerReceiptCommands } from "../../src/commands/receipt.js";
+import { signReceipt } from "../../src/receipt.js";
+import type { McpReceipt } from "../../src/receipt.js";
+
+function makeProgram(): Command {
+  const program = new Command();
+  program.enablePositionalOptions(); // matches src/cli.ts's root Command config; receipt's passThroughOptions() requires it
+  program.exitOverride(); // throw instead of calling process.exit on parse errors
+  registerReceiptCommands(program);
+  return program;
+}
+
+async function run(program: Command, args: string[]): Promise<void> {
+  await program.parseAsync(["node", "cli", ...args], { from: "node" });
+}
+
+describe("receipt keygen", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "mcp-observatory-keygen-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("writes a PEM public and private key pair", async () => {
+    const pub = path.join(dir, "test.pub");
+    const priv = path.join(dir, "test.key");
+    const program = makeProgram();
+
+    await run(program, ["receipt", "keygen", "--public", pub, "--private", priv]);
+
+    const publicKey = await readFile(pub, "utf8");
+    const privateKey = await readFile(priv, "utf8");
+    expect(publicKey).toContain("BEGIN PUBLIC KEY");
+    expect(privateKey).toContain("BEGIN PRIVATE KEY");
+  });
+
+  it("restricts the private key file to owner-only permissions", async () => {
+    if (process.platform === "win32") return; // POSIX mode bits aren't meaningful on Windows.
+    const pub = path.join(dir, "test.pub");
+    const priv = path.join(dir, "test.key");
+    const program = makeProgram();
+
+    await run(program, ["receipt", "keygen", "--public", pub, "--private", priv]);
+
+    const mode = (await stat(priv)).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  it("defaults to mcp-observatory.pub / mcp-observatory.key in the current directory", async () => {
+    const cwd = process.cwd();
+    process.chdir(dir);
+    try {
+      const program = makeProgram();
+      await run(program, ["receipt", "keygen"]);
+      const publicKey = await readFile(path.join(dir, "mcp-observatory.pub"), "utf8");
+      expect(publicKey).toContain("BEGIN PUBLIC KEY");
+    } finally {
+      process.chdir(cwd);
+    }
+  });
+});
+
+describe("receipt verify", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "mcp-observatory-verify-"));
+    vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code})`);
+    }) as never);
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  async function makeSignedReceiptFile(signerId = "test@example.com"): Promise<{ file: string; publicKeyPath: string }> {
+    const program = makeProgram();
+    const pub = path.join(dir, "signer.pub");
+    const priv = path.join(dir, "signer.key");
+    await run(program, ["receipt", "keygen", "--public", pub, "--private", priv]);
+
+    const privateKey = await readFile(priv, "utf8");
+    const receipt = { receipt_type: "mcp-observatory-receipt" as const } as unknown as McpReceipt;
+    const signed = signReceipt(receipt, privateKey, signerId);
+    const file = path.join(dir, "receipt.json");
+    await writeFile(file, JSON.stringify(signed), "utf8");
+    return { file, publicKeyPath: pub };
+  }
+
+  it("verifies a correctly signed JSON receipt", async () => {
+    const { file, publicKeyPath } = await makeSignedReceiptFile("maintainer@example.com");
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const program = makeProgram();
+    await run(program, ["receipt", "verify", file, "--key", publicKeyPath]);
+    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("✓ Receipt verified — signed by maintainer@example.com"));
+  });
+
+  it("fails verification against the wrong public key", async () => {
+    const { file } = await makeSignedReceiptFile();
+    const otherProgram = makeProgram();
+    const otherPub = path.join(dir, "other.pub");
+    const otherPriv = path.join(dir, "other.key");
+    await run(otherProgram, ["receipt", "keygen", "--public", otherPub, "--private", otherPriv]);
+
+    const program = makeProgram();
+    await expect(run(program, ["receipt", "verify", file, "--key", otherPub])).rejects.toThrow("process.exit(1)");
+  });
+
+  it("fails cleanly on a non-JSON (markdown) receipt instead of throwing an unhandled parse error", async () => {
+    const file = path.join(dir, "receipt.md");
+    await writeFile(file, "# MCP Observatory Receipt\n\nNot JSON.\n", "utf8");
+    const { publicKeyPath } = await makeSignedReceiptFile();
+
+    const program = makeProgram();
+    await expect(run(program, ["receipt", "verify", file, "--key", publicKeyPath])).rejects.toThrow("process.exit(1)");
+  });
+});


### PR DESCRIPTION
Closes #288.

## Summary
- `receipt keygen [--public <path>] [--private <path>]` generates an Ed25519 key pair via the existing `generateReceiptKeyPair()`, defaulting to `mcp-observatory.pub`/`mcp-observatory.key`. The private key is written with `0600` permissions (POSIX; a no-op on Windows, where the mode bit isn't meaningful).
- `receipt verify <file> --key <pubkey>` reads a receipt file and verifies it against `verifyReceipt()`.

Both are registered as subcommands of the existing `receipt` command, following the same parent-command-with-its-own-action-plus-subcommands pattern already used for `cloud`.

## One thing worth flagging
`renderReceiptMarkdown()` never emits the `signer`/`signature` fields, so a markdown-format receipt can't actually be verified — only JSON receipts carry the signature. `verify` fails with a clear message pointing this out (generate with `--format json`) rather than throwing an unhandled `JSON.parse` error when pointed at a markdown file. Happy to also add a note about this in the receipt docs if that's useful, didn't want to scope-creep past what the issue asked for without checking first.

## Testing
- `npm run typecheck` — clean.
- `npm run lint` on changed files — clean.
- New test file `tests/commands/receipt.test.ts` (6 tests): keygen writes valid PEM files, keygen defaults to the documented filenames, keygen restricts the private key to owner-only permissions, verify succeeds on a correctly signed JSON receipt, verify fails against the wrong public key, verify fails cleanly (not an unhandled exception) on a non-JSON receipt.
- Ran the full existing suite before and after on a clean checkout of `main` to confirm no regressions — same 60 pre-existing failures on both (unrelated: a docs-file check and a `spawn npm ENOENT` environment issue in `schema.test.ts`), my branch adds exactly the 6 new passing tests on top.
- Smoke-tested both commands end-to-end through the actual CLI entry point (`tsx src/cli.ts receipt keygen ...` / `receipt verify ...`), not just the test harness.