### PR TITLE
fix: restore Node 20 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,26 @@ jobs:
 
       - name: README smoke test
         run: npm run smoke
+
+  node-compatibility:
+    name: node-compatibility (${{ matrix.node }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [20, 22, 24]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+
+      - name: Install with strict engine validation
+        run: npm ci --engine-strict
+
+      - name: Build and run CLI
+        run: npm run build && node dist/src/cli.js --version

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "ci-info": "^4.4.0",
-        "commander": "15.0.0",
+        "commander": "14.0.3",
         "update-notifier": "^7.3.1",
         "zod": "4.5.2"
       },
@@ -1877,12 +1877,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
-      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "license": "MIT",
       "engines": {
-        "node": ">=22.12.0"
+        "node": ">=20"
       }
     },
     "node_modules/config-chain": {

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "ci-info": "^4.4.0",
-    "commander": "15.0.0",
+    "commander": "14.0.3",
     "update-notifier": "^7.3.1",
     "zod": "4.5.2"
   },


### PR DESCRIPTION
Commander 15 requires Node 22.12+, which made npm emit an engine incompatibility warning even though MCP Observatory supports Node 20+. This pins Commander 14.0.3 (Node 20+) and adds engine-strict CI coverage on Node 20, 22, and 24. Local Node 20 validation passed all 658 tests.