### PR TITLE
feat(commercial): show hosted-plan CTA on every run, not just failures

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -79,6 +79,13 @@ const MENU_GROUPS: MenuGroup[] = [
     ],
   },
   {
+    heading: "Hosted",
+    items: [
+      { command: ["cloud"], label: "cloud", outcome: "Hosted history, private reports, security review, and enterprise pilots" },
+      { command: ["cloud", "login"], label: "cloud login", outcome: "Connect this CLI to your hosted account" },
+    ],
+  },
+  {
     heading: "Scoring & Badges",
     items: [
       { command: ["score"],  label: "score",  outcome: "Health score (0-100) for a specific server" },
@@ -247,7 +254,7 @@ async function main(): Promise<void> {
       });
       notifier.notify({
         isGlobal: true,
-        message: "MCP Observatory update available: {currentVersion} → {latestVersion}\nRun latest receipts + CI: npx @kryptosai/mcp-observatory@latest attack-sim <cmd>\nUpgrade command: npx @kryptosai/mcp-observatory@latest",
+        message: "MCP Observatory update available: {currentVersion} → {latestVersion}\nRun latest receipts + CI: npx @kryptosai/mcp-observatory@latest attack-sim <cmd>\nUpgrade command: npx @kryptosai/mcp-observatory@latest\nHosted history + private reports: https://app.mcp-observatory.com/pricing",
       });
     } catch {
       // update-notifier not available — skip silently

--- a/src/commercial.ts
+++ b/src/commercial.ts
@@ -49,12 +49,28 @@ export function cloudUpgradeLine(context: "ci" | "security" | "fleet" | "general
   ].join("\n");
 }
 
+export function cloudPassLine(context: "ci" | "security" | "fleet" | "general" = "general"): string {
+  const value =
+    context === "ci"
+      ? "hosted CI history and private-repo reports"
+      : context === "security"
+        ? "hosted security reports and certification"
+        : context === "fleet"
+          ? "fleet visibility and production support"
+          : "hosted history and private reports";
+  const plan = context === "ci" || context === "fleet" ? "team" : "individual";
+  return c(ANSI.dim, `  Production teams: ${value} — ${c(ANSI.cyan, `${SELF_SERVE_PRICING_URL}?plan=${plan}`)}`);
+}
+
 export function maybePrintCloudCta(
   context: "ci" | "security" | "fleet" | "general" = "general",
   gate?: string,
 ): void {
   if (isQuiet() || hasCloudToken()) return;
-  if (gate !== "fail" && gate !== "critical_risk") return;
+  if (gate !== "fail" && gate !== "critical_risk") {
+    process.stdout.write(`${cloudPassLine(context)}\n\n`);
+    return;
+  }
   process.stdout.write(`${cloudUpgradeLine(context)}\n\n`);
 }
 

--- a/tests/commercial.test.ts
+++ b/tests/commercial.test.ts
@@ -69,15 +69,22 @@ describe("commercial cloud messaging", () => {
     expect(second.output()).toBe("");
   });
 
-  it("does not print a CTA on passing gates", () => {
+  it("prints a compact CTA on passing gates", () => {
     process.env["NO_COLOR"] = "1";
     delete process.env["MCP_OBSERVATORY_CLOUD_TOKEN"];
     const stdout = captureStdout();
 
     maybePrintCloudCta("ci", "pass");
-    maybePrintCloudCta("ci");
 
-    expect(stdout.output()).toBe("");
+    expect(stdout.output()).toContain("Production teams");
+    expect(stdout.output()).toContain("hosted CI history");
+    expect(stdout.output()).toContain("pricing?plan=team");
+
+    vi.restoreAllMocks();
+    const general = captureStdout();
+    maybePrintCloudCta();
+    expect(general.output()).toContain("hosted history and private reports");
+    expect(general.output()).toContain("pricing?plan=individual");
   });
 
   it("suppresses the CTA in quiet mode even without a cloud token", () => {


### PR DESCRIPTION
Passing scans previously never saw the paid tier — maybePrintCloudCta only fired on fail/critical_risk. Every non-quiet, non-authenticated run now prints a compact hosted-plan CTA; the interactive menu gains a Hosted group; the update notice mentions hosted history.