### PR TITLE
feat: n8n Safety Index target, receipt signer binding, roadmap hygiene

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "typescript"
+        versions: [">=6"]
     groups:
       dev-tooling:
         dependency-type: "development"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,9 +35,7 @@ Good contributions make the evidence clearer. Weak contributions usually add sur
 
 - Add one safe MCP target to the [MCP Target Registry](./docs/target-registry.md)
 - Follow the [Target Contribution Guide](./docs/target-contribution-guide.md) for a small first PR with evidence
-- [#3 Improve artifact output readability in the Markdown report](https://github.com/KryptosAI/mcp-observatory/issues/3)
-- [#6 Improve CLI startup error messaging for connection and setup failures](https://github.com/KryptosAI/mcp-observatory/issues/6)
-- [#1](https://github.com/KryptosAI/mcp-observatory/issues/1) and [#2](https://github.com/KryptosAI/mcp-observatory/issues/2) once a concrete passing server is identified
+- Pick from open [good first issues](https://github.com/KryptosAI/mcp-observatory/issues?q=is%3Aopen+label%3A%22good+first+issue%22) or [roadmap issues](https://github.com/KryptosAI/mcp-observatory/issues?q=is%3Aopen+label%3Aroadmap), tracked against the [ROADMAP](./ROADMAP.md)
 
 ## What Will Probably Be Declined
 
@@ -104,7 +102,7 @@ When you add a fixture:
 - prefer explicit evidence over clever test machinery
 - document what the fixture is proving and why it matters
 
-The `fixture contribution` issue template is the best starting point for proposing a new case.
+Propose the new case in a regular GitHub issue (blank issues are enabled), or use the [MCP target contribution](https://github.com/KryptosAI/mcp-observatory/issues/new?template=target-contribution.yml) template when the fixture backs a Safety Index target.
 
 ## Target Registry Contributions
 

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -10,7 +10,7 @@
 
 - [中文 README](README.zh-CN.md) — 简体中文文档
 - 欢迎提交中文 issues 和 PRs
-- 我们使用 `新手友好` 标签标注适合新手的任务
+- 我们使用 `good first issue`（新手友好）标签标注适合新手的任务
 - Gitee 镜像: https://gitee.com/williamweishuhn/mcp-observatory
 
 ## 5 分钟快速开始
@@ -40,9 +40,7 @@ npm run lint      # 约5秒，干净通过
 
 - 向 [MCP Target Registry](./docs/target-registry.md) 添加一个安全的 MCP 目标
 - 按照 [Target Contribution Guide](./docs/target-contribution-guide.md) 提交带证据的小型首次 PR
-- [#3 改善 artifact 输出在 Markdown 报告中的可读性](https://github.com/KryptosAI/mcp-observatory/issues/3)
-- [#6 改善 CLI 启动错误消息，覆盖连接和配置失败场景](https://github.com/KryptosAI/mcp-observatory/issues/6)
-- [#1](https://github.com/KryptosAI/mcp-observatory/issues/1) 和 [#2](https://github.com/KryptosAI/mcp-observatory/issues/2)，在确定一个通过测试的服务器后推进
+- 从开放的 [good first issue](https://github.com/KryptosAI/mcp-observatory/issues?q=is%3Aopen+label%3A%22good+first+issue%22) 或 [roadmap issue](https://github.com/KryptosAI/mcp-observatory/issues?q=is%3Aopen+label%3Aroadmap) 中挑选，对照 [ROADMAP](./ROADMAP.md) 推进
 
 ## 可能不会被接受的贡献
 
@@ -109,7 +107,7 @@ npm run integration:real
 - 偏好明确的证据而非巧妙的测试技巧
 - 记录这个 fixture 在证明什么、为什么重要
 
-`fixture contribution` issue 模板是提出新案例的最佳起点。
+通过普通 GitHub issue（已启用空白 issue）提出新案例，或当 fixture 支撑某个 Safety Index 目标时使用 [MCP target contribution](https://github.com/KryptosAI/mcp-observatory/issues/new?template=target-contribution.yml) 模板。
 
 ## Target Registry 贡献
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,103 @@
+# Roadmap
+
+Where MCP Observatory goes now that the Safety Index bet paid off, and where
+each kind of work lives.
+
+---
+
+## The Pivot
+
+The Safety Index target is met: 100+ entries, 175 targets live. The index was
+the proof. Now the work splits by where it belongs.
+
+- **Local OSS** is the portable evidence engine. Scan, receipts, scoring,
+  attack simulation, CI gates. MIT, no account, runs anywhere.
+- **Hosted (cloud)** is the trust registry and compliance layer.
+  Multi-observer verification, fleet workflows, framework mappings. Not OSS.
+
+OSS produces evidence. Hosted turns evidence into registry trust and
+compliance workflows. Boundary:
+[docs/commercial-boundary.md](docs/commercial-boundary.md) and
+[docs/repository-boundary.md](docs/repository-boundary.md).
+
+---
+
+## Epics
+
+Closed issues are absorbed here. Closed means rehomed, not dropped.
+
+### 1. Trust / Registry
+
+Absorbs #166 (Safety Index at scale) and #170 (observer network).
+
+- Multi-observer receipts: each server gets receipts from independent
+  observers, not one run.
+- Observer identity: receipts are signed and attributable to a verifiable
+  observer.
+- Consensus scoring: the Safety Index score is the median across observers,
+  not a single run.
+- Trust tiers: servers grouped by evidence depth.
+- Observer reputation: a lightweight model that rewards qualified observers.
+
+Hosted v3 work. OSS keeps local Ed25519 receipts and verification. The
+multi-observer network and the registry itself live in the hosted product.
+
+### 2. Research
+
+Absorbs #167 (fuzzing engine) and #224 (agent behavior simulation).
+
+- Schema-aware fuzzing: adversarial inputs against tool schemas in a
+  sandboxed, non-destructive harness.
+- Agent behavior simulation: a controlled LLM sandbox observing what an
+  agent actually does with a tool, to catch injection paths and misuse.
+
+Safe-mode research bets. No timeline. Results ship only when they are
+safe-mode, reproducible, and backed by checked-in evidence. Destructive or
+live probing stays out of the default scanner.
+
+### 3. Compliance
+
+Absorbs #173 (framework audit mappings).
+
+- SOC 2, ISO 27001, FedRAMP, PCI-DSS, GDPR, HIPAA profiles mapping findings
+  to controls.
+
+Commercial v2. OSS keeps exactly one profile: nsa-mcp. The remaining
+framework profiles and the hosted compliance workflows ship in the
+commercial product.
+
+### 4. Growth
+
+Absorbs #222 (community challenges).
+
+- Monthly challenges: Scan Storm (most servers scanned) and Vuln Hunter
+  (highest severity finding).
+- Public leaderboard generated from merged PRs. Recognition badges.
+
+Non-engineering program. It runs on the existing scan and attack-simulation
+command surface and is owned outside the codebase.
+
+---
+
+## Near-term OSS
+
+Live issues, in priority order.
+
+- **Gate-check policy enforcement** — #353 (slice of #164): policy-as-code
+  file, preflight `gate-check` before an agent connects, fail closed.
+- **Cloud device flow** — #352: `cloud login` speaks the live `/auth/device`
+  endpoints and auto-opens the URL. Makes hosted signup a real flow.
+- **Shell completions** — #257: zsh and bash tab completion generated from
+  the Commander tree (not a hand-maintained command list).
+- **Receipt signer binding** — shipped: `signer` is part of the signed
+  receipt bytes and `receipt verify` prints a public key fingerprint.
+
+## Not in OSS
+
+- trust registry and multi-observer network (hosted v3)
+- compliance profiles beyond nsa-mcp (commercial v2)
+- fuzzing and agent simulation engines (research, safe-mode only)
+- hosted auth, retention, fleet coordination, private indexes
+
+The public repo must stay runnable without a hosted account or private
+credentials.

--- a/docs/mcp-receipts.md
+++ b/docs/mcp-receipts.md
@@ -99,6 +99,18 @@ Supported `environment_class` values:
 - `public_safety_index`
 - `private_fleet`
 
+## Signing And Verification
+
+Receipts can be signed with an Ed25519 key pair so downstream systems can prove who produced a receipt and detect tampering:
+
+```bash
+mcp-observatory receipt keygen --public mcp-observatory.pub --private mcp-observatory.key
+mcp-observatory receipt npx -y my-mcp-server --format json --output receipt.json --sign-key mcp-observatory.key --signer "your-org"
+mcp-observatory receipt verify receipt.json --key mcp-observatory.pub
+```
+
+The signature covers the entire receipt except the `signature` field itself; the `signer` identity label is part of the signed bytes, so rewriting the signer invalidates the signature. Signing requires `--format json` — markdown receipts do not carry a signature. Keep the private key secure and share only the public key. Verify prints the signer plus a truncated SHA-256 fingerprint of the public key so key identity can be confirmed out of band. Do not hand-edit or re-serialize signed JSON: canonicalization is field-order sensitive.
+
 ## Safe-Mode Guarantee
 
 Receipts inherit the same safe-mode posture as the audit and attack-simulation flow. MCP Observatory inspects metadata, schemas, startup behavior, and inert attack-readiness evidence. It does not execute destructive payloads, exfiltrate secrets, or contact attacker-controlled callbacks.

--- a/docs/mcp-server-safety-index.md
+++ b/docs/mcp-server-safety-index.md
@@ -10,12 +10,12 @@ For the rules behind this page, see the [Safety Methodology](./methodology.md) a
 
 ## Snapshot
 
-- Evaluated servers: 175
-- Ready for CI: 24
+- Evaluated servers: 176
+- Ready for CI: 25
 - Needs review before production: 11
 - Unsafe default posture: 14
 - Not reproducible: 126
-- Latest run: 2026-07-22T21:37:06.047Z
+- Latest run: 2026-08-21T00:14:17.871Z
 
 ## Evaluations
 
@@ -196,6 +196,7 @@ For the rules behind this page, see the [Safety Methodology](./methodology.md) a
 | 173 | [Daraz MCP](https://github.com/shaheedghazi/daraz-mcp) | E-commerce | **Not reproducible** | `rerun` | Product/order/seller boundary | `npx -y daraz-mcp` | `npx @kryptosai/mcp-observatory setup-ci --all --command "npx -y daraz-mcp" --sarif --schedule weekly` | [JSON](./safety-index/artifacts/daraz-mcp.json) / [report](./safety-index/artifacts/daraz-mcp.md) | Schema-only evaluation; requires Daraz Open Platform API credentials. Community package — exact npm name pending verification. |
 | 174 | [OLX Pakistan MCP](https://www.npmjs.com/package/olx-pakistan-mcp) | Classifieds | **Not reproducible** | `rerun` | Listing/ad/user boundary | `npx -y olx-pakistan-mcp` | `npx @kryptosai/mcp-observatory setup-ci --all --command "npx -y olx-pakistan-mcp" --sarif --schedule weekly` | [JSON](./safety-index/artifacts/olx-pakistan-mcp.json) / [report](./safety-index/artifacts/olx-pakistan-mcp.md) | Schema-only evaluation; requires OLX Pakistan API credentials. Community package — exact npm name pending verification. |
 | 175 | [PakWheels MCP](https://www.npmjs.com/package/pakwheels-mcp) | Auto Marketplace | **Not reproducible** | `rerun` | Vehicle/listing/dealer boundary | `npx -y pakwheels-mcp` | `npx @kryptosai/mcp-observatory setup-ci --all --command "npx -y pakwheels-mcp" --sarif --schedule weekly` | [JSON](./safety-index/artifacts/pakwheels-mcp.json) / [report](./safety-index/artifacts/pakwheels-mcp.md) | Schema-only evaluation; requires PakWheels API credentials. Community package — exact npm name pending verification. |
+| 176 | [n8n MCP](https://github.com/czlonkowski/n8n-mcp) | Agent Runtime / Automation | **Ready for CI** | `allow` | Workflow mutation/execution boundary | `npx -y n8n-mcp` | `npx @kryptosai/mcp-observatory setup-ci --all --command "npx -y n8n-mcp" --sarif --schedule weekly` | [JSON](./safety-index/artifacts/n8n-mcp.json) / [report](./safety-index/artifacts/n8n-mcp.md) | Runs in docs-only mode without N8N_API_URL/N8N_API_KEY and lists node documentation/search tools; the 16 workflow-management tools require n8n API configuration and are not exercised. |
 
 ## Patterns Observed
 
@@ -367,6 +368,7 @@ For the rules behind this page, see the [Safety Methodology](./methodology.md) a
 - Web search/reader boundary: 1 server(s)
 - Web search/result boundary: 1 server(s)
 - Work item/repo/pipeline boundary: 1 server(s)
+- Workflow mutation/execution boundary: 1 server(s)
 - Write/merge tool boundary: 1 server(s)
 
 ## Publication Rules

--- a/docs/safety-index/artifacts/n8n-mcp.json
+++ b/docs/safety-index/artifacts/n8n-mcp.json
@@ -1,0 +1,714 @@
+{
+  "artifactType": "run",
+  "schemaVersion": "1.0.0",
+  "gate": "pass",
+  "runId": "run_2026-08-21T001417870Z_0659ddb9",
+  "createdAt": "2026-08-21T00:14:17.871Z",
+  "toolVersion": "1.37.1",
+  "target": {
+    "targetId": "n8n-mcp",
+    "adapter": "local-process",
+    "command": "npx",
+    "args": [
+      "-y",
+      "n8n-mcp"
+    ],
+    "cwd": ".",
+    "metadata": {
+      "package": "n8n-mcp",
+      "purpose": "mcp-safety-index",
+      "riskClass": "Workflow automation surface",
+      "failureClass": "Workflow mutation/execution boundary",
+      "whyItMatters": "Agents may use n8n MCP to browse node documentation and, with credentials, create or execute workflow automations; the credential-free surface should be explicit before agents rely on it."
+    },
+    "serverName": "n8n-documentation-mcp",
+    "serverVersion": "2.73.0"
+  },
+  "environment": {
+    "platform": "darwin 25.5.0",
+    "nodeVersion": "v22.23.1"
+  },
+  "summary": {
+    "total": 9,
+    "pass": 7,
+    "fail": 0,
+    "partial": 1,
+    "unsupported": 1,
+    "flaky": 0,
+    "skipped": 0,
+    "gate": "pass"
+  },
+  "checks": [
+    {
+      "id": "tools",
+      "capability": "tools",
+      "status": "pass",
+      "durationMs": 8.865999999999985,
+      "message": "Advertised capability responded with the minimal expected shape (7 items).",
+      "evidence": [
+        {
+          "endpoint": "tools/list",
+          "advertised": true,
+          "responded": true,
+          "minimalShapePresent": true,
+          "itemCount": 7,
+          "identifiers": [
+            "tools_documentation",
+            "search_nodes",
+            "get_node",
+            "validate_node",
+            "get_template",
+            "search_templates",
+            "validate_workflow"
+          ],
+          "diagnostics": [
+            "║                                                             ║",
+            "║  Learn more:                                               ║",
+            "║  https://github.com/czlonkowski/n8n-mcp/blob/main/PRIVACY.md ║",
+            "║                                                             ║",
+            "╚════════════════════════════════════════════════════════════╝"
+          ],
+          "schemas": {
+            "tools_documentation": {
+              "type": "object",
+              "properties": {
+                "topic": {
+                  "type": "string",
+                  "description": "Tool name (e.g., \"search_nodes\") or \"overview\" for general guide. Leave empty for quick reference."
+                },
+                "depth": {
+                  "type": "string",
+                  "enum": [
+                    "essentials",
+                    "full"
+                  ],
+                  "description": "Level of detail. \"essentials\" (default) for quick reference, \"full\" for comprehensive docs.",
+                  "default": "essentials"
+                }
+              }
+            },
+            "search_nodes": {
+              "type": "object",
+              "properties": {
+                "query": {
+                  "type": "string",
+                  "description": "Search terms. Use quotes for exact phrase."
+                },
+                "limit": {
+                  "type": "number",
+                  "description": "Max results (default 20)",
+                  "default": 20
+                },
+                "mode": {
+                  "type": "string",
+                  "enum": [
+                    "OR",
+                    "AND",
+                    "FUZZY"
+                  ],
+                  "description": "OR=any word, AND=all words, FUZZY=typo-tolerant",
+                  "default": "OR"
+                },
+                "includeExamples": {
+                  "type": "boolean",
+                  "description": "Include top 2 real-world configuration examples from popular templates (default: false)",
+                  "default": false
+                },
+                "includeOperations": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Include resource/operation tree per node. Adds ~100-300 tokens per result but saves a get_node round-trip."
+                },
+                "source": {
+                  "type": "string",
+                  "enum": [
+                    "all",
+                    "core",
+                    "community",
+                    "verified"
+                  ],
+                  "description": "Filter by node source: all=everything (default), core=n8n base nodes, community=community nodes, verified=verified community nodes only",
+                  "default": "all"
+                }
+              },
+              "required": [
+                "query"
+              ]
+            },
+            "get_node": {
+              "type": "object",
+              "properties": {
+                "nodeType": {
+                  "type": "string",
+                  "description": "Full node type: \"nodes-base.httpRequest\" or \"nodes-langchain.agent\""
+                },
+                "detail": {
+                  "type": "string",
+                  "enum": [
+                    "minimal",
+                    "standard",
+                    "full"
+                  ],
+                  "default": "standard",
+                  "description": "Information detail level. standard=essential properties (recommended), full=everything"
+                },
+                "mode": {
+                  "type": "string",
+                  "enum": [
+                    "info",
+                    "docs",
+                    "search_properties",
+                    "versions",
+                    "compare",
+                    "breaking",
+                    "migrations"
+                  ],
+                  "default": "info",
+                  "description": "Operation mode. info=node schema, docs=readable markdown documentation, search_properties=find specific properties, versions/compare/breaking/migrations=version info"
+                },
+                "includeTypeInfo": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Include type structure metadata (type category, JS type, validation rules). Only applies to mode=info. Adds ~80-120 tokens per property."
+                },
+                "includeExamples": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Include real-world configuration examples from templates. Only applies to mode=info with detail=standard. Adds ~200-400 tokens per example."
+                },
+                "fromVersion": {
+                  "type": "string",
+                  "description": "Source version for compare/breaking/migrations modes (e.g., \"1.0\")"
+                },
+                "toVersion": {
+                  "type": "string",
+                  "description": "Target version for compare mode (e.g., \"2.0\"). Defaults to latest if omitted."
+                },
+                "propertyQuery": {
+                  "type": "string",
+                  "description": "For mode=search_properties: search term to find properties (e.g., \"auth\", \"header\", \"body\")"
+                },
+                "maxPropertyResults": {
+                  "type": "number",
+                  "description": "For mode=search_properties: max results (default 20)",
+                  "default": 20
+                }
+              },
+              "required": [
+                "nodeType"
+              ]
+            },
+            "validate_node": {
+              "type": "object",
+              "properties": {
+                "nodeType": {
+                  "type": "string",
+                  "description": "Node type as string. Example: \"nodes-base.slack\""
+                },
+                "config": {
+                  "type": "object",
+                  "description": "Configuration as object. For simple nodes use {}. For complex nodes include fields like {resource:\"channel\",operation:\"create\"}"
+                },
+                "mode": {
+                  "type": "string",
+                  "enum": [
+                    "full",
+                    "minimal"
+                  ],
+                  "description": "Validation mode. full=comprehensive validation with errors/warnings/suggestions, minimal=quick required fields check only. Default is \"full\"",
+                  "default": "full"
+                },
+                "profile": {
+                  "type": "string",
+                  "enum": [
+                    "strict",
+                    "runtime",
+                    "ai-friendly",
+                    "minimal"
+                  ],
+                  "description": "Profile for mode=full: \"minimal\", \"runtime\", \"ai-friendly\", or \"strict\". Default is \"ai-friendly\"",
+                  "default": "ai-friendly"
+                }
+              },
+              "required": [
+                "nodeType",
+                "config"
+              ],
+              "additionalProperties": false
+            },
+            "get_template": {
+              "type": "object",
+              "properties": {
+                "templateId": {
+                  "type": "number",
+                  "description": "The template ID to retrieve"
+                },
+                "mode": {
+                  "type": "string",
+                  "enum": [
+                    "nodes_only",
+                    "structure",
+                    "full"
+                  ],
+                  "description": "Response detail level. nodes_only: just node list, structure: nodes+connections, full: complete workflow JSON.",
+                  "default": "full"
+                }
+              },
+              "required": [
+                "templateId"
+              ]
+            },
+            "search_templates": {
+              "type": "object",
+              "properties": {
+                "searchMode": {
+                  "type": "string",
+                  "enum": [
+                    "keyword",
+                    "by_nodes",
+                    "by_task",
+                    "by_metadata",
+                    "patterns"
+                  ],
+                  "description": "Search mode. keyword=text search (default), by_nodes=find by node types, by_task=curated task templates, by_metadata=filter by complexity/services, patterns=lightweight workflow pattern summaries",
+                  "default": "keyword"
+                },
+                "query": {
+                  "type": "string",
+                  "description": "For searchMode=keyword: search keyword (e.g., \"chatbot\")"
+                },
+                "fields": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "id",
+                      "name",
+                      "description",
+                      "author",
+                      "nodes",
+                      "views",
+                      "created",
+                      "url",
+                      "metadata"
+                    ]
+                  },
+                  "description": "For searchMode=keyword: fields to include in response. Default: all fields."
+                },
+                "nodeTypes": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "For searchMode=by_nodes: array of node types (e.g., [\"n8n-nodes-base.httpRequest\", \"n8n-nodes-base.slack\"])"
+                },
+                "task": {
+                  "type": "string",
+                  "enum": [
+                    "ai_automation",
+                    "data_sync",
+                    "webhook_processing",
+                    "email_automation",
+                    "slack_integration",
+                    "data_transformation",
+                    "file_processing",
+                    "scheduling",
+                    "api_integration",
+                    "database_operations"
+                  ],
+                  "description": "For searchMode=by_task: the type of task. For searchMode=patterns: optional category filter (omit for overview of all categories)."
+                },
+                "category": {
+                  "type": "string",
+                  "description": "For searchMode=by_metadata: filter by category (e.g., \"automation\", \"integration\")"
+                },
+                "complexity": {
+                  "type": "string",
+                  "enum": [
+                    "simple",
+                    "medium",
+                    "complex"
+                  ],
+                  "description": "For searchMode=by_metadata: filter by complexity level"
+                },
+                "maxSetupMinutes": {
+                  "type": "number",
+                  "description": "For searchMode=by_metadata: maximum setup time in minutes",
+                  "minimum": 5,
+                  "maximum": 480
+                },
+                "minSetupMinutes": {
+                  "type": "number",
+                  "description": "For searchMode=by_metadata: minimum setup time in minutes",
+                  "minimum": 5,
+                  "maximum": 480
+                },
+                "requiredService": {
+                  "type": "string",
+                  "description": "For searchMode=by_metadata: filter by required service (e.g., \"openai\", \"slack\")"
+                },
+                "targetAudience": {
+                  "type": "string",
+                  "description": "For searchMode=by_metadata: filter by target audience (e.g., \"developers\", \"marketers\")"
+                },
+                "limit": {
+                  "type": "number",
+                  "description": "Maximum number of results. Default 20.",
+                  "default": 20,
+                  "minimum": 1,
+                  "maximum": 100
+                },
+                "offset": {
+                  "type": "number",
+                  "description": "Pagination offset. Default 0.",
+                  "default": 0,
+                  "minimum": 0
+                }
+              }
+            },
+            "validate_workflow": {
+              "type": "object",
+              "properties": {
+                "workflow": {
+                  "type": "object",
+                  "description": "The complete workflow JSON to validate. Must include nodes array and connections object."
+                },
+                "options": {
+                  "type": "object",
+                  "properties": {
+                    "validateNodes": {
+                      "type": "boolean",
+                      "description": "Validate individual node configurations. Default true.",
+                      "default": true
+                    },
+                    "validateConnections": {
+                      "type": "boolean",
+                      "description": "Validate node connections and flow. Default true.",
+                      "default": true
+                    },
+                    "validateExpressions": {
+                      "type": "boolean",
+                      "description": "Validate n8n expressions syntax and references. Default true.",
+                      "default": true
+                    },
+                    "profile": {
+                      "type": "string",
+                      "enum": [
+                        "minimal",
+                        "runtime",
+                        "ai-friendly",
+                        "strict"
+                      ],
+                      "description": "Validation profile for node validation. Default \"runtime\".",
+                      "default": "runtime"
+                    }
+                  },
+                  "description": "Optional validation settings"
+                }
+              },
+              "required": [
+                "workflow"
+              ],
+              "additionalProperties": false
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "prompts",
+      "capability": "prompts",
+      "status": "unsupported",
+      "durationMs": 0.0038340000000971486,
+      "message": "Prompts are not advertised by the target.",
+      "evidence": [
+        {
+          "endpoint": "prompts/list",
+          "advertised": false,
+          "responded": false,
+          "minimalShapePresent": false,
+          "diagnostics": []
+        }
+      ]
+    },
+    {
+      "id": "resources",
+      "capability": "resources",
+      "status": "pass",
+      "durationMs": 1.7775830000000497,
+      "message": "Advertised capability responded with the minimal expected shape (2 items).",
+      "evidence": [
+        {
+          "endpoint": "resources/list",
+          "advertised": true,
+          "responded": true,
+          "minimalShapePresent": true,
+          "itemCount": 2,
+          "identifiers": [
+            "ui://n8n-mcp/operation-result",
+            "ui://n8n-mcp/validation-summary"
+          ],
+          "diagnostics": [
+            "║                                                             ║",
+            "║  Learn more:                                               ║",
+            "║  https://github.com/czlonkowski/n8n-mcp/blob/main/PRIVACY.md ║",
+            "║                                                             ║",
+            "╚════════════════════════════════════════════════════════════╝"
+          ]
+        },
+        {
+          "endpoint": "resources/templates/list",
+          "advertised": true,
+          "responded": true,
+          "minimalShapePresent": true,
+          "itemCount": 0,
+          "identifiers": [],
+          "diagnostics": [
+            "║                                                             ║",
+            "║  Learn more:                                               ║",
+            "║  https://github.com/czlonkowski/n8n-mcp/blob/main/PRIVACY.md ║",
+            "║                                                             ║",
+            "╚════════════════════════════════════════════════════════════╝"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "security-lite",
+      "capability": "security-lite",
+      "status": "pass",
+      "durationMs": 0.527499999999236,
+      "message": "No security issues detected (lightweight scan).",
+      "evidence": [
+        {
+          "endpoint": "security/scan-lite",
+          "advertised": true,
+          "responded": true,
+          "minimalShapePresent": true,
+          "itemCount": 0
+        }
+      ]
+    },
+    {
+      "id": "runtime-profile",
+      "capability": "runtime-profile",
+      "status": "pass",
+      "durationMs": 1.1257920000007289,
+      "message": "Detected 1 potential egress target(s) and 2 potential state mutation(s) with low confidence.",
+      "evidence": [
+        {
+          "endpoint": "runtime-profile/analyze",
+          "advertised": true,
+          "responded": true,
+          "minimalShapePresent": true,
+          "itemCount": 3,
+          "diagnostics": [
+            "Egress entries: 1",
+            "State mutations: 2",
+            "Confidence: medium"
+          ],
+          "findings": [
+            {
+              "target": "search_nodes",
+              "protocol": "unknown",
+              "source": "description_analysis",
+              "confidence": "low"
+            },
+            {
+              "resource": "filesystem",
+              "operation": "write",
+              "scope": "working_directory",
+              "source": "description_analysis"
+            },
+            {
+              "resource": "filesystem",
+              "operation": "write",
+              "scope": "working_directory",
+              "source": "description_analysis"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "conformance",
+      "capability": "conformance",
+      "status": "pass",
+      "durationMs": 9.329625000000306,
+      "message": "All 7 conformance checks passed.",
+      "evidence": [
+        {
+          "endpoint": "conformance/check",
+          "advertised": true,
+          "responded": true,
+          "minimalShapePresent": true,
+          "itemCount": 7,
+          "identifiers": [],
+          "diagnostics": [
+            "[pass] capabilities-present: Server returned capabilities object.",
+            "[pass] server-info: Server provided initialization info.",
+            "[pass] tools-capability-match: tools/list returned 7 tool(s).",
+            "[pass] prompts-capability-match: Prompts not advertised — endpoint check skipped.",
+            "[pass] resources-capability-match: resources/list returned 2 resource(s).",
+            "[pass] tool-response-content: Tool \"tools_documentation\" response has valid content array.",
+            "[pass] error-handling: Server returned proper error code -32601 for unknown method."
+          ]
+        }
+      ]
+    },
+    {
+      "id": "schema-quality",
+      "capability": "schema-quality",
+      "status": "partial",
+      "durationMs": 3.5992910000004485,
+      "message": "Found 2 quality finding(s) across 9 item(s): 0 warnings, 2 info.",
+      "evidence": [
+        {
+          "endpoint": "schema-quality/scan",
+          "advertised": true,
+          "responded": true,
+          "minimalShapePresent": true,
+          "itemCount": 2,
+          "identifiers": [
+            "tools_documentation",
+            "search_templates"
+          ],
+          "diagnostics": [
+            "[info] tool \"tools_documentation\": Has properties but no 'required' array declared",
+            "[info] tool \"search_templates\": Has properties but no 'required' array declared"
+          ],
+          "findings": [
+            {
+              "itemType": "tool",
+              "itemName": "tools_documentation",
+              "issue": "Has properties but no 'required' array declared",
+              "severity": "info"
+            },
+            {
+              "itemType": "tool",
+              "itemName": "search_templates",
+              "issue": "Has properties but no 'required' array declared",
+              "severity": "info"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "security",
+      "capability": "security",
+      "status": "pass",
+      "durationMs": 2.131999999999607,
+      "message": "No security issues detected.",
+      "evidence": [
+        {
+          "endpoint": "security/scan",
+          "advertised": true,
+          "responded": true,
+          "minimalShapePresent": true,
+          "itemCount": 0
+        }
+      ]
+    },
+    {
+      "id": "attack-sim",
+      "capability": "attack-sim",
+      "status": "pass",
+      "durationMs": 7.837999999999738,
+      "message": "Safe attack simulation found no high-risk MCP attack-readiness findings.",
+      "evidence": [
+        {
+          "endpoint": "attack-sim/safe",
+          "advertised": true,
+          "responded": true,
+          "minimalShapePresent": true,
+          "itemCount": 0,
+          "identifiers": []
+        }
+      ]
+    }
+  ],
+  "healthScore": {
+    "overall": 89,
+    "grade": "B",
+    "dimensions": [
+      {
+        "name": "Protocol Compliance",
+        "weight": 0.3,
+        "score": 100,
+        "details": [
+          "conformance: pass (100/100)"
+        ]
+      },
+      {
+        "name": "Schema Quality",
+        "weight": 0.2,
+        "score": 60,
+        "details": [
+          "schema-quality: partial (60/100)"
+        ]
+      },
+      {
+        "name": "Security",
+        "weight": 0.2,
+        "score": 100,
+        "details": [
+          "security-lite: pass (100/100)",
+          "security: pass (100/100)",
+          "attack-sim: pass (100/100)"
+        ]
+      },
+      {
+        "name": "Reliability",
+        "weight": 0.2,
+        "score": 83,
+        "details": [
+          "tools: pass (100/100)",
+          "prompts: unsupported (50/100)",
+          "resources: pass (100/100)"
+        ]
+      },
+      {
+        "name": "Performance",
+        "weight": 0.1,
+        "score": 100,
+        "details": [
+          "Connect: 6556ms",
+          "p95 latency: 9ms (3 operations)"
+        ]
+      }
+    ]
+  },
+  "performanceMetrics": {
+    "connectMs": 6555.86475,
+    "toolsListMs": 8.865999999999985,
+    "promptsListMs": 0.0038340000000971486,
+    "resourcesListMs": 1.7775830000000497
+  },
+  "runtimeProfile": {
+    "egress": [
+      {
+        "target": "search_nodes",
+        "protocol": "unknown",
+        "source": "description_analysis",
+        "confidence": "low"
+      }
+    ],
+    "stateMutations": [
+      {
+        "resource": "filesystem",
+        "operation": "write",
+        "scope": "working_directory",
+        "source": "description_analysis"
+      },
+      {
+        "resource": "filesystem",
+        "operation": "write",
+        "scope": "working_directory",
+        "source": "description_analysis"
+      }
+    ],
+    "analyzedAt": "2026-08-21T00:14:24.443Z",
+    "confidence": "medium"
+  }
+}

--- a/docs/safety-index/artifacts/n8n-mcp.md
+++ b/docs/safety-index/artifacts/n8n-mcp.md
@@ -1,0 +1,217 @@
+# MCP Observatory Run Report
+
+Generated at 2026-08-21T00:14:17.871Z
+
+## Target and Environment Metadata
+
+- Target: `n8n-mcp`
+- Adapter: `local-process`
+- Command: `npx -y n8n-mcp`
+- Server: `n8n-documentation-mcp 2.73.0`
+- Platform: `darwin 25.5.0`
+- Node: `v22.23.1`
+
+## Executive Summary
+
+**Health Score: 89/100 (B)**
+
+| Dimension | Score | Weight |
+| --- | --- | --- |
+| Protocol Compliance | 100/100 | 30% |
+| Schema Quality | 60/100 | 20% |
+| Security | 100/100 | 20% |
+| Reliability | 83/100 | 20% |
+| Performance | 100/100 | 10% |
+
+| Gate | Total | Pass | Fail | Partial | Unsupported | Flaky | Skipped |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| pass | 9 | 7 | 0 | 1 | 1 | 0 | 0 |
+
+## At a Glance
+
+- Safety verdict: **Needs review** — The server is usable, but caveated checks should be reviewed before agents depend on it.
+- Top risks: schema-quality: Found 2 quality finding(s) across 9 item(s): 0 warnings, 2 info.
+- Regression/schema drift: Run `mcp-observatory diff <previous-run.json> <current-run.json>` to classify regressions and schema drift.
+- Failing checks: none
+- Partial or flaky checks: schema-quality
+- Skipped checks: none
+- Unsupported checks: prompts
+- Suggested next step: Fix: Review the check output and update the MCP server or target configuration before release.
+- CI next step: `Add CI: npx -y @kryptosai/mcp-observatory@latest setup-ci --all --command "npx -y <server-package>"`
+
+## What Was Not Tested
+
+- 🔒 network_egress: No outbound network calls were attempted during scan
+- 🔒 filesystem_mutation: Filesystem write operations were not exercised
+- ℹ️ credential_access: Credential scanning was performed (see security findings)
+- ℹ️ destructive_payloads: Destructive payloads were not attempted (safe-mode only)
+
+## Runtime Profile
+
+### Egress Manifest
+
+The following targets were identified as potentially reachable by this server (confidence: **medium**):
+
+| Target | Protocol | Source | Confidence |
+| --- | --- | --- | --- |
+| search_nodes | unknown | description_analysis | low |
+
+### State Mutations
+
+The following state-modifying operations were identified from tool schemas:
+
+| Resource | Operation | Scope | Source |
+| --- | --- | --- | --- |
+| filesystem | write | working_directory | description_analysis |
+| filesystem | write | working_directory | description_analysis |
+
+_Analyzed at 2026-08-21T00:14:24.443Z_
+
+## Regressions and Recoveries
+
+_Use the `diff` command against another run artifact to classify regressions and recoveries over time._
+
+## Full Capability Status Table
+
+| Focus | Check | Status | Duration (ms) | Message |
+| --- | --- | --- | --- | --- |
+| healthy | attack-sim | pass | 7.84 | Safe attack simulation found no high-risk MCP attack-readiness findings. |
+| healthy | conformance | pass | 9.33 | All 7 conformance checks passed. |
+| healthy | resources | pass | 1.78 | Advertised capability responded with the minimal expected shape (2 items). |
+| healthy | runtime-profile | pass | 1.13 | Detected 1 potential egress target(s) and 2 potential state mutation(s) with low confidence. |
+| healthy | security | pass | 2.13 | No security issues detected. |
+| healthy | security-lite | pass | 0.53 | No security issues detected (lightweight scan). |
+| healthy | tools | pass | 8.87 | Advertised capability responded with the minimal expected shape (7 items). |
+| review | schema-quality | partial | 3.60 | Found 2 quality finding(s) across 9 item(s): 0 warnings, 2 info. |
+| confirm intent | prompts | unsupported | 0.00 | Prompts are not advertised by the target. |
+
+## Evidence Snippets
+
+### attack-sim — pass
+
+Summary: Safe attack simulation found no high-risk MCP attack-readiness findings.
+
+- Endpoint: `attack-sim/safe`
+  - Advertised: `true`
+  - Responded: `true`
+  - Minimal shape present: `true`
+  - Item count: `0`
+  - Identifiers: none
+  - Diagnostics: none
+
+### conformance — pass
+
+Summary: All 7 conformance checks passed.
+
+- Endpoint: `conformance/check`
+  - Advertised: `true`
+  - Responded: `true`
+  - Minimal shape present: `true`
+  - Item count: `7`
+  - Identifiers: none
+  - Diagnostics: [pass] capabilities-present: Server returned capabilities object., [pass] server-info: Server provided initialization info., [pass] tools-capability-match: tools/list returned 7 tool(s). (+4 more)
+
+### resources — pass
+
+Summary: Advertised capability responded with the minimal expected shape (2 items).
+
+- Endpoint: `resources/list`
+  - Advertised: `true`
+  - Responded: `true`
+  - Minimal shape present: `true`
+  - Item count: `2`
+  - Identifiers: ui://n8n-mcp/operation-result, ui://n8n-mcp/validation-summary
+  - Diagnostics: ║                                                             ║, ║  Learn more:                                               ║, ║  https://github.com/czlonkowski/n8n-mcp/blob/main/PRIVACY.md ║ (+2 more)
+- Endpoint: `resources/templates/list`
+  - Advertised: `true`
+  - Responded: `true`
+  - Minimal shape present: `true`
+  - Item count: `0`
+  - Identifiers: none
+  - Diagnostics: ║                                                             ║, ║  Learn more:                                               ║, ║  https://github.com/czlonkowski/n8n-mcp/blob/main/PRIVACY.md ║ (+2 more)
+
+### runtime-profile — pass
+
+Summary: Detected 1 potential egress target(s) and 2 potential state mutation(s) with low confidence.
+
+- Endpoint: `runtime-profile/analyze`
+  - Advertised: `true`
+  - Responded: `true`
+  - Minimal shape present: `true`
+  - Item count: `3`
+  - Identifiers: none
+  - Diagnostics: Egress entries: 1, State mutations: 2, Confidence: medium
+
+### security — pass
+
+Summary: No security issues detected.
+
+- Endpoint: `security/scan`
+  - Advertised: `true`
+  - Responded: `true`
+  - Minimal shape present: `true`
+  - Item count: `0`
+  - Identifiers: none
+  - Diagnostics: none
+
+### security-lite — pass
+
+Summary: No security issues detected (lightweight scan).
+
+- Endpoint: `security/scan-lite`
+  - Advertised: `true`
+  - Responded: `true`
+  - Minimal shape present: `true`
+  - Item count: `0`
+  - Identifiers: none
+  - Diagnostics: none
+
+### tools — pass
+
+Summary: Advertised capability responded with the minimal expected shape (7 items).
+
+- Endpoint: `tools/list`
+  - Advertised: `true`
+  - Responded: `true`
+  - Minimal shape present: `true`
+  - Item count: `7`
+  - Identifiers: tools_documentation, search_nodes, get_node, validate_node, get_template (+2 more)
+  - Diagnostics: ║                                                             ║, ║  Learn more:                                               ║, ║  https://github.com/czlonkowski/n8n-mcp/blob/main/PRIVACY.md ║ (+2 more)
+
+### schema-quality — partial
+
+Summary: Found 2 quality finding(s) across 9 item(s): 0 warnings, 2 info.
+
+- Endpoint: `schema-quality/scan`
+  - Advertised: `true`
+  - Responded: `true`
+  - Minimal shape present: `true`
+  - Item count: `2`
+  - Identifiers: tools_documentation, search_templates
+  - Diagnostics: [info] tool "tools_documentation": Has properties but no 'required' array declared, [info] tool "search_templates": Has properties but no 'required' array declared
+
+### prompts — unsupported
+
+Summary: Prompts are not advertised by the target.
+
+- Endpoint: `prompts/list`
+  - Advertised: `false`
+  - Responded: `false`
+  - Minimal shape present: `false`
+  - Item count: `0`
+  - Identifiers: none
+  - Diagnostics: none
+
+## Reproduction Commands
+
+```bash
+npm run cli -- run --target <path-to-target-config.json>
+npm run cli -- report --run <path-to-run-artifact.json> --format markdown
+```
+
+## Artifact Provenance
+
+- Artifact type: `run`
+- Schema version: `1.0.0`
+- Run ID: `run_2026-08-21T001417870Z_0659ddb9`
+- Gate: `pass`

--- a/docs/safety-index/targets.json
+++ b/docs/safety-index/targets.json
@@ -2998,5 +2998,22 @@
     "failureClass": "Vehicle/listing/dealer boundary",
     "whyItMatters": "PakWheels is Pakistan's largest automotive marketplace with 15M+ monthly visitors, handling new and used car sales, auto parts, reviews, and price comparisons. MCP servers exposing vehicle listings, seller data, and automotive commerce handle the country's dominant auto commerce platform.",
     "reproductionNotes": "Schema-only evaluation; requires PakWheels API credentials. Community package — exact npm name pending verification."
+  },
+  {
+    "id": "n8n-mcp",
+    "name": "n8n MCP",
+    "repo": "https://github.com/czlonkowski/n8n-mcp",
+    "packageName": "n8n-mcp",
+    "category": "Agent Runtime / Automation",
+    "command": "npx",
+    "args": [
+      "-y",
+      "n8n-mcp"
+    ],
+    "timeoutMs": 120000,
+    "riskClass": "Workflow automation surface",
+    "failureClass": "Workflow mutation/execution boundary",
+    "whyItMatters": "Agents may use n8n MCP to browse node documentation and, with credentials, create or execute workflow automations; the credential-free surface should be explicit before agents rely on it.",
+    "reproductionNotes": "Runs in docs-only mode without N8N_API_URL/N8N_API_KEY and lists node documentation/search tools; the 16 workflow-management tools require n8n API configuration and are not exercised."
   }
 ]

--- a/src/commands/receipt.ts
+++ b/src/commands/receipt.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import type { Command } from "commander";
 
 import { resolveAuditTarget, runAudit } from "../audit.js";
-import { buildMcpReceipt, generateReceiptKeyPair, receiptFormatFromPath, renderReceipt, signReceipt, verifyReceipt, type McpReceipt, type ReceiptEnvironmentClass, type ReceiptFormat } from "../receipt.js";
+import { buildMcpReceipt, generateReceiptKeyPair, publicKeyFingerprint, receiptFormatFromPath, renderReceipt, signReceipt, verifyReceipt, type McpReceipt, type ReceiptEnvironmentClass, type ReceiptFormat } from "../receipt.js";
 import { buildEvent, recordEvent } from "../command-events.js";
 import { ANSI, c } from "./helpers.js";
 
@@ -106,17 +106,21 @@ export function registerReceiptCommands(program: Command): void {
         outputPath: options.output,
         topFindingsLimit: Number.parseInt(options.topFindings ?? "5", 10),
       });
+      const format = receiptFormatFromPath(options.output, options.format);
+      if (format !== "json" && format !== "markdown") {
+        throw new Error("Unsupported receipt format. Use json or markdown.");
+      }
       if (options.signKey) {
         if (!options.signer) {
           process.stderr.write("Error: --signer is required when --sign-key is used.\n");
           process.exit(1);
         }
+        if (format !== "json") {
+          process.stderr.write("Error: --sign-key requires a JSON-format receipt; markdown receipts do not carry the signature. Use --format json.\n");
+          process.exit(1);
+        }
         const keyContent = await readFile(options.signKey);
         receipt = signReceipt(receipt, keyContent, options.signer);
-      }
-      const format = receiptFormatFromPath(options.output, options.format);
-      if (format !== "json" && format !== "markdown") {
-        throw new Error("Unsupported receipt format. Use json or markdown.");
       }
       await writeMaybe(options.output, renderReceipt(receipt, format));
       recordEvent(buildEvent("command_complete", "receipt", "cli", {
@@ -186,6 +190,6 @@ export function registerReceiptCommands(program: Command): void {
         process.stderr.write(`✗ Receipt verification failed against ${options.key} — signature does not match, or the receipt is unsigned.\n`);
         process.exit(1);
       }
-      process.stdout.write(`✓ Receipt verified — signed by ${receipt.signer ?? "unknown"}\n`);
+      process.stdout.write(`✓ Receipt verified — signed by ${receipt.signer ?? "unknown"} (public key fingerprint: ${publicKeyFingerprint(publicKey)})\n`);
     });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ export {
   buildMcpReceipt,
   generateReceiptKeyPair,
   mapStatusToReceiptVerdict,
+  publicKeyFingerprint,
   renderReceipt,
   renderReceiptMarkdown,
   receiptFormatFromPath,

--- a/src/receipt.ts
+++ b/src/receipt.ts
@@ -1,4 +1,4 @@
-import { createHash, sign, verify, generateKeyPairSync, type KeyObject } from "node:crypto";
+import { createHash, createPublicKey, sign, verify, generateKeyPairSync, type KeyObject } from "node:crypto";
 import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import os from "node:os";
@@ -576,20 +576,31 @@ export function receiptFormatFromPath(outputPath: string | undefined, fallback: 
 
 function canonicalReceiptBytes(receipt: McpReceipt): Buffer {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { signer, signature, ...rest } = receipt as McpReceipt & { signer?: string; signature?: string };
+  const { signature, ...rest } = receipt as McpReceipt & { signature?: string };
   return Buffer.from(JSON.stringify(rest), "utf8");
 }
 
 export function signReceipt(receipt: McpReceipt, privateKey: string | Buffer | KeyObject, signer: string): McpReceipt {
-  const data = canonicalReceiptBytes(receipt);
+  // The signer label is part of the signed bytes, so it must be attached
+  // before canonicalization. Only the signature itself is excluded.
+  const unsigned = { ...receipt, signer };
+  const data = canonicalReceiptBytes(unsigned);
   const sig = sign(null, data, privateKey);
-  return { ...receipt, signer, signature: sig.toString("base64") };
+  return { ...unsigned, signature: sig.toString("base64") };
 }
 
 export function verifyReceipt(receipt: McpReceipt, publicKey: string | Buffer | KeyObject): boolean {
   if (!receipt.signature) return false;
   const data = canonicalReceiptBytes(receipt);
   return verify(null, data, publicKey, Buffer.from(receipt.signature, "base64"));
+}
+
+export function publicKeyFingerprint(publicKey: string | Buffer | KeyObject): string {
+  const keyObject = typeof publicKey === "string" || Buffer.isBuffer(publicKey)
+    ? createPublicKey(publicKey)
+    : publicKey;
+  const der = keyObject.export({ type: "spki", format: "der" });
+  return createHash("sha256").update(der).digest("hex").slice(0, 32);
 }
 
 export function generateReceiptKeyPair(): { publicKey: string; privateKey: string } {

--- a/tests/commands/receipt.test.ts
+++ b/tests/commands/receipt.test.ts
@@ -142,6 +142,7 @@ describe("receipt verify", () => {
     const program = makeProgram();
     await run(program, ["receipt", "verify", file, "--key", publicKeyPath]);
     expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("✓ Receipt verified — signed by maintainer@example.com"));
+    expect(writeSpy).toHaveBeenCalledWith(expect.stringMatching(/public key fingerprint: [0-9a-f]{32}/));
   });
 
   it("fails verification against the wrong public key", async () => {

--- a/tests/receipt.test.ts
+++ b/tests/receipt.test.ts
@@ -6,7 +6,7 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import { buildActionReceipt, recommendedActionForFinding, renderActionReceipt } from "../src/action-receipt.js";
 import { buildAuditReport } from "../src/audit.js";
-import { buildMcpReceipt, detectNotObserved, generateReceiptKeyPair, mapStatusToReceiptVerdict, receiptFormatFromPath, renderReceipt, renderReceiptMarkdown, signReceipt, verifyReceipt } from "../src/receipt.js";
+import { buildMcpReceipt, detectNotObserved, generateReceiptKeyPair, mapStatusToReceiptVerdict, publicKeyFingerprint, receiptFormatFromPath, renderReceipt, renderReceiptMarkdown, signReceipt, verifyReceipt } from "../src/receipt.js";
 import type { McpReceipt } from "../src/receipt.js";
 import { makeArtifact } from "./fixtures/test-helpers.js";
 
@@ -495,6 +495,29 @@ describe("Ed25519 receipt signing", () => {
     const signed = signReceipt(receipt, privateKey, "test@example.com");
     const tampered = { ...signed, receipt_type: "tampered" as const } as unknown as McpReceipt;
     expect(verifyReceipt(tampered, publicKey)).toBe(false);
+  });
+
+  it("detects signer tampering", () => {
+    const { publicKey, privateKey } = generateReceiptKeyPair();
+    const receipt = { receipt_type: "mcp-observatory-receipt" as const } as unknown as McpReceipt;
+    const signed = signReceipt(receipt, privateKey, "test@example.com");
+    const tampered = { ...signed, signer: "attacker@example.com" } as McpReceipt;
+    expect(verifyReceipt(tampered, publicKey)).toBe(false);
+  });
+
+  it("detects signature rewriting", () => {
+    const { publicKey, privateKey } = generateReceiptKeyPair();
+    const receipt = { receipt_type: "mcp-observatory-receipt" as const } as unknown as McpReceipt;
+    const signed = signReceipt(receipt, privateKey, "test@example.com");
+    const tampered = { ...signed, signature: Buffer.alloc(64, 1).toString("base64") } as McpReceipt;
+    expect(verifyReceipt(tampered, publicKey)).toBe(false);
+  });
+
+  it("computes a stable public key fingerprint", () => {
+    const { publicKey } = generateReceiptKeyPair();
+    const fingerprint = publicKeyFingerprint(publicKey);
+    expect(fingerprint).toMatch(/^[0-9a-f]{32}$/);
+    expect(publicKeyFingerprint(publicKey)).toBe(fingerprint);
   });
 
   it("rejects unsigned receipt", () => {


### PR DESCRIPTION
Closes #131.

- **n8n MCP Safety Index target**: `npx -y n8n-mcp` runs docs-only with no secrets (7 documentation tools listed; management tools need `N8N_API_URL`/`N8N_API_KEY` and are not exercised). Verdict: Ready for CI, 89/100. Evidence generated through the safety-index pipeline (`n8n-mcp.json`/`.md`, index row 176).
- **Receipt signer binding** (#165 follow-up): `signer` is now part of the signed bytes, so rewriting the label invalidates the signature. `receipt verify` prints a truncated SHA-256 public key fingerprint. `--sign-key` with markdown output errors instead of silently emitting an unverifiable receipt.
- **Roadmap hygiene**: ROADMAP.md absorbs the parked trust/research/compliance/growth epics (#166, #167, #170, #171, #172, #173, #219, #222, #223, #224); CONTRIBUTING (EN + zh-CN) no longer cites issues closed in March; dependabot ignores `typescript >=6` so the dev-tooling group stops failing on the 7.x peer conflict (see closed #349).

Validation: `npm test` green (655 tests), lint, typecheck, `validate:artifacts` pass.