### PR TITLE
fix: keep informational diagnostics out of the demo fix list

### DIFF
--- a/src/commands/demo.ts
+++ b/src/commands/demo.ts
@@ -310,7 +310,9 @@ export function registerDemoCommands(program: Command): void {
 
       process.stdout.write("\n");
 
-      const fixes = extractObservatoryFindings(artifact).filter((finding) => finding.recommendation).slice(0, 3);
+      const fixes = extractObservatoryFindings(artifact)
+        .filter((finding) => finding.severity !== "info" && finding.recommendation)
+        .slice(0, 3);
       if (fixes.length > 0) {
         process.stdout.write(`  ${c(ANSI.bold, "Issues to fix")}\n`);
         for (const finding of fixes) {

--- a/tests/cli-entrypoint.test.ts
+++ b/tests/cli-entrypoint.test.ts
@@ -70,6 +70,7 @@ describe("CLI entrypoint", () => {
       const result = runCli(["demo", "--example"], { cwd: tmpDir, env: { MCP_OBSERVATORY_TELEMETRY: "0" } });
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain("Your configured servers are not started");
+      expect(result.stdout).not.toContain("Issues to fix");
       expect(result.stdout).toContain("mcp-observatory-demo");
       expect(result.stdout).toContain("Receipt saved:");
       expect(result.stdout).not.toContain("must-not-start");


### PR DESCRIPTION
A successful first scan of the packaged example printed three informational protocol diagnostics under “Issues to fix,” immediately before saying the release gate passed. Exclude informational findings from the demo's compact fix list. Check results and the saved receipt retain the full diagnostic evidence; warnings and actionable findings remain visible.

Validation: the CLI integration test runs the real packaged example with a configured-server decoy and now asserts that its successful output has no misleading fix list. Lint, typecheck, and build pass locally; the required full CI suite runs on this PR.
