### PR TITLE
chore(ci): honor branch protection in releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: ["main"]
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: ["main"]
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,20 +171,55 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: 385e00f98ceabbee25800bda2756cc75
         run: npx wrangler pages deploy dashboard --project-name mcp-observatory
 
-      - name: Point action@v1 and Homebrew formula at the published package
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Prepare Homebrew formula update
+        id: homebrew-formula
+        if: steps.package-version.outputs.published == 'true'
         run: |
           set -euo pipefail
           version="$(npm view @kryptosai/mcp-observatory version)"
           node scripts/update-homebrew-formula.mjs "$version"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          if git diff --quiet -- Formula/mcp-observatory.rb; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open protected Homebrew formula update
+        if: steps.homebrew-formula.outputs.changed == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          version="${{ steps.homebrew-formula.outputs.version }}"
+          branch="automation/homebrew-formula-v${version}"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c "$branch"
           git add Formula/mcp-observatory.rb
-          if ! git diff --cached --quiet; then
-            git commit -m "chore(formula): bump Homebrew formula to v${version}"
-            git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${GITHUB_REF_NAME}"
+          git commit -m "chore(formula): bump Homebrew formula to v${version}"
+          gh auth setup-git
+          git push --force-with-lease origin "$branch"
+          pr_url="$(gh pr list --head "$branch" --state open --json url --jq '.[0].url // empty')"
+          if [ -z "$pr_url" ]; then
+            pr_url="$(gh pr create \
+              --base main \
+              --head "$branch" \
+              --title "chore(formula): bump Homebrew formula to v${version}" \
+              --body "Updates the Homebrew formula to the npm package published by the release workflow. This PR is used so the automated update follows main branch protection.")"
           fi
+          echo "Homebrew formula update: ${pr_url}"
+          for workflow in ci.yml coverage.yml action-test.yml codeql.yml; do
+            gh workflow run "$workflow" --ref "$branch"
+          done
+
+      - name: Point action@v1 at the published package
+        if: steps.package-version.outputs.published == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          version="${{ steps.homebrew-formula.outputs.version }}"
           git fetch --tags origin
           if git rev-parse "v${version}" >/dev/null 2>&1; then
             git tag -f v1 "v${version}"


### PR DESCRIPTION
Refactors post-release bookkeeping after branch protection correctly rejected a direct push to `main`. Homebrew formula updates now use a PR and explicitly dispatch the four required checks; the `action@v1` tag update is isolated so it can complete independently. No package or runtime behavior changes.